### PR TITLE
build: excluded -nonprod.json files from definition on preview and staging

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -71,7 +71,7 @@ withPipeline(type, product, component) {
       ./bin/add-roles.sh
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
       ./bin/pull-latest-release-asset.sh civil-camunda-bpmn-definition civil-camunda-bpmn-definition.zip
-      ./bin/import-ccd-definition.sh
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
       ./bin/import-bpmn-diagram.sh .
     """
 
@@ -102,7 +102,7 @@ withPipeline(type, product, component) {
       ./bin/add-roles.sh
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
       ./bin/pull-latest-release-asset.sh civil-camunda-bpmn-definition civil-camunda-bpmn-definition.zip
-      ./bin/import-ccd-definition.sh
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
       ./bin/import-bpmn-diagram.sh .
     """
     env.URL="https://civil-service-xui-staging.aat.platform.hmcts.net"


### PR DESCRIPTION
### Change description ###

All `-nonprod.json` files are now excluded on staging and preview to ensure we deploy and test production version of CCD definition.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
