### PR TITLE
fix : backwards compatible new field type for certificate of suitability on litigation friend event (CMC-1596) (1/5)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/LitigationFriend.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/LitigationFriend.java
@@ -16,4 +16,5 @@ public class LitigationFriend {
     private final YesOrNo hasSameAddressAsLitigant;
     private final Address primaryAddress;
     private final List<Element<Document>> certificateOfSuitability;
+    private final List<Element<DocumentWithRegex>> certificateOfSuitabilityNew;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1596

### Change description ###
- introducing new code for change of field type of `certificateOfSuitability` from collection of `Document` to collection of `DocumentOrImageWithRegex`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
