### PR TITLE
fix: change dependabot to update weekly

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,4 +2,4 @@ version: 1
 update_configs:
   - package_manager: "java:gradle"
     directory: "/"
-    update_schedule: "daily"
+    update_schedule: "weekly"


### PR DESCRIPTION
### JIRA link (if applicable) ###
n/a


### Change description ###
- Changing depandabot to update weekly rather than daily, using less PR resources


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
