### PR TITLE
fix: added tenant id to camunda messages

### DIFF
--- a/bin/import-bpmn-diagram.sh
+++ b/bin/import-bpmn-diagram.sh
@@ -14,6 +14,7 @@ do
     -H "Accept: application/json" \
     -H "ServiceAuthorization: Bearer ${serviceToken}" \
     -F "deployment-name=$(date +"%Y%m%d-%H%M%S")-$(basename ${file})" \
+    -F "tenant-id=civil" \
     -F "file=@${filepath}/$(basename ${file})")
 
 upload_http_code=$(echo "$uploadResponse" | tail -n1)

--- a/src/main/java/uk/gov/hmcts/reform/civil/config/CamundaConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/CamundaConfiguration.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.reform.civil.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@Configuration
+@EnableConfigurationProperties
+@ConfigurationProperties(prefix = "camunda")
+public class CamundaConfiguration {
+
+    private String tenantId;
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/EventEmitterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/EventEmitterService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.RuntimeService;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.civil.config.CamundaConfiguration;
 import uk.gov.hmcts.reform.civil.event.DispatchBusinessProcessEvent;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 
@@ -17,6 +18,7 @@ public class EventEmitterService {
 
     private final ApplicationEventPublisher applicationEventPublisher;
     private final RuntimeService runtimeService;
+    private final CamundaConfiguration camundaConfiguration;
 
     public void emitBusinessProcessCamundaEvent(CaseData caseData, boolean dispatchProcess) {
         var caseId = caseData.getCcdCaseReference();
@@ -25,6 +27,7 @@ public class EventEmitterService {
         log.info(format("Emitting %s camunda event for case: %d", camundaEvent, caseId));
         try {
             runtimeService.createMessageCorrelation(camundaEvent)
+                .tenantId(camundaConfiguration.getTenantId())
                 .setVariable("caseId", caseId)
                 .correlateStartMessage();
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -121,6 +121,9 @@ exit-survey:
   applicant-link: https://www.smartsurvey.co.uk/s/CivilDamages_ExitSurvey_Claimant/
   respondent-link: https://www.smartsurvey.co.uk/s/CivilDamages_ExitSurvey_Defendant/
 
+camunda:
+  tenantId: "civil"
+
 ---
 
 spring:


### PR DESCRIPTION
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
