### PR TITLE
fix: capture payment method and the field text when it is Other payme…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/PaymentMethod.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/PaymentMethod.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.reform.civil.model;
+
+public enum PaymentMethod {
+    CREDIT_CARD, CHEQUE, BACS, OTHER
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/RespondToClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/RespondToClaim.java
@@ -12,6 +12,7 @@ public class RespondToClaim {
 
     private final BigDecimal howMuchWasPaid;
     private final LocalDate whenWasThisAmountPaid;
-    private final String howWasThisAmountPaid;
+    private final PaymentMethod howWasThisAmountPaid;
+    private final String howWasThisAmountPaidOther;
 
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ROC-9545


### Change description ###
Capturing payment method from the Defendant LR response journey and capturing field text when payment method is 'Other'


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
