### PR TITLE
fix: RPA 35 character address line fix (CMC-1708)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/Address.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/Address.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.reform.prd.model.ContactInformation;
 import static uk.gov.hmcts.reform.civil.utils.StringUtils.joinNonNull;
 
 @Data
-@Builder
+@Builder(toBuilder = true)
 @JsonNaming(PropertyNamingStrategy.UpperCamelCaseStrategy.class)
 public class Address {
 
@@ -22,6 +22,19 @@ public class Address {
     private final String county;
     private final String country;
     private final String postCode;
+
+    @JsonIgnore
+    public static Address fromContactInformation(ContactInformation contactInformation) {
+        return Address.builder()
+            .addressLine1(contactInformation.getAddressLine1())
+            .addressLine2(contactInformation.getAddressLine2())
+            .addressLine3(contactInformation.getAddressLine3())
+            .postTown(contactInformation.getTownCity())
+            .county(contactInformation.getCounty())
+            .country(contactInformation.getCountry())
+            .postCode(contactInformation.getPostCode())
+            .build();
+    }
 
     @JsonIgnore
     public String firstNonNull() {
@@ -76,18 +89,5 @@ public class Address {
             postTown,
             joinNonNull(", ", county, country)
         );
-    }
-
-    @JsonIgnore
-    public static Address fromContactInformation(ContactInformation contactInformation) {
-        return Address.builder()
-            .addressLine1(contactInformation.getAddressLine1())
-            .addressLine2(contactInformation.getAddressLine2())
-            .addressLine3(contactInformation.getAddressLine3())
-            .postTown(contactInformation.getTownCity())
-            .county(contactInformation.getCounty())
-            .country(contactInformation.getCountry())
-            .postCode(contactInformation.getPostCode())
-            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/exception/AddressLineExceedsLengthLimitException.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/exception/AddressLineExceedsLengthLimitException.java
@@ -1,0 +1,4 @@
+package uk.gov.hmcts.reform.civil.service.robotics.exception;
+
+public class AddressLineExceedsLengthLimitException extends RuntimeException {
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsAddressMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsAddressMapper.java
@@ -23,7 +23,7 @@ public class RoboticsAddressMapper {
     public RoboticsAddress toRoboticsAddress(Address address) {
         requireNonNull(address);
 
-        if (address.getAddressLine1().length() > 35
+        if ((address.getAddressLine1() != null && address.getAddressLine1().length() > 35)
             || (address.getAddressLine2() != null && address.getAddressLine2().length() > 35)) {
             try {
                 Address alteredAddress = tryToRollOverAddressLines(address);

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsAddressMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsAddressMapper.java
@@ -1,12 +1,16 @@
 package uk.gov.hmcts.reform.civil.service.robotics.mapper;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.civil.model.Address;
 import uk.gov.hmcts.reform.civil.model.robotics.RoboticsAddress;
 import uk.gov.hmcts.reform.civil.model.robotics.RoboticsAddresses;
+import uk.gov.hmcts.reform.civil.service.robotics.exception.AddressLineExceedsLengthLimitException;
 import uk.gov.hmcts.reform.prd.model.ContactInformation;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static io.jsonwebtoken.lang.Collections.isEmpty;
@@ -18,14 +22,16 @@ public class RoboticsAddressMapper {
 
     public RoboticsAddress toRoboticsAddress(Address address) {
         requireNonNull(address);
-        return RoboticsAddress.builder()
-            .addressLine1(address.firstNonNull())
-            .addressLine2(Optional.ofNullable(address.secondNonNull()).orElse("-"))
-            .addressLine3(address.thirdNonNull())
-            .addressLine4(address.fourthNonNull())
-            .addressLine5(address.fifthNonNull())
-            .postCode(address.getPostCode())
-            .build();
+
+        if (address.getAddressLine1().length() > 35
+            || (address.getAddressLine2() != null && address.getAddressLine2().length() > 35)) {
+            try {
+                Address alteredAddress = tryToRollOverAddressLines(address);
+                return toNonDefaultRoboticsAddress(alteredAddress);
+            } catch (AddressLineExceedsLengthLimitException ignored) { }
+        }
+
+        return toDefaultRoboticsAddress(address);
     }
 
     public RoboticsAddresses toRoboticsAddresses(Address address) {
@@ -39,5 +45,72 @@ public class RoboticsAddressMapper {
         return isEmpty(contactInformation)
             ? null
             : toRoboticsAddresses(fromContactInformation(contactInformation.get(0)));
+    }
+
+    private Address tryToRollOverAddressLines(Address address) {
+        String[] addressLines = new String[]{
+            address.getAddressLine1(), address.getAddressLine2(), address.getAddressLine3()};
+
+        if (addressLines[0].length() > 35) {
+            tryToRollOverAddressLine(addressLines, 0);
+        }
+
+        if (addressLines[1] != null && addressLines[1].length() > 35) {
+            tryToRollOverAddressLine(addressLines, 1);
+        }
+
+        if (Arrays.stream(addressLines).filter(Objects::nonNull).anyMatch(addressLine -> addressLine.length() > 35)) {
+            throw new AddressLineExceedsLengthLimitException();
+        }
+
+        return Address.builder()
+            .addressLine1(addressLines[0])
+            .addressLine2(addressLines[1])
+            .addressLine3(addressLines[2])
+            .postTown(address.getPostTown())
+            .county(address.getCounty())
+            .country(address.getCountry())
+            .postCode(address.getPostCode())
+            .build();
+    }
+
+    private void tryToRollOverAddressLine(String[] addressLines, int addressLineIndex) {
+        String[] addressSplit = addressLines[addressLineIndex].split(", ");
+
+        if (addressSplit.length == 1)
+            throw new AddressLineExceedsLengthLimitException();
+
+        addressLines[addressLineIndex] = String.join(
+            ", ",
+            ArrayUtils.subarray(addressSplit, 0, addressSplit.length - 1)
+        );
+
+        if (addressLines[addressLineIndex + 1] == null) {
+            addressLines[addressLineIndex + 1] = addressSplit[addressSplit.length - 1];
+        } else {
+            addressLines[addressLineIndex + 1] = addressSplit[addressSplit.length - 1] + ", " + addressLines[addressLineIndex + 1];
+        }
+    }
+
+    private RoboticsAddress toDefaultRoboticsAddress(Address address) {
+        return RoboticsAddress.builder()
+            .addressLine1(address.firstNonNull())
+            .addressLine2(Optional.ofNullable(address.secondNonNull()).orElse("-"))
+            .addressLine3(address.thirdNonNull())
+            .addressLine4(address.fourthNonNull())
+            .addressLine5(address.fifthNonNull())
+            .postCode(address.getPostCode())
+            .build();
+    }
+
+    private RoboticsAddress toNonDefaultRoboticsAddress(Address address) {
+        return RoboticsAddress.builder()
+            .addressLine1(address.firstNonNull())
+            .addressLine2(address.secondNonNull())
+            .addressLine3(address.thirdNonNull())
+            .addressLine4(address.fourthNonNull())
+            .addressLine5(address.fifthNonNull())
+            .postCode(address.getPostCode())
+            .build();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsAddressMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsAddressMapper.java
@@ -28,7 +28,9 @@ public class RoboticsAddressMapper {
             try {
                 Address alteredAddress = tryToRollOverAddressLines(address);
                 return toNonDefaultRoboticsAddress(alteredAddress);
-            } catch (AddressLineExceedsLengthLimitException ignored) { }
+            } catch (AddressLineExceedsLengthLimitException ignored) {
+                return toDefaultRoboticsAddress(address);
+            }
         }
 
         return toDefaultRoboticsAddress(address);
@@ -77,8 +79,9 @@ public class RoboticsAddressMapper {
     private void tryToRollOverAddressLine(String[] addressLines, int addressLineIndex) {
         String[] addressSplit = addressLines[addressLineIndex].split(", ");
 
-        if (addressSplit.length == 1)
+        if (addressSplit.length == 1) {
             throw new AddressLineExceedsLengthLimitException();
+        }
 
         addressLines[addressLineIndex] = String.join(
             ", ",
@@ -88,7 +91,8 @@ public class RoboticsAddressMapper {
         if (addressLines[addressLineIndex + 1] == null) {
             addressLines[addressLineIndex + 1] = addressSplit[addressSplit.length - 1];
         } else {
-            addressLines[addressLineIndex + 1] = addressSplit[addressSplit.length - 1] + ", " + addressLines[addressLineIndex + 1];
+            addressLines[addressLineIndex + 1] = addressSplit[addressSplit.length - 1] + ", "
+                + addressLines[addressLineIndex + 1];
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsAddressMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsAddressMapperTest.java
@@ -48,6 +48,127 @@ class RoboticsAddressMapperTest {
 
             assertThat(roboticsAddress).isEqualTo(address);
         }
+
+        @Test
+        void shouldMapToRoboticsAddress_whenAllAddressLinesAreEqualTo35Characters() {
+            Address address = AddressBuilder.maximal().build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress).isEqualTo(address);
+        }
+
+        @Test
+        void shouldRollOverToAddressLine2_whenAddressLine1IsMoreThan35CharactersWithCommas() {
+            Address address = Address.builder()
+                .addressLine1("address line 1, address line 1, address line 2")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress)
+                .isEqualTo(RoboticsAddress.builder()
+                               .addressLine1("address line 1, address line 1")
+                               .addressLine2("address line 2")
+                               .postCode("SW1 1AA")
+                               .build());
+        }
+
+        @Test
+        void shouldRollOverToAddressLine3_whenAddressLine2IsMoreThan35CharactersWithCommas() {
+            Address address = Address.builder()
+                .addressLine1("address line 1, address line 1")
+                .addressLine2("address line 2, address line 2, address line 3")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress)
+                .isEqualTo(RoboticsAddress.builder()
+                               .addressLine1("address line 1, address line 1")
+                               .addressLine2("address line 2, address line 2")
+                               .addressLine3("address line 3")
+                               .postCode("SW1 1AA")
+                               .build());
+        }
+
+        @Test
+        void shouldRollOverBothAddressLines1And2_whenBothAddressLine1And2AreMoreThan35CharactersWithCommas() {
+            Address address = Address.builder()
+                .addressLine1("address line 1, address line 1, address line 2")
+                .addressLine2("address line 2, address line 3")
+                .addressLine3("address line 3")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress)
+                .isEqualTo(RoboticsAddress.builder()
+                               .addressLine1("address line 1, address line 1")
+                               .addressLine2("address line 2, address line 2")
+                               .addressLine3("address line 3, address line 3")
+                               .postCode("SW1 1AA")
+                               .build());
+        }
+
+        @Test
+        void shouldMapToRoboticsAddress_whenAddressLine1IsMoreThan35CharactersWithoutCommas() {
+            Address address = Address.builder()
+                .addressLine1("address line 1 address line 1 address line 1")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress).isEqualTo(address);
+        }
+
+        @Test
+        void shouldMapToRoboticsAddress_whenAddressLine1IsMoreThan70CharactersWithCommas() {
+            Address address = Address.builder()
+                .addressLine1("address line 1 address line 1, address line 1 address line 1 address line 1")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress).isEqualTo(address);
+        }
+
+        @Test
+        void shouldMapToRoboticsAddress_whenAddressLine2IsMoreThan35CharactersWithoutCommas() {
+            Address address = Address.builder()
+                .addressLine1("address line 1, address line 1")
+                .addressLine2("address line 2 address line 2 address line 2")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress).isEqualTo(address);
+        }
+
+        @Test
+        void shouldMapToRoboticsAddress_whenAddressLine2IsMoreThan70CharactersWithCommas() {
+            Address address = Address.builder()
+                .addressLine1("address line 1, address line 1")
+                .addressLine2("address line 2 address line 2, address line 2 address line 2 address line 2")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress).isEqualTo(address);
+        }
+
+        @Test
+        void shouldMapToRoboticsAddress_whenAddressLine3IsMoreThan35Characters() {
+            Address address = Address.builder()
+                .addressLine1("address line 1, address line 1")
+                .addressLine2("address line 2, address line 2")
+                .addressLine3("address line 3, address line 3, address line 3")
+                .postCode("SW1 1AA").build();
+
+            RoboticsAddress roboticsAddress = mapper.toRoboticsAddress(address);
+
+            assertThat(roboticsAddress).isEqualTo(address);
+        }
     }
 
     @Nested


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1708

### Change description ###

See ticket for implementation details. Attempts to wrap the last comma-separated value in an address line around to the next one if the line exceeds 35 characters in length.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
