### PR TITLE
Increment allowed address line length for RPA to 60

### DIFF
--- a/src/main/resources/schema/rpa-json-schema.json
+++ b/src/main/resources/schema/rpa-json-schema.json
@@ -544,7 +544,7 @@
     "addressLineType": {
       "$id": "#/definitions/addressLineType",
       "type": "string",
-      "maxLength": 35,
+      "maxLength": 60,
       "description": ""
     },
     "addressLineOrNullType": {
@@ -553,7 +553,7 @@
         "string",
         "null"
       ],
-      "maxLength": 35,
+      "maxLength": 60,
       "description": ""
     },
     "postCodeType": {


### PR DESCRIPTION

### Change description ###

Allowing address line to have up to 60 char length in RPA mapping.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
