### PR TITLE
fix: Bump dependencies (CMC-1684)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,11 @@ plugins {
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.4.2'
   id 'org.owasp.dependencycheck' version '6.1.5'
-  id 'com.github.ben-manes.versions' version '0.38.0'
+  id 'com.github.ben-manes.versions' version '0.39.0'
   id 'org.sonarqube' version '3.3'
   id 'au.com.dius.pact' version '4.2.4'
   id "io.freefair.lombok" version "5.3.3.3"
-  id "org.flywaydb.flyway" version "7.8.1"
+  id "org.flywaydb.flyway" version "7.10.0"
   id 'net.ltgt.apt' version '0.21'
 }
 
@@ -75,18 +75,18 @@ allprojects {
       dependencySet(group: 'com.google.guava', version: '30.1.1-jre') {
         entry 'guava'
       }
-      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.4.32'
-      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk7', version: '1.4.32'
-      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.4.32'
-      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.4.31'
-      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.4.32'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.5.10'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk7', version: '1.5.10'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.5.10'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.5.10'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.5.10'
       // CVE-2020-29582
 
       // CVE-2021-29425
-      dependency group: 'commons-io', name: 'commons-io', version: '2.9.0'
+      dependency group: 'commons-io', name: 'commons-io', version: '2.10.0'
     }
     imports {
-      mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.2'
+      mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.3'
     }
   }
 
@@ -245,7 +245,7 @@ jacocoTestReport.dependsOn {
 
 def versions = [
   junit              : '5.7.0',
-  junitPlatform      : '1.7.1',
+  junitPlatform      : '1.7.2',
   reformLogging      : '5.1.5',
   springBoot         : springBoot.class.package.implementationVersion,
   springStatemachine : '3.0.0.M2',
@@ -278,16 +278,16 @@ dependencies {
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.19'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.2.22'
 
-  implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.19.0'
+  implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.20.1'
   implementation group: 'org.jdbi', name: 'jdbi3-spring4', version: '3.19.0'
 
   implementation group: 'org.flywaydb', name: 'flyway-core'
 
   implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
   implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
-  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.7.RELEASE'
+  implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.8.RELEASE'
   implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
   implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0'
 
@@ -300,21 +300,21 @@ dependencies {
   implementation group: 'com.github.hmcts', name: 'payments-java-client', version: '1.0.1'
   implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '4.0.0'
   implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version: '0.1.0'
-  implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.17.0-RELEASE'
+  implementation group: 'uk.gov.service.notify', name: 'notifications-java-client', version: '3.17.2-RELEASE'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-cache'
-  implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '2.7.0'
+  implementation group: 'com.github.ben-manes.caffeine', name: 'caffeine', version: '3.0.2'
 
   implementation group: 'org.springframework.security', name: 'spring-security-web'
   implementation group: 'org.springframework.security', name: 'spring-security-config'
   // CVE-2021-22112 - Privilege Escalation
-  implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.4.6'
+  implementation group: 'org.springframework.security', name: 'spring-security-core', version: '5.4.7'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-client'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-oauth2-resource-server'
-  implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.8.1'
+  implementation group: 'com.nimbusds', name: 'nimbus-jose-jwt', version: '9.10'
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '2.0.0'
 
@@ -324,7 +324,7 @@ dependencies {
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.43'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.5'
 
-  implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.12.0'
+  implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.13.2'
 
   implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.52'
 
@@ -338,11 +338,11 @@ dependencies {
   implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.0.0'
   implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '3.0.0'
 
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.4.1'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.5.0'
 
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.0'
-  testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.9.0'
-  testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
+  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
+  testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.11.2'
+  testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.2'
 
   testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   testCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok

--- a/sendgrid-client/build.gradle
+++ b/sendgrid-client/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 def versions = [
   junit        : '5.7.0',
-  junitPlatform: '1.7.1',
+  junitPlatform: '1.7.2',
   lombok       : '1.18.12'
 ]
 
@@ -50,9 +50,9 @@ dependencies {
   testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   testCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
-  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.0'
-  testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.9.0'
-  testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.9.0'
+  testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
+  testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '3.11.2'
+  testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.11.2'
 
   testImplementation libraries.junit5
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test', {


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1684

### Change description ###

Bump the backlog of dependabot PRs.

This covers PRs #48, #50, #66, #67, #68, #69, #71, #74, #76, #78, #79, #81, #84, #85, #87, #91, #101, #104, #108, #109, #110, and #116.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
