### PR TITLE
tech: use send grid api key from civil account (CMC-1555)

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -40,7 +40,7 @@ data "azurerm_key_vault_secret" "send_grid_api_key" {
   provider = azurerm.send-grid
 
   key_vault_id = data.azurerm_key_vault.send_grid.id
-  name         = "hmcts-damages-api-key"
+  name         = "hmcts-civil-api-key"
 }
 
 resource "azurerm_key_vault_secret" "sendgrid_api_key" {


### PR DESCRIPTION
### Change description ###
Use send grid api key from civil account instead of damages account.

I did setup a new account on sendGrid for new name of our service civil This PR should use the api key from that account. damages account will be removed later. 

**Does this PR introduce a breaking change?** (check one with "x")

- [ ] Yes
- [x] No

