### PR TITLE
fix: catch exceptions in scheduler handlers (CMC-1584)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/tasks/ClaimDismissedHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/tasks/ClaimDismissedHandler.java
@@ -24,7 +24,12 @@ public class ClaimDismissedHandler implements BaseExternalTaskHandler {
         List<CaseDetails> cases = caseSearchService.getCases();
         log.info("Job '{}' found {} case(s)", externalTask.getTopicName(), cases.size());
 
-        cases.forEach(caseDetails -> applicationEventPublisher.publishEvent(
-            new DismissClaimEvent(caseDetails.getId())));
+        cases.forEach(caseDetails -> {
+            try {
+                applicationEventPublisher.publishEvent(new DismissClaimEvent(caseDetails.getId()));
+            } catch (Exception e) {
+                log.error("Updating case with id: '{}' failed", caseDetails.getId(), e);
+            }
+        });
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/tasks/TakeCaseOfflineHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/tasks/TakeCaseOfflineHandler.java
@@ -24,7 +24,12 @@ public class TakeCaseOfflineHandler implements BaseExternalTaskHandler {
         List<CaseDetails> cases = caseSearchService.getCases();
         log.info("Job '{}' found {} case(s)", externalTask.getTopicName(), cases.size());
 
-        cases.forEach(caseDetails -> applicationEventPublisher.publishEvent(
-            new TakeCaseOfflineEvent(caseDetails.getId())));
+        cases.forEach(caseDetails -> {
+            try {
+                applicationEventPublisher.publishEvent(new TakeCaseOfflineEvent(caseDetails.getId()));
+            } catch (Exception e) {
+                log.error("Updating case with id: '{}' failed", caseDetails.getId(), e);
+            }
+        });
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/ClaimDismissedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/ClaimDismissedHandlerTest.java
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -111,5 +112,34 @@ class ClaimDismissedHandlerTest {
             anyInt(),
             anyLong()
         );
+    }
+
+    @Test
+    void shouldHandleExceptionAndContinue_whenOneCaseErrors() {
+        long caseId = 1L;
+        long otherId = 2L;
+        Map<String, Object> data = Map.of("data", "some data");
+        List<CaseDetails> caseDetails = List.of(
+            CaseDetails.builder().id(caseId).data(data).build(),
+            CaseDetails.builder().id(otherId).data(data).build());
+
+        when(searchService.getCases()).thenReturn(caseDetails);
+
+        String errorMessage = "there was an error";
+
+        doThrow(new NullPointerException(errorMessage))
+            .when(applicationEventPublisher).publishEvent(eq(new DismissClaimEvent(caseId)));
+
+        handler.execute(mockTask, externalTaskService);
+
+        verify(externalTaskService, never()).handleFailure(
+            any(ExternalTask.class),
+            anyString(),
+            anyString(),
+            anyInt(),
+            anyLong()
+        );
+
+        verify(applicationEventPublisher, times(2)).publishEvent(any(DismissClaimEvent.class));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/ClaimDismissedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/ClaimDismissedHandlerTest.java
@@ -141,5 +141,7 @@ class ClaimDismissedHandlerTest {
         );
 
         verify(applicationEventPublisher, times(2)).publishEvent(any(DismissClaimEvent.class));
+        verify(applicationEventPublisher).publishEvent(new DismissClaimEvent(caseId));
+        verify(applicationEventPublisher).publishEvent(new DismissClaimEvent(otherId));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/TakeCaseOfflineHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/TakeCaseOfflineHandlerTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mock;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.civil.event.DismissClaimEvent;
 import uk.gov.hmcts.reform.civil.event.TakeCaseOfflineEvent;
 import uk.gov.hmcts.reform.civil.service.search.TakeCaseOfflineSearchService;
 
@@ -142,5 +141,7 @@ class TakeCaseOfflineHandlerTest {
         );
 
         verify(applicationEventPublisher, times(2)).publishEvent(any(TakeCaseOfflineEvent.class));
+        verify(applicationEventPublisher).publishEvent(new TakeCaseOfflineEvent(caseId));
+        verify(applicationEventPublisher).publishEvent(new TakeCaseOfflineEvent(otherId));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1584

### Change description ###

Scheduler handlers should now be resilient when handling multiple cases when one errors.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
