### PR TITLE
Revert "build(deps): bump spring-security-core from 5.4.6 to 5.5.0"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -311,7 +311,7 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-web'
   implementation group: 'org.springframework.security', name: 'spring-security-config'
   // CVE-2021-22112 - Privilege Escalation
-  implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.5.0'
+  implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.4.6'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
   implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.8.1'


### PR DESCRIPTION
Reverts hmcts/civil-service#51
Causing issues with master build:  
[Fatal Error] spring-statemachine-core-3.0.0.M2.pom:7:3: The element type "hr" must be terminated by the matching end-tag "</hr>"