### PR TITLE
fix: business process set to ready only for respondent 1 (CMC-1348)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandler.java
@@ -126,7 +126,6 @@ public class InformAgreedExtensionDateCallbackHandler extends CallbackHandler {
             .atTime(END_OF_BUSINESS_DAY);
 
         CaseData.CaseDataBuilder caseDataBuilder = caseData.toBuilder()
-            .businessProcess(BusinessProcess.ready(INFORM_AGREED_EXTENSION_DATE))
             .isRespondent1(null);
 
         if (representsRespondent2(callbackParams)) {
@@ -134,6 +133,7 @@ public class InformAgreedExtensionDateCallbackHandler extends CallbackHandler {
                 .respondent2ResponseDeadline(newDeadline);
         } else {
             caseDataBuilder.respondent1TimeExtensionDate(time.now())
+                .businessProcess(BusinessProcess.ready(INFORM_AGREED_EXTENSION_DATE))
                 .respondent1ResponseDeadline(newDeadline);
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandlerTest.java
@@ -302,14 +302,7 @@ class InformAgreedExtensionDateCallbackHandlerTest extends BaseCallbackHandlerTe
                 .containsEntry("respondent2TimeExtensionDate", timeExtensionDate.format(ISO_DATE_TIME));
 
             assertThat(response.getData())
-                .extracting("businessProcess")
-                .extracting("camundaEvent")
-                .isEqualTo(INFORM_AGREED_EXTENSION_DATE.name());
-
-            assertThat(response.getData())
-                .extracting("businessProcess")
-                .extracting("status")
-                .isEqualTo("READY");
+                .doesNotContainKey("businessProcess");
         }
     }
 


### PR DESCRIPTION
### Change description ###

Business process should be set to READY (and therefore triggered on submitted callback) only for respondent 1, as Camunda diagram contains notification only for 1v1 cases.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
