### PR TITLE
feat: added RPA_CONTINUOUS_FEED flow flag to state flow engine (CMC-1692)

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/RpaConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/RpaConsumerTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataMaxEdgeCasesBuilder;
@@ -81,6 +82,8 @@ class RpaConsumerTest extends BaseRpaTest {
     OrganisationApi organisationApi;
     @MockBean
     AuthTokenGenerator authTokenGenerator;
+    @MockBean
+    FeatureToggleService featureToggleService;
     @MockBean
     IdamClient idamClient;
     @MockBean

--- a/src/main/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleService.java
@@ -40,6 +40,10 @@ public class FeatureToggleService {
         return internalClient.boolVariation("multiparty", createLDUser().build(), false);
     }
 
+    public boolean isRpaContinuousFeedEnabled() {
+        return internalClient.boolVariation("rpaContinuousFeed", createLDUser().build(), false);
+    }
+
     public LDUser.Builder createLDUser() {
         return new LDUser.Builder("civil-service")
             .custom("timestamp", String.valueOf(System.currentTimeMillis()))

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowFlag.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowFlag.java
@@ -2,5 +2,6 @@ package uk.gov.hmcts.reform.civil.service.flowstate;
 
 public enum FlowFlag {
     ONE_RESPONDENT_REPRESENTATIVE,
-    TWO_RESPONDENT_REPRESENTATIVES
+    TWO_RESPONDENT_REPRESENTATIVES,
+    RPA_CONTINUOUS_FEED
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/aspect/EventAllowedAspectTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/aspect/EventAllowedAspectTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CallbackType;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.sampledata.CallbackParamsBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
 import uk.gov.hmcts.reform.civil.service.flowstate.FlowStateAllowedEventService;
@@ -47,6 +48,8 @@ class EventAllowedAspectTest {
     EventAllowedAspect eventAllowedAspect;
     @MockBean
     ProceedingJoinPoint proceedingJoinPoint;
+    @MockBean
+    FeatureToggleService featureToggleService;
 
     @ParameterizedTest
     @EnumSource(value = CallbackType.class, mode = EnumSource.Mode.EXCLUDE, names = {"ABOUT_TO_START"})

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/robotics/NotifyRoboticsOnCaseHandedOfflineHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/robotics/NotifyRoboticsOnCaseHandedOfflineHandlerTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CallbackParamsBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -64,6 +65,8 @@ class NotifyRoboticsOnCaseHandedOfflineHandlerTest extends BaseCallbackHandlerTe
     OrganisationApi organisationApi;
     @MockBean
     IdamClient idamClient;
+    @MockBean
+    FeatureToggleService featureToggleService;
     @MockBean
     PrdAdminUserConfiguration userConfig;
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandlerTest.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.reform.civil.config.ExitSurveyConfiguration;
 import uk.gov.hmcts.reform.civil.config.MockDatabaseConfiguration;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.launchdarkly.OnBoardingOrganisationControlService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.CorrectEmail;
@@ -114,6 +115,9 @@ class CreateClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
 
     @MockBean
     private IdamClient idamClient;
+
+    @MockBean
+    private FeatureToggleService featureToggleService;
 
     @Autowired
     private CreateClaimCallbackHandler handler;

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/CaseEventTaskHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/CaseEventTaskHandlerTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.enums.BusinessProcessStatus;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -64,6 +65,9 @@ class CaseEventTaskHandlerTest {
 
     @MockBean
     private CoreCaseDataService coreCaseDataService;
+
+    @MockBean
+    private FeatureToggleService featureToggleService;
 
     @Autowired
     private CaseEventTaskHandler caseEventTaskHandler;

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/PaymentTaskHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/PaymentTaskHandlerTest.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.enums.BusinessProcessStatus;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -53,6 +54,8 @@ class PaymentTaskHandlerTest {
     private ExternalTaskService externalTaskService;
     @MockBean
     private CoreCaseDataService coreCaseDataService;
+    @MockBean
+    private FeatureToggleService featureToggleService;
     @Autowired
     private PaymentTaskHandler paymentTaskHandler;
 
@@ -76,7 +79,8 @@ class PaymentTaskHandlerTest {
                 .build();
             VariableMap variables = Variables.createVariables();
             variables.putValue(FLOW_STATE, "MAIN.CLAIM_SUBMITTED");
-            variables.putValue(FLOW_FLAGS, Map.of("ONE_RESPONDENT_REPRESENTATIVE", true));
+            variables.putValue(FLOW_FLAGS, Map.of("ONE_RESPONDENT_REPRESENTATIVE", true,
+                                                  "RPA_CONTINUOUS_FEED", false));
 
             CaseDetails caseDetails = CaseDetailsBuilder.builder().data(caseData).build();
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/StartBusinessProcessTaskHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/StartBusinessProcessTaskHandlerTest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.enums.BusinessProcessStatus;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -64,6 +65,8 @@ class StartBusinessProcessTaskHandlerTest {
     private ExternalTaskService externalTaskService;
     @MockBean
     private CoreCaseDataService coreCaseDataService;
+    @MockBean
+    private FeatureToggleService featureToggleService;
     @Autowired
     private StartBusinessProcessTaskHandler handler;
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleServiceTest.java
@@ -77,6 +77,15 @@ class FeatureToggleServiceTest {
     }
 
     @Test
+    void shouldCallBoolVariation_whenIsRpaContinuousFeedEnabledInvoked() {
+        var multipartyFeatureKey = "rpaContinuousFeed";
+        givenToggle(multipartyFeatureKey, true);
+
+        assertThat(featureToggleService.isRpaContinuousFeedEnabled()).isTrue();
+        verifyBoolVariationCalled(multipartyFeatureKey, List.of("timestamp", "environment"));
+    }
+
+    @Test
     void shouldCallBoolVariation_whenIsOrganisationOnboardedInvoked() {
         var organisationOnboardedFeatureKey = "isOrganisationOnboarded";
         givenToggle(organisationOnboardedFeatureKey, true);

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/RepresentativeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/RepresentativeServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.Address;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.SolicitorServiceAddress;
@@ -55,6 +56,9 @@ class RepresentativeServiceTest {
 
     @MockBean
     private OrganisationService organisationService;
+
+    @MockBean
+    private FeatureToggleService featureToggleService;
 
     @Autowired
     private RepresentativeService representativeService;

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/dq/DirectionsQuestionnaireGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/dq/DirectionsQuestionnaireGeneratorTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.civil.enums.ExpertReportsSent;
 import uk.gov.hmcts.reform.civil.enums.dq.Language;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.LitigationFriend;
 import uk.gov.hmcts.reform.civil.model.Party;
@@ -89,6 +90,9 @@ class DirectionsQuestionnaireGeneratorTest {
 
     @MockBean
     private RepresentativeService representativeService;
+
+    @MockBean
+    private FeatureToggleService featureToggleService;
 
     @Autowired
     private DirectionsQuestionnaireGenerator generator;

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
@@ -11,9 +11,11 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
@@ -70,6 +72,9 @@ import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.PENDING
     FlowStateAllowedEventService.class
 })
 class FlowStateAllowedEventServiceTest {
+
+    @MockBean
+    private FeatureToggleService featureToggleService;
 
     @Autowired
     FlowStateAllowedEventService flowStateAllowedEventService;

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/StateFlowEngineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/StateFlowEngineTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.service.flowstate;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -8,8 +9,10 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
@@ -18,7 +21,10 @@ import uk.gov.hmcts.reform.civil.stateflow.model.State;
 
 import java.time.LocalDateTime;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.CLAIM_DETAILS_NOTIFIED;
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION;
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE;
@@ -58,6 +64,14 @@ class StateFlowEngineTest {
     @Autowired
     private StateFlowEngine stateFlowEngine;
 
+    @MockBean
+    private FeatureToggleService featureToggleService;
+
+    @BeforeEach
+    void setup() {
+        when(featureToggleService.isRpaContinuousFeedEnabled()).thenReturn(true);
+    }
+
     @Nested
     class EvaluateStateFlowEngine {
 
@@ -76,7 +90,9 @@ class StateFlowEngineTest {
                 .extracting(State::getName)
                 .containsExactly(
                     DRAFT.fullName(), CLAIM_SUBMITTED.fullName());
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -94,7 +110,9 @@ class StateFlowEngineTest {
                 .extracting(State::getName)
                 .containsExactly(
                     DRAFT.fullName(), CLAIM_SUBMITTED.fullName());
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("TWO_RESPONDENT_REPRESENTATIVES", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("TWO_RESPONDENT_REPRESENTATIVES", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -115,7 +133,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED_UNREPRESENTED_DEFENDANT.fullName(),
                     TAKEN_OFFLINE_UNREPRESENTED_DEFENDANT.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -136,7 +156,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED_UNREGISTERED_DEFENDANT.fullName(),
                     TAKEN_OFFLINE_UNREGISTERED_DEFENDANT.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -154,7 +176,9 @@ class StateFlowEngineTest {
                 .extracting(State::getName)
                 .containsExactly(
                     DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName());
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -172,7 +196,9 @@ class StateFlowEngineTest {
                 .extracting(State::getName)
                 .containsExactly(
                     DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_FAILED.fullName());
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -192,7 +218,9 @@ class StateFlowEngineTest {
                     DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
                     PENDING_CLAIM_ISSUED.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -212,7 +240,9 @@ class StateFlowEngineTest {
                     DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -233,7 +263,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -254,7 +286,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName(), CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -275,7 +309,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -297,7 +333,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
                     NOTIFICATION_ACKNOWLEDGED_TIME_EXTENSION.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -324,7 +362,9 @@ class StateFlowEngineTest {
                     PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA.fullName(),
                     CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -345,7 +385,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName(), CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -366,7 +408,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(), FULL_DEFENCE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -387,7 +431,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(), FULL_ADMISSION.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -408,7 +454,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(), PART_ADMISSION.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -429,7 +477,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(), COUNTER_CLAIM.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -452,7 +502,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA.fullName(),
                     CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @ParameterizedTest
@@ -480,7 +532,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(), FULL_DEFENCE.fullName(),
                     flowState.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -500,7 +554,9 @@ class StateFlowEngineTest {
                     DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -544,7 +600,9 @@ class StateFlowEngineTest {
                     PAST_APPLICANT_RESPONSE_DEADLINE_AWAITING_CAMUNDA.fullName(),
                     TAKEN_OFFLINE_PAST_APPLICANT_RESPONSE_DEADLINE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -586,7 +644,9 @@ class StateFlowEngineTest {
                     PAST_CLAIM_NOTIFICATION_DEADLINE_AWAITING_CAMUNDA.fullName(),
                     CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -632,7 +692,9 @@ class StateFlowEngineTest {
                     PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE_AWAITING_CAMUNDA.fullName(),
                     CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
     }
 
@@ -655,7 +717,9 @@ class StateFlowEngineTest {
                     DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -674,7 +738,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -693,7 +759,9 @@ class StateFlowEngineTest {
                     PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                     CLAIM_DETAILS_NOTIFIED.fullName(), TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -714,7 +782,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION.fullName(),
                     TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -735,7 +805,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
                     TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -758,7 +830,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
                     NOTIFICATION_ACKNOWLEDGED_TIME_EXTENSION.fullName(), TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -779,7 +853,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
                     FULL_DEFENCE.fullName(), TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -802,7 +878,9 @@ class StateFlowEngineTest {
                     CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE.fullName(),
                     TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -825,7 +903,9 @@ class StateFlowEngineTest {
                     CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE.fullName(),
                     TAKEN_OFFLINE_BY_STAFF.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
     }
 
@@ -888,7 +968,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION.fullName(),
                     PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -912,7 +994,9 @@ class StateFlowEngineTest {
                     PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA.fullName(),
                     CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -935,7 +1019,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
                     PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -960,7 +1046,9 @@ class StateFlowEngineTest {
                     PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA.fullName(),
                     CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
 
         @Test
@@ -1030,7 +1118,9 @@ class StateFlowEngineTest {
                     CLAIM_DETAILS_NOTIFIED.fullName(), PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA.fullName(),
                     CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE.fullName()
                 );
-            assertThat(stateFlow.getFlags()).hasSize(1).containsEntry("ONE_RESPONDENT_REPRESENTATIVE", true);
+            verify(featureToggleService).isRpaContinuousFeedEnabled();
+            assertThat(stateFlow.getFlags()).hasSize(2).containsExactly(entry("ONE_RESPONDENT_REPRESENTATIVE", true),
+                                                                        entry("RPA_CONTINUOUS_FEED", true));
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/RoboticsNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/RoboticsNotificationServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
 import uk.gov.hmcts.reform.civil.config.properties.robotics.RoboticsEmailConfiguration;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sendgrid.EmailData;
@@ -58,6 +59,8 @@ class RoboticsNotificationServiceTest {
     RoboticsNotificationService service;
     @Autowired
     RoboticsEmailConfiguration emailConfiguration;
+    @MockBean
+    FeatureToggleService featureToggleService;
 
     @Captor
     private ArgumentCaptor<EmailData> emailDataArgumentCaptor;

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapperTest.java
@@ -7,7 +7,9 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.robotics.Event;
 import uk.gov.hmcts.reform.civil.model.robotics.EventDetails;
@@ -38,6 +40,9 @@ import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.NOTIFIC
 class EventHistoryMapperTest {
 
     private static final Event EMPTY_EVENT = Event.builder().build();
+
+    @MockBean
+    private FeatureToggleService featureToggleService;
 
     @Autowired
     EventHistoryMapper mapper;

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.civil.assertion.CustomAssertions;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.Address;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.SolicitorOrganisationDetails;
@@ -67,6 +68,8 @@ class RoboticsDataMapperTest {
     AuthTokenGenerator authTokenGenerator;
     @MockBean
     IdamClient idamClient;
+    @MockBean
+    FeatureToggleService featureToggleService;
     @MockBean
     PrdAdminUserConfiguration userConfig;
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1692

### Change description ###

Example flow flag use in Camunda expression: `${!empty flowFlags.RPA_CONTINUOUS_FEED}`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
