### PR TITLE
feat: changes to add or amend claims logic (CMC-1490) (2/2)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddOrAmendClaimDocumentsCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddOrAmendClaimDocumentsCallbackHandler.java
@@ -31,8 +31,9 @@ public class AddOrAmendClaimDocumentsCallbackHandler extends CallbackHandler imp
     protected Map<String, Callback> callbacks() {
         return Map.of(
             callbackKey(ABOUT_TO_START), this::emptyCallbackResponse,
-            callbackKey(V_1, MID, "particulars-of-claim"), this::validateParticularsOfClaim,
-            callbackKey(MID, "particulars-of-claim"), this::validateParticularsOfClaimBackwardsCompatible,
+            callbackKey(V_1, MID, "particulars-of-claim"), this::validateParticularsOfClaimAddOrAmendDocuments,
+            callbackKey(MID, "particulars-of-claim"),
+            this::validateParticularsOfClaimAddOrAmendDocumentsBackwardsCompatible,
             callbackKey(SUBMITTED), this::buildConfirmation
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -45,6 +45,7 @@ public class CaseData implements MappableObject {
     private final YesOrNo respondent1Represented;
     private final YesOrNo respondent1OrgRegistered;
     private final String respondentSolicitor1EmailAddress;
+    private final YesOrNo uploadParticularsOfClaim;
     private final String detailsOfClaim;
     private final ClaimValue claimValue;
     private final Fee claimFee;

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFiles.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFiles.java
@@ -24,16 +24,16 @@ public class ServedDocumentFiles {
     private String particularsOfClaimText;
     private List<Element<DocumentWithRegex>> certificateOfSuitability;
 
-    private final String bothParticularsOfClaimError = "You need to either upload 1 Particulars of claim only "
+    private static final String BOTH_PARTICULARS_OF_CLAIM_ERROR = "You need to either upload 1 Particulars of claim only "
         + "or enter the Particulars of claim text in the field provided. You cannot do both.";
-    private final String emptyError = "You must add Particulars of claim details";
+    private static final String EMPTY_ERROR = "You must add Particulars of claim details";
 
     @JsonIgnore
     public List<String> getErrors() {
         List<String> errors = getErrorsAddOrAmendDocuments();
 
         if (ofNullable(particularsOfClaimDocumentNew).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
-            errors.add(emptyError);
+            errors.add(EMPTY_ERROR);
         }
         return errors;
     }
@@ -42,7 +42,7 @@ public class ServedDocumentFiles {
     public List<String> getErrorsAddOrAmendDocuments() {
         List<String> errors = new ArrayList<>();
         if (ofNullable(particularsOfClaimDocumentNew).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
-            errors.add(bothParticularsOfClaimError);
+            errors.add(BOTH_PARTICULARS_OF_CLAIM_ERROR);
         }
         return errors;
     }
@@ -52,7 +52,7 @@ public class ServedDocumentFiles {
         List<String> errors = getErrorsAddOrAmendDocumentsBackwardsCompatible();
 
         if (ofNullable(particularsOfClaimDocument).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
-            errors.add(emptyError);
+            errors.add(EMPTY_ERROR);
         }
         return errors;
     }
@@ -61,7 +61,7 @@ public class ServedDocumentFiles {
     public List<String> getErrorsAddOrAmendDocumentsBackwardsCompatible() {
         List<String> errors = new ArrayList<>();
         if (ofNullable(particularsOfClaimDocument).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
-            errors.add(bothParticularsOfClaimError);
+            errors.add(BOTH_PARTICULARS_OF_CLAIM_ERROR);
         }
         return errors;
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFiles.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFiles.java
@@ -24,8 +24,8 @@ public class ServedDocumentFiles {
     private String particularsOfClaimText;
     private List<Element<DocumentWithRegex>> certificateOfSuitability;
 
-    private static final String BOTH_PARTICULARS_OF_CLAIM_ERROR = "You need to either upload 1 Particulars of claim only "
-        + "or enter the Particulars of claim text in the field provided. You cannot do both.";
+    private static final String BOTH_PARTICULARS_OF_CLAIM_ERROR = "You need to either upload 1 Particulars of claim "
+        + "only or enter the Particulars of claim text in the field provided. You cannot do both.";
     private static final String EMPTY_ERROR = "You must add Particulars of claim details";
 
     @JsonIgnore

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFiles.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFiles.java
@@ -24,12 +24,16 @@ public class ServedDocumentFiles {
     private String particularsOfClaimText;
     private List<Element<DocumentWithRegex>> certificateOfSuitability;
 
+    private final String bothParticularsOfClaimError = "You need to either upload 1 Particulars of claim only "
+        + "or enter the Particulars of claim text in the field provided. You cannot do both.";
+    private final String emptyError = "You must add Particulars of claim details";
+
     @JsonIgnore
     public List<String> getErrors() {
         List<String> errors = getErrorsAddOrAmendDocuments();
 
         if (ofNullable(particularsOfClaimDocumentNew).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
-            errors.add("You must add Particulars of claim details");
+            errors.add(emptyError);
         }
         return errors;
     }
@@ -38,8 +42,7 @@ public class ServedDocumentFiles {
     public List<String> getErrorsAddOrAmendDocuments() {
         List<String> errors = new ArrayList<>();
         if (ofNullable(particularsOfClaimDocumentNew).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
-            errors.add("You need to either upload 1 Particulars of claim only or enter the Particulars "
-                + "of claim text in the field provided. You cannot do both.");
+            errors.add(bothParticularsOfClaimError);
         }
         return errors;
     }
@@ -49,7 +52,7 @@ public class ServedDocumentFiles {
         List<String> errors = getErrorsAddOrAmendDocumentsBackwardsCompatible();
 
         if (ofNullable(particularsOfClaimDocument).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
-            errors.add("You must add Particulars of claim details");
+            errors.add(emptyError);
         }
         return errors;
     }
@@ -58,8 +61,7 @@ public class ServedDocumentFiles {
     public List<String> getErrorsAddOrAmendDocumentsBackwardsCompatible() {
         List<String> errors = new ArrayList<>();
         if (ofNullable(particularsOfClaimDocument).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
-            errors.add("You need to either upload 1 Particulars of claim only or enter the Particulars "
-                           + "of claim text in the field provided. You cannot do both.");
+            errors.add(bothParticularsOfClaimError);
         }
         return errors;
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFiles.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFiles.java
@@ -26,11 +26,7 @@ public class ServedDocumentFiles {
 
     @JsonIgnore
     public List<String> getErrors() {
-        List<String> errors = new ArrayList<>();
-        if (ofNullable(particularsOfClaimDocumentNew).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
-            errors.add("You need to either upload 1 Particulars of claim only or enter the Particulars "
-                           + "of claim text in the field provided. You cannot do both.");
-        }
+        List<String> errors = getErrorsAddOrAmendDocuments();
 
         if (ofNullable(particularsOfClaimDocumentNew).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
             errors.add("You must add Particulars of claim details");
@@ -39,15 +35,31 @@ public class ServedDocumentFiles {
     }
 
     @JsonIgnore
+    public List<String> getErrorsAddOrAmendDocuments() {
+        List<String> errors = new ArrayList<>();
+        if (ofNullable(particularsOfClaimDocumentNew).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
+            errors.add("You need to either upload 1 Particulars of claim only or enter the Particulars "
+                + "of claim text in the field provided. You cannot do both.");
+        }
+        return errors;
+    }
+
+    @JsonIgnore
     public List<String> getErrorsBackwardsCompatible() {
+        List<String> errors = getErrorsAddOrAmendDocumentsBackwardsCompatible();
+
+        if (ofNullable(particularsOfClaimDocument).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
+            errors.add("You must add Particulars of claim details");
+        }
+        return errors;
+    }
+
+    @JsonIgnore
+    public List<String> getErrorsAddOrAmendDocumentsBackwardsCompatible() {
         List<String> errors = new ArrayList<>();
         if (ofNullable(particularsOfClaimDocument).isPresent() && ofNullable(particularsOfClaimText).isPresent()) {
             errors.add("You need to either upload 1 Particulars of claim only or enter the Particulars "
                            + "of claim text in the field provided. You cannot do both.");
-        }
-
-        if (ofNullable(particularsOfClaimDocument).isEmpty() && ofNullable(particularsOfClaimText).isEmpty()) {
-            errors.add("You must add Particulars of claim details");
         }
         return errors;
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/validation/interfaces/ParticularsOfClaimValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/validation/interfaces/ParticularsOfClaimValidator.java
@@ -3,18 +3,33 @@ package uk.gov.hmcts.reform.civil.validation.interfaces;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
+import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.ServedDocumentFiles;
 
 import static java.util.Optional.ofNullable;
 
 public interface ParticularsOfClaimValidator {
 
+    private ServedDocumentFiles getServedDocumentFiles(CaseData caseData) {
+        ServedDocumentFiles servedDocumentFiles = caseData.getServedDocumentFiles();
+
+        return ofNullable(servedDocumentFiles)
+           .orElse(ServedDocumentFiles.builder().build());
+    }
+
     default CallbackResponse validateParticularsOfClaim(CallbackParams callbackParams) {
-        ServedDocumentFiles servedDocumentFiles = ofNullable(callbackParams.getCaseData().getServedDocumentFiles())
-            .orElse(ServedDocumentFiles.builder().build());
+        CaseData caseData = callbackParams.getCaseData();
 
         return AboutToStartOrSubmitCallbackResponse.builder()
-            .errors(servedDocumentFiles.getErrors())
+            .errors(getServedDocumentFiles(caseData).getErrors())
+            .build();
+    }
+
+    default CallbackResponse validateParticularsOfClaimAddOrAmendDocuments(CallbackParams callbackParams) {
+        CaseData caseData = callbackParams.getCaseData();
+
+        return AboutToStartOrSubmitCallbackResponse.builder()
+            .errors(getServedDocumentFiles(caseData).getErrorsAddOrAmendDocuments())
             .build();
     }
 
@@ -24,6 +39,15 @@ public interface ParticularsOfClaimValidator {
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .errors(servedDocumentFiles.getErrorsBackwardsCompatible())
+            .build();
+    }
+
+    default CallbackResponse validateParticularsOfClaimAddOrAmendDocumentsBackwardsCompatible(CallbackParams
+                                                                                                  callbackParams) {
+        CaseData caseData = callbackParams.getCaseData();
+
+        return AboutToStartOrSubmitCallbackResponse.builder()
+            .errors(getServedDocumentFiles(caseData).getErrorsAddOrAmendDocumentsBackwardsCompatible())
             .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/validation/interfaces/ParticularsOfClaimValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/validation/interfaces/ParticularsOfClaimValidator.java
@@ -10,44 +10,39 @@ import static java.util.Optional.ofNullable;
 
 public interface ParticularsOfClaimValidator {
 
-    private ServedDocumentFiles getServedDocumentFiles(CaseData caseData) {
-        ServedDocumentFiles servedDocumentFiles = caseData.getServedDocumentFiles();
+    private ServedDocumentFiles getServedDocumentFiles(CallbackParams callbackParams) {
+        CaseData caseData = callbackParams.getCaseData();
 
-        return ofNullable(servedDocumentFiles)
+        return ofNullable(caseData.getServedDocumentFiles())
            .orElse(ServedDocumentFiles.builder().build());
     }
 
     default CallbackResponse validateParticularsOfClaim(CallbackParams callbackParams) {
-        CaseData caseData = callbackParams.getCaseData();
 
         return AboutToStartOrSubmitCallbackResponse.builder()
-            .errors(getServedDocumentFiles(caseData).getErrors())
+            .errors(getServedDocumentFiles(callbackParams).getErrors())
             .build();
     }
 
     default CallbackResponse validateParticularsOfClaimAddOrAmendDocuments(CallbackParams callbackParams) {
-        CaseData caseData = callbackParams.getCaseData();
 
         return AboutToStartOrSubmitCallbackResponse.builder()
-            .errors(getServedDocumentFiles(caseData).getErrorsAddOrAmendDocuments())
+            .errors(getServedDocumentFiles(callbackParams).getErrorsAddOrAmendDocuments())
             .build();
     }
 
     default CallbackResponse validateParticularsOfClaimBackwardsCompatible(CallbackParams callbackParams) {
-        ServedDocumentFiles servedDocumentFiles = ofNullable(callbackParams.getCaseData().getServedDocumentFiles())
-            .orElse(ServedDocumentFiles.builder().build());
 
         return AboutToStartOrSubmitCallbackResponse.builder()
-            .errors(servedDocumentFiles.getErrorsBackwardsCompatible())
+            .errors(getServedDocumentFiles(callbackParams).getErrorsBackwardsCompatible())
             .build();
     }
 
     default CallbackResponse validateParticularsOfClaimAddOrAmendDocumentsBackwardsCompatible(CallbackParams
                                                                                                   callbackParams) {
-        CaseData caseData = callbackParams.getCaseData();
 
         return AboutToStartOrSubmitCallbackResponse.builder()
-            .errors(getServedDocumentFiles(caseData).getErrorsAddOrAmendDocumentsBackwardsCompatible())
+            .errors(getServedDocumentFiles(callbackParams).getErrorsAddOrAmendDocumentsBackwardsCompatible())
             .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddOrAmendClaimDocumentsCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddOrAmendClaimDocumentsCallbackHandlerTest.java
@@ -78,7 +78,7 @@ class AddOrAmendClaimDocumentsCallbackHandlerTest extends BaseCallbackHandlerTes
         }
 
         @Test
-        void shouldReturnError_whenParticularOfClaimsTextAndDocumentSubmitted() {
+        void shouldReturnError_whenParticularOfClaimsTextAndDocumentSubmittedBackwardsCompatible() {
             CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder()
                                                                         .particularsOfClaimText("Some string")
                                                                         .particularsOfClaimDocument(

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddOrAmendClaimDocumentsCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddOrAmendClaimDocumentsCallbackHandlerTest.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.MID;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
+import static uk.gov.hmcts.reform.civil.callback.CallbackVersion.V_1;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
 
 @SpringBootTest(classes = {
@@ -48,6 +49,16 @@ class AddOrAmendClaimDocumentsCallbackHandlerTest extends BaseCallbackHandlerTes
         @Test
         void shouldNotReturnErrors_whenNoDocuments() {
             CaseData caseData = caseDataBuilder.build();
+            CallbackParams params = callbackParamsOf(V_1, caseData, MID, pageId);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).isEmpty();
+        }
+
+        @Test
+        void shouldNotReturnErrors_whenNoDocumentsBackwardsCompatible() {
+            CaseData caseData = caseDataBuilder.build();
             CallbackParams params = callbackParamsOf(caseData, MID, pageId);
 
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
@@ -57,6 +68,16 @@ class AddOrAmendClaimDocumentsCallbackHandlerTest extends BaseCallbackHandlerTes
 
         @Test
         void shouldNotReturnErrors_whenParticularsOfClaimFieldsAreEmpty() {
+            CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder().build()).build();
+            CallbackParams params = callbackParamsOf(V_1, caseData, MID, pageId);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).isEmpty();
+        }
+
+        @Test
+        void shouldNotReturnErrors_whenParticularsOfClaimFieldsAreEmptyBackwardsCompatible() {
             CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder().build()).build();
             CallbackParams params = callbackParamsOf(caseData, MID, pageId);
 
@@ -70,11 +91,39 @@ class AddOrAmendClaimDocumentsCallbackHandlerTest extends BaseCallbackHandlerTes
             CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder()
                                                                         .particularsOfClaimText("Some string")
                                                                         .build()).build();
+            CallbackParams params = callbackParamsOf(V_1, caseData, MID, pageId);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).isEmpty();
+        }
+
+        @Test
+        void shouldReturnNoErrors_whenParticularOfClaimsFieldsAreValidBackwardsCompatible() {
+            CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder()
+                                                                        .particularsOfClaimText("Some string")
+                                                                        .build()).build();
             CallbackParams params = callbackParamsOf(caseData, MID, pageId);
 
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
 
             assertThat(response.getErrors()).isEmpty();
+        }
+
+        @Test
+        void shouldReturnError_whenParticularOfClaimsTextAndDocumentSubmitted() {
+            CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder()
+                                                                        .particularsOfClaimText("Some string")
+                                                                        .particularsOfClaimDocumentNew(
+                                                                            wrapElements(Document.builder().build()))
+                                                                        .build()).build();
+            CallbackParams params = callbackParamsOf(V_1, caseData, MID, pageId);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).containsOnly(
+                "You need to either upload 1 Particulars of claim only or enter the "
+                    + "Particulars of claim text in the field provided. You cannot do both.");
         }
 
         @Test
@@ -98,6 +147,18 @@ class AddOrAmendClaimDocumentsCallbackHandlerTest extends BaseCallbackHandlerTes
             CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder()
                                                                         .particularsOfClaimText("Some string").build())
                                                                         .build();
+            CallbackParams params = callbackParamsOf(V_1, caseData, MID, pageId);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).isEmpty();
+        }
+
+        @Test
+        void shouldReturnNoErrors_whenOnlyParticularOfClaimsTextSubmittedBackwardsCompatible() {
+            CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder()
+                                                                        .particularsOfClaimText("Some string").build())
+                .build();
             CallbackParams params = callbackParamsOf(caseData, MID, pageId);
 
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/NotifyClaimDetailsCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/NotifyClaimDetailsCallbackHandlerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.MID;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
+import static uk.gov.hmcts.reform.civil.callback.CallbackVersion.V_1;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.NOTIFY_DEFENDANT_OF_CLAIM_DETAILS;
 import static uk.gov.hmcts.reform.civil.helpers.DateFormatHelper.DATE_TIME_AT;
 import static uk.gov.hmcts.reform.civil.helpers.DateFormatHelper.formatLocalDateTime;
@@ -65,6 +66,16 @@ class NotifyClaimDetailsCallbackHandlerTest extends BaseCallbackHandlerTest {
         @Test
         void shouldReturnErrors_whenNoDocuments() {
             CaseData caseData = caseDataBuilder.build();
+            CallbackParams params = callbackParamsOf(V_1, caseData, MID, pageId);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).containsOnly("You must add Particulars of claim details");
+        }
+
+        @Test
+        void shouldReturnErrors_whenNoDocumentsBackwardsCompatible() {
+            CaseData caseData = caseDataBuilder.build();
             CallbackParams params = callbackParamsOf(caseData, MID, pageId);
 
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
@@ -75,6 +86,16 @@ class NotifyClaimDetailsCallbackHandlerTest extends BaseCallbackHandlerTest {
         @Test
         void shouldReturnErrors_whenParticularsOfClaimFieldsAreInErrorState() {
             CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder().build()).build();
+            CallbackParams params = callbackParamsOf(V_1, caseData, MID, pageId);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).containsOnly("You must add Particulars of claim details");
+        }
+
+        @Test
+        void shouldReturnErrors_whenParticularsOfClaimFieldsAreInErrorStateBackwardsCompatible() {
+            CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder().build()).build();
             CallbackParams params = callbackParamsOf(caseData, MID, pageId);
 
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
@@ -84,6 +105,18 @@ class NotifyClaimDetailsCallbackHandlerTest extends BaseCallbackHandlerTest {
 
         @Test
         void shouldReturnNoErrors_whenParticularOfClaimsFieldsAreValid() {
+            CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder()
+                                                                        .particularsOfClaimText("Some string")
+                                                                        .build()).build();
+            CallbackParams params = callbackParamsOf(V_1, caseData, MID, pageId);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getErrors()).isEmpty();
+        }
+
+        @Test
+        void shouldReturnNoErrors_whenParticularOfClaimsFieldsAreValidBackwardsCompatible() {
             CaseData caseData = caseDataBuilder.servedDocumentFiles(ServedDocumentFiles.builder()
                                                                         .particularsOfClaimText("Some string")
                                                                         .build()).build();

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFilesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFilesTest.java
@@ -19,6 +19,7 @@ class ServedDocumentFilesTest {
                 .build();
 
             assertThat(servedDocumentFiles.getErrors()).isEmpty();
+            assertThat(servedDocumentFiles.getErrorsAddOrAmendDocuments()).isEmpty();
         }
 
         @Test
@@ -28,6 +29,7 @@ class ServedDocumentFilesTest {
                 .build();
 
             assertThat(servedDocumentFiles.getErrors()).isEmpty();
+            assertThat(servedDocumentFiles.getErrorsAddOrAmendDocuments()).isEmpty();
         }
 
         @Test
@@ -45,6 +47,9 @@ class ServedDocumentFilesTest {
                 .build();
 
             assertThat(servedDocumentFiles.getErrors())
+                .containsOnly("You need to either upload 1 Particulars of claim only or enter the Particulars "
+                                  + "of claim text in the field provided. You cannot do both.");
+            assertThat(servedDocumentFiles.getErrorsAddOrAmendDocuments())
                 .containsOnly("You need to either upload 1 Particulars of claim only or enter the Particulars "
                                   + "of claim text in the field provided. You cannot do both.");
         }

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFilesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFilesTest.java
@@ -23,6 +23,16 @@ class ServedDocumentFilesTest {
         }
 
         @Test
+        void shouldReturnEmptyList_WhenOnlyDocumentBackwardsCompatible() {
+            ServedDocumentFiles servedDocumentFiles = ServedDocumentFiles.builder()
+                .particularsOfClaimDocument(wrapElements(Document.builder().build()))
+                .build();
+
+            assertThat(servedDocumentFiles.getErrorsBackwardsCompatible()).isEmpty();
+            assertThat(servedDocumentFiles.getErrorsAddOrAmendDocumentsBackwardsCompatible()).isEmpty();
+        }
+
+        @Test
         void shouldReturnEmptyList_WhenOnlyText() {
             ServedDocumentFiles servedDocumentFiles = ServedDocumentFiles.builder()
                 .particularsOfClaimText("Some string")
@@ -50,6 +60,21 @@ class ServedDocumentFilesTest {
                 .containsOnly("You need to either upload 1 Particulars of claim only or enter the Particulars "
                                   + "of claim text in the field provided. You cannot do both.");
             assertThat(servedDocumentFiles.getErrorsAddOrAmendDocuments())
+                .containsOnly("You need to either upload 1 Particulars of claim only or enter the Particulars "
+                                  + "of claim text in the field provided. You cannot do both.");
+        }
+
+        @Test
+        void shouldReturnMoreThanOneError_WhenBothParticularsOfClaimFieldsAreNotNullBackwardsCompatible() {
+            ServedDocumentFiles servedDocumentFiles = ServedDocumentFiles.builder()
+                .particularsOfClaimDocument(wrapElements(Document.builder().build()))
+                .particularsOfClaimText("Some string")
+                .build();
+
+            assertThat(servedDocumentFiles.getErrorsBackwardsCompatible())
+                .containsOnly("You need to either upload 1 Particulars of claim only or enter the Particulars "
+                                  + "of claim text in the field provided. You cannot do both.");
+            assertThat(servedDocumentFiles.getErrorsAddOrAmendDocumentsBackwardsCompatible())
                 .containsOnly("You need to either upload 1 Particulars of claim only or enter the Particulars "
                                   + "of claim text in the field provided. You cannot do both.");
         }

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFilesTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/ServedDocumentFilesTest.java
@@ -40,6 +40,8 @@ class ServedDocumentFilesTest {
 
             assertThat(servedDocumentFiles.getErrors()).isEmpty();
             assertThat(servedDocumentFiles.getErrorsAddOrAmendDocuments()).isEmpty();
+            assertThat(servedDocumentFiles.getErrorsBackwardsCompatible()).isEmpty();
+            assertThat(servedDocumentFiles.getErrorsAddOrAmendDocumentsBackwardsCompatible()).isEmpty();
         }
 
         @Test
@@ -47,6 +49,8 @@ class ServedDocumentFilesTest {
             ServedDocumentFiles servedDocumentFiles = ServedDocumentFiles.builder().build();
 
             assertThat(servedDocumentFiles.getErrors()).containsOnly("You must add Particulars of claim details");
+            assertThat(servedDocumentFiles.getErrorsBackwardsCompatible()).containsOnly(
+                "You must add Particulars of claim details");
         }
 
         @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1490

### Change description ###
- Created a new function in `ParticularsOfClaimValidator` that will validate for addOrAmendClaimDocuments event, as now ParticularsOfClaim document and text are optional (also accounting for backwards compatible code for particulars of claim)
- created tests in `AddOrAmendClaimDocumentsCallbackHandlerTest` (also backwards compatible)
- created tests in `NotifyClaimDetailsCallbackHandlerTest` (also backwards compatible)
- amended tests in `ServedDocumentFilesTest`

( https://github.com/hmcts/civil-damages-ccd-definition/pull/41 merged first)
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
