### PR TITLE
fix: remove experts, witnesses and unavailable dates from case data (CMC-1598)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Applicant1DQ.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Applicant1DQ.java
@@ -53,19 +53,19 @@ public class Applicant1DQ implements DQ {
     @Override
     @JsonProperty("applicant1DQExperts")
     public Experts getExperts() {
-        return applicant1DQExperts;
+        return getExperts(applicant1DQExperts);
     }
 
     @Override
     @JsonProperty("applicant1DQWitnesses")
     public Witnesses getWitnesses() {
-        return applicant1DQWitnesses;
+        return getWitnesses(applicant1DQWitnesses);
     }
 
     @Override
     @JsonProperty("applicant1DQHearing")
     public Hearing getHearing() {
-        return applicant1DQHearing;
+        return getHearing(applicant1DQHearing);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/dq/DQ.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/dq/DQ.java
@@ -18,9 +18,30 @@ public interface DQ {
 
     Experts getExperts();
 
+    default Experts getExperts(Experts experts) {
+        if (ofNullable(experts).map(Experts::getExpertRequired).map(NO::equals).orElse(false)) {
+            return experts.toBuilder().details(null).build();
+        }
+        return experts;
+    }
+
     Witnesses getWitnesses();
 
+    default Witnesses getWitnesses(Witnesses witnesses) {
+        if (ofNullable(witnesses).map(Witnesses::getWitnessesToAppear).map(NO::equals).orElse(false)) {
+            return witnesses.toBuilder().details(null).build();
+        }
+        return witnesses;
+    }
+
     Hearing getHearing();
+
+    default Hearing getHearing(Hearing hearing) {
+        if (ofNullable(hearing).map(Hearing::getUnavailableDatesRequired).map(NO::equals).orElse(false)) {
+            return hearing.toBuilder().unavailableDates(null).build();
+        }
+        return hearing;
+    }
 
     Document getDraftDirections();
 
@@ -33,25 +54,4 @@ public interface DQ {
     WelshLanguageRequirements getWelshLanguageRequirements();
 
     StatementOfTruth getStatementOfTruth();
-
-    default Experts getExperts(Experts experts) {
-        if (ofNullable(experts).map(Experts::getExpertRequired).map(NO::equals).orElse(false)) {
-            return experts.toBuilder().details(null).build();
-        }
-        return experts;
-    }
-
-    default Witnesses getWitnesses(Witnesses witnesses) {
-        if (ofNullable(witnesses).map(Witnesses::getWitnessesToAppear).map(NO::equals).orElse(false)) {
-            return witnesses.toBuilder().details(null).build();
-        }
-        return witnesses;
-    }
-
-    default Hearing getHearing(Hearing hearing) {
-        if (ofNullable(hearing).map(Hearing::getUnavailableDatesRequired).map(NO::equals).orElse(false)) {
-            return hearing.toBuilder().unavailableDates(null).build();
-        }
-        return hearing;
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/dq/DQ.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/dq/DQ.java
@@ -3,6 +3,9 @@ package uk.gov.hmcts.reform.civil.model.dq;
 import uk.gov.hmcts.reform.civil.model.StatementOfTruth;
 import uk.gov.hmcts.reform.civil.model.documents.Document;
 
+import static java.util.Optional.ofNullable;
+import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
+
 public interface DQ {
 
     FileDirectionsQuestionnaire getFileDirectionQuestionnaire();
@@ -30,4 +33,25 @@ public interface DQ {
     WelshLanguageRequirements getWelshLanguageRequirements();
 
     StatementOfTruth getStatementOfTruth();
+
+    default Experts getExperts(Experts experts) {
+        if (ofNullable(experts).map(Experts::getExpertRequired).map(NO::equals).orElse(false)) {
+            return experts.toBuilder().details(null).build();
+        }
+        return experts;
+    }
+
+    default Witnesses getWitnesses(Witnesses witnesses) {
+        if (ofNullable(witnesses).map(Witnesses::getWitnessesToAppear).map(NO::equals).orElse(false)) {
+            return witnesses.toBuilder().details(null).build();
+        }
+        return witnesses;
+    }
+
+    default Hearing getHearing(Hearing hearing) {
+        if (ofNullable(hearing).map(Hearing::getUnavailableDatesRequired).map(NO::equals).orElse(false)) {
+            return hearing.toBuilder().unavailableDates(null).build();
+        }
+        return hearing;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Experts.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Experts.java
@@ -9,7 +9,7 @@ import uk.gov.hmcts.reform.civil.model.common.Element;
 import java.util.List;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Experts {
 
     private final YesOrNo expertRequired;

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Hearing.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Hearing.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.civil.model.common.Element;
 import java.util.List;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Hearing {
 
     private final HearingLength hearingLength;

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Respondent1DQ.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Respondent1DQ.java
@@ -53,19 +53,19 @@ public class Respondent1DQ implements DQ {
     @Override
     @JsonProperty("respondent1DQExperts")
     public Experts getExperts() {
-        return respondent1DQExperts;
+        return getExperts(respondent1DQExperts);
     }
 
     @Override
     @JsonProperty("respondent1DQWitnesses")
     public Witnesses getWitnesses() {
-        return respondent1DQWitnesses;
+        return getWitnesses(respondent1DQWitnesses);
     }
 
     @Override
     @JsonProperty("respondent1DQHearing")
     public Hearing getHearing() {
-        return respondent1DQHearing;
+        return getHearing(respondent1DQHearing);
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Witnesses.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Witnesses.java
@@ -8,7 +8,7 @@ import uk.gov.hmcts.reform.civil.model.common.Element;
 import java.util.List;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 public class Witnesses {
 
     private final YesOrNo witnessesToAppear;

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/dq/Applicant1DQTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/dq/Applicant1DQTest.java
@@ -5,14 +5,15 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 
-class Respondent1DQTest extends DQTest {
+class Applicant1DQTest extends DQTest {
 
     @Test
     void shouldGetVariables_usingInterfaceMethods() {
-        Respondent1DQ dq = buildRespondent1Dq();
+        Applicant1DQ dq = buildApplicant1Dq();
 
         assertEquals(disclosureOfElectronicDocuments(), dq.getDisclosureOfElectronicDocuments());
         assertEquals(disclosureOfNonElectronicDocuments(), dq.getDisclosureOfNonElectronicDocuments());
@@ -23,27 +24,27 @@ class Respondent1DQTest extends DQTest {
         assertEquals(furtherInformation(), dq.getFurtherInformation());
         assertEquals(hearing(), dq.getHearing());
         assertEquals(hearingSupport(), dq.getHearingSupport());
-        assertEquals(requestedCourt(), dq.getRequestedCourt());
+        assertNull(dq.getRequestedCourt());
         assertEquals(statementOfTruth(), dq.getStatementOfTruth());
         assertEquals(witnesses(), dq.getWitnesses());
         assertEquals(welshLanguageRequirements(), dq.getWelshLanguageRequirements());
     }
 
-    private Respondent1DQ buildRespondent1Dq() {
-        return Respondent1DQ.builder()
-            .respondent1DQDisclosureOfElectronicDocuments(disclosureOfElectronicDocuments())
-            .respondent1DQDisclosureOfNonElectronicDocuments(disclosureOfNonElectronicDocuments())
-            .respondent1DQDisclosureReport(disclosureReport())
-            .respondent1DQDraftDirections(draftDirections())
-            .respondent1DQExperts(experts())
-            .respondent1DQFileDirectionsQuestionnaire(fileDirectionsQuestionnaire())
-            .respondent1DQFurtherInformation(furtherInformation())
-            .respondent1DQHearing(hearing())
-            .respondent1DQHearingSupport(hearingSupport())
-            .respondent1DQRequestedCourt(requestedCourt())
-            .respondent1DQStatementOfTruth(statementOfTruth())
-            .respondent1DQWitnesses(witnesses())
-            .respondent1DQLanguage(welshLanguageRequirements())
+    private Applicant1DQ buildApplicant1Dq() {
+        return Applicant1DQ.builder()
+            .applicant1DQDisclosureOfElectronicDocuments(disclosureOfElectronicDocuments())
+            .applicant1DQDisclosureOfNonElectronicDocuments(disclosureOfNonElectronicDocuments())
+            .applicant1DQDisclosureReport(disclosureReport())
+            .applicant1DQDraftDirections(draftDirections())
+            .applicant1DQExperts(experts())
+            .applicant1DQFileDirectionsQuestionnaire(fileDirectionsQuestionnaire())
+            .applicant1DQFurtherInformation(furtherInformation())
+            .applicant1DQHearing(hearing())
+            .applicant1DQHearingSupport(hearingSupport())
+            .applicant1DQRequestedCourt(requestedCourt())
+            .applicant1DQStatementOfTruth(statementOfTruth())
+            .applicant1DQWitnesses(witnesses())
+            .applicant1DQLanguage(welshLanguageRequirements())
             .build();
     }
 
@@ -52,9 +53,9 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldRemoveDetails_whenNoExpertsRequired() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQExperts(dq.getExperts().toBuilder()
+                .applicant1DQExperts(dq.getExperts().toBuilder()
                                           .expertRequired(NO)
                                           .build())
                 .build();
@@ -64,9 +65,9 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldNotRemoveDetails_whenExpertsRequired() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQExperts(dq.getExperts().toBuilder()
+                .applicant1DQExperts(dq.getExperts().toBuilder()
                                           .expertRequired(YES)
                                           .build())
                 .build();
@@ -76,9 +77,9 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldReturnNull_whenExpertsIsNull() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQExperts(null)
+                .applicant1DQExperts(null)
                 .build();
 
             assertThat(dq.getExperts()).isNull();
@@ -90,11 +91,11 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldRemoveDetails_whenNoWitnessesToAppear() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQWitnesses(dq.getWitnesses().toBuilder()
-                                          .witnessesToAppear(NO)
-                                          .build())
+                .applicant1DQWitnesses(dq.getWitnesses().toBuilder()
+                                            .witnessesToAppear(NO)
+                                            .build())
                 .build();
 
             assertThat(dq.getWitnesses().getDetails()).isNull();
@@ -102,11 +103,11 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldNotRemoveDetails_whenWitnessesToAppear() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQWitnesses(dq.getWitnesses().toBuilder()
-                                          .witnessesToAppear(YES)
-                                          .build())
+                .applicant1DQWitnesses(dq.getWitnesses().toBuilder()
+                                            .witnessesToAppear(YES)
+                                            .build())
                 .build();
 
             assertThat(dq.getWitnesses()).isEqualTo(witnesses());
@@ -114,9 +115,9 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldReturnNull_whenWitnessesIsNull() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQWitnesses(null)
+                .applicant1DQWitnesses(null)
                 .build();
 
             assertThat(dq.getWitnesses()).isNull();
@@ -128,11 +129,11 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldRemoveUnavailableDates_whenNoUnavailableDatesRequired() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQHearing(dq.getHearing().toBuilder()
-                                            .unavailableDatesRequired(NO)
-                                            .build())
+                .applicant1DQHearing(dq.getHearing().toBuilder()
+                                          .unavailableDatesRequired(NO)
+                                          .build())
                 .build();
 
             assertThat(dq.getHearing().getUnavailableDates()).isNull();
@@ -140,11 +141,11 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldNotRemoveUnavailableDates_whenUnavailableDatesRequired() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQHearing(dq.getHearing().toBuilder()
-                                            .unavailableDatesRequired(YES)
-                                            .build())
+                .applicant1DQHearing(dq.getHearing().toBuilder()
+                                          .unavailableDatesRequired(YES)
+                                          .build())
                 .build();
 
             assertThat(dq.getHearing().getUnavailableDates()).isEqualTo(hearing().getUnavailableDates());
@@ -152,9 +153,9 @@ class Respondent1DQTest extends DQTest {
 
         @Test
         void shouldReturnNull_whenUnavailableDatesIsNull() {
-            Respondent1DQ dq = buildRespondent1Dq();
+            Applicant1DQ dq = buildApplicant1Dq();
             dq = dq.toBuilder()
-                .respondent1DQHearing(null)
+                .applicant1DQHearing(null)
                 .build();
 
             assertThat(dq.getHearing()).isNull();

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/dq/DQTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/dq/DQTest.java
@@ -1,0 +1,130 @@
+package uk.gov.hmcts.reform.civil.model.dq;
+
+import uk.gov.hmcts.reform.civil.enums.ExpertReportsSent;
+import uk.gov.hmcts.reform.civil.enums.YesOrNo;
+import uk.gov.hmcts.reform.civil.enums.dq.HearingLength;
+import uk.gov.hmcts.reform.civil.enums.dq.Language;
+import uk.gov.hmcts.reform.civil.enums.dq.SupportRequirements;
+import uk.gov.hmcts.reform.civil.model.StatementOfTruth;
+import uk.gov.hmcts.reform.civil.model.UnavailableDate;
+import uk.gov.hmcts.reform.civil.model.documents.Document;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
+
+abstract class DQTest {
+
+    protected DisclosureOfNonElectronicDocuments disclosureOfNonElectronicDocuments() {
+        return DisclosureOfNonElectronicDocuments.builder()
+            .directionsForDisclosureProposed(YesOrNo.YES)
+            .standardDirectionsRequired(YesOrNo.YES)
+            .bespokeDirections("non electronic documents")
+            .build();
+    }
+
+    protected Witnesses witnesses() {
+        return Witnesses.builder()
+            .witnessesToAppear(YesOrNo.YES)
+            .details(wrapElements(Witness.builder().name("John Smith").reasonForWitness("reason").build()))
+            .build();
+    }
+
+    protected StatementOfTruth statementOfTruth() {
+        return StatementOfTruth.builder()
+            .name("John Smith")
+            .role("Solicitor")
+            .build();
+    }
+
+    protected RequestedCourt requestedCourt() {
+        return RequestedCourt.builder()
+            .responseCourtCode("343")
+            .reasonForHearingAtSpecificCourt("reason for court")
+            .requestHearingAtSpecificCourt(YesOrNo.YES)
+            .build();
+    }
+
+    protected HearingSupport hearingSupport() {
+        return HearingSupport.builder()
+            .requirements(List.of(SupportRequirements.values()))
+            .languageToBeInterpreted("English")
+            .signLanguageRequired("Spanish")
+            .otherSupport("other support")
+            .build();
+    }
+
+    protected Hearing hearing() {
+        return Hearing.builder()
+            .hearingLength(HearingLength.LESS_THAN_DAY)
+            .hearingLengthHours("1")
+            .unavailableDatesRequired(YesOrNo.YES)
+            .unavailableDates(wrapElements(UnavailableDate.builder().who("John Smith").date(LocalDate.now()).build()))
+            .build();
+    }
+
+    protected FurtherInformation furtherInformation() {
+        return FurtherInformation.builder()
+            .futureApplications(YesOrNo.YES)
+            .otherInformationForJudge("Other information")
+            .reasonForFutureApplications("Reason for future applications")
+            .build();
+    }
+
+    protected FileDirectionsQuestionnaire fileDirectionsQuestionnaire() {
+        return FileDirectionsQuestionnaire.builder()
+            .explainedToClient(List.of("yes"))
+            .oneMonthStayRequested(YesOrNo.YES)
+            .reactionProtocolCompliedWith(YesOrNo.NO)
+            .reactionProtocolNotCompliedWithReason("Not complied with reason")
+            .build();
+    }
+
+    protected Experts experts() {
+        return Experts.builder()
+            .expertRequired(YesOrNo.YES)
+            .expertReportsSent(ExpertReportsSent.YES)
+            .jointExpertSuitable(YesOrNo.YES)
+            .details(wrapElements(Expert.builder()
+                                      .name("John Smith")
+                                      .fieldOfExpertise("Science")
+                                      .estimatedCost(BigDecimal.ONE)
+                                      .whyRequired("Reason")
+                                      .build()))
+            .build();
+    }
+
+    protected Document draftDirections() {
+        return Document.builder()
+            .documentBinaryUrl("binary url")
+            .documentFileName("Order")
+            .documentUrl("url")
+            .build();
+    }
+
+    protected DisclosureReport disclosureReport() {
+        return DisclosureReport.builder()
+            .disclosureFormFiledAndServed(YesOrNo.YES)
+            .disclosureProposalAgreed(YesOrNo.YES)
+            .draftOrderNumber("order number")
+            .build();
+    }
+
+    protected DisclosureOfElectronicDocuments disclosureOfElectronicDocuments() {
+        return DisclosureOfElectronicDocuments.builder()
+            .agreementLikely(YesOrNo.YES)
+            .reachedAgreement(YesOrNo.NO)
+            .reasonForNoAgreement("reason")
+            .build();
+    }
+
+    protected WelshLanguageRequirements welshLanguageRequirements() {
+        return WelshLanguageRequirements.builder()
+            .court(Language.WELSH)
+            .documents(Language.WELSH)
+            .evidence(Language.WELSH)
+            .build();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1598

### Change description ###

Removing:
- experts details
- witnesses details
- hearing unavailable dates

when data was provided, but then changed to not needed (hidden fields in CCD does not remove the data as expected).

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```