### PR TITLE
refactor: remove "What happens next" from confirmation pages (CMC-1628) (2/2)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandler.java
@@ -90,7 +90,7 @@ public class InformAgreedExtensionDateCallbackHandler extends CallbackHandler {
         LocalDateTime responseDeadline = caseData.getRespondent1ResponseDeadline();
 
         String body = format(
-            "<br />What happens next%n%n You must respond to the claimant by %s",
+            "<br />You must respond to the claimant by %s",
             formatLocalDateTime(responseDeadline, DATE_TIME_AT)) + exitSurveyContentService.respondentSurvey();
         return SubmittedCallbackResponse.builder()
             .confirmationHeader("# Extension deadline submitted")

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandler.java
@@ -62,7 +62,7 @@ public class ResubmitClaimCallbackHandler extends CallbackHandler {
         return SubmittedCallbackResponse.builder()
             .confirmationHeader("# Claim pending")
             .confirmationBody(
-                "<br />You claim will be processed. Wait for us to contact you."
+                "<br />Your claim will be processed. Wait for us to contact you."
                     + exitSurveyContentService.applicantSurvey()
             )
             .build();

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandler.java
@@ -19,7 +19,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static java.lang.String.format;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
@@ -63,7 +62,7 @@ public class ResubmitClaimCallbackHandler extends CallbackHandler {
         return SubmittedCallbackResponse.builder()
             .confirmationHeader("# Claim pending")
             .confirmationBody(
-                format("## What happens next %n%nYou claim will be processed. Wait for us to contact you.")
+                "<br />You claim will be processed. Wait for us to contact you."
                     + exitSurveyContentService.applicantSurvey()
             )
             .build();

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandlerTest.java
@@ -162,7 +162,7 @@ class InformAgreedExtensionDateCallbackHandlerTest extends BaseCallbackHandlerTe
     @Nested
     class SubmittedCallback {
 
-        private static final String BODY = "<br />What happens next%n%n You must respond to the claimant by %s";
+        private static final String BODY = "<br />You must respond to the claimant by %s";
 
         @Test
         void shouldReturnExpectedResponse_whenInvoked() {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandlerTest.java
@@ -73,7 +73,7 @@ class ResubmitClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
                 SubmittedCallbackResponse.builder()
                     .confirmationHeader("# Claim pending")
                     .confirmationBody(
-                        "<br />You claim will be processed. Wait for us to contact you."
+                        "<br />Your claim will be processed. Wait for us to contact you."
                             + exitSurveyContentService.applicantSurvey()
                     )
                     .build());

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandlerTest.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.ExitSurveyContentService;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
@@ -74,7 +73,7 @@ class ResubmitClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
                 SubmittedCallbackResponse.builder()
                     .confirmationHeader("# Claim pending")
                     .confirmationBody(
-                        format("## What happens next %n%nYou claim will be processed. Wait for us to contact you.")
+                        "<br />You claim will be processed. Wait for us to contact you."
                             + exitSurveyContentService.applicantSurvey()
                     )
                     .build());


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1628

### Change description ###

-Standardised the confirmation pages by removing the "What happens next" text from confirmation pages

![Screenshot 2021-06-09 at 11 45 19](https://user-images.githubusercontent.com/48325651/121341962-18a89980-c919-11eb-86f8-4e0bab105ef7.png)
![Screenshot 2021-06-09 at 11 43 57](https://user-images.githubusercontent.com/48325651/121341973-1b0af380-c919-11eb-816e-de45bb84c33f.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
