### PR TITLE
fix: further validation for emails (CMC-1718)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/validation/ValidateEmailService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/validation/ValidateEmailService.java
@@ -24,6 +24,7 @@ public class ValidateEmailService {
     private static final int EMAIL_MAX_LENGTH = 320;
     private static final int HOST_MAX_LENGTH = 253;
     private static final int HOST_PART_MAX_LENGTH = 63;
+    private static final int USERNAME_MAX_LENGTH = 64;
 
     private static final String ERROR_MESSAGE = "Enter an email address in the correct format,"
         + " for example john.smith@example.com";
@@ -51,6 +52,23 @@ public class ValidateEmailService {
         }
 
         final String emailAddress = StringUtils.trim(email);
+
+        if (emailAddress.startsWith(".")) {
+            log.warn("Email begins with .");
+            return false;
+        }
+
+        final String username = emailAddress.split("@")[0];
+
+        if (username.endsWith(".")) {
+            log.warn("Username ends with .");
+            return false;
+        }
+
+        if (username.length() > USERNAME_MAX_LENGTH) {
+            log.warn("Email username is longer than {} characters", USERNAME_MAX_LENGTH);
+            return false;
+        }
 
         if (emailAddress.length() > EMAIL_MAX_LENGTH) {
             log.warn("Email is longer than {} characters", EMAIL_MAX_LENGTH);

--- a/src/test/java/uk/gov/hmcts/reform/civil/validation/ValidateEmailServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/validation/ValidateEmailServiceTest.java
@@ -45,7 +45,9 @@ class ValidateEmailServiceTest {
             "firstname-lastname@domain.com",
             "info@german-financial-services.vermögensberatung",
             "info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase",
-            "japanese-info@例え.テスト");
+            "japanese-info@例え.テスト",
+            format("%s@example.com", "a".repeat(64)),
+            format("%s@example.com", "a".repeat(63)));
     }
 
     //See https://github.com/alphagov/notifications-utils/blob/master/tests/test_recipient_validation.py#L122-L152
@@ -83,6 +85,9 @@ class ValidateEmailServiceTest {
             "local-with-”-quotes@domain.com",
             "domain-starts-with-a-dot@.domain.com",
             "brackets(in)local@domain.com",
+            ".Douglas.@hmcts.net",
+            "Douglas.@hmcts.net",
+            format("%s@example.com", "a".repeat(65)),
             format("email-too-long-%s@example.com", "a".repeat(320)));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1718

### Change description ###

Validate emails with:
- dot at beginning of username
- dot at end of username
- username larger than 64 characters

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
