### PR TITLE
Build/bump dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,12 +4,12 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.5.5'
-  id 'org.owasp.dependencycheck' version '6.3.2'
+  id 'org.owasp.dependencycheck' version '6.4.1.1'
   id 'com.github.ben-manes.versions' version '0.39.0'
   id 'org.sonarqube' version '3.3'
   id 'au.com.dius.pact' version '4.2.14'
   id "io.freefair.lombok" version "5.3.3.3"
-  id "org.flywaydb.flyway" version "8.0.0"
+  id "org.flywaydb.flyway" version "8.0.1"
   id 'net.ltgt.apt' version '0.21'
 }
 
@@ -337,9 +337,9 @@ dependencies {
 
   implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.61'
 
-  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.15.0'
+  implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.16.0'
   implementation group: 'org.camunda.bpm.extension.rest', name: 'camunda-rest-client-spring-boot-starter', version: '0.0.4'
-  implementation group: 'org.camunda.bpm', name: 'camunda-engine-rest-core', version: '7.14.0'
+  implementation group: 'org.camunda.bpm', name: 'camunda-engine-rest-core', version: '7.16.0'
   implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.0'
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.0'
 
@@ -348,7 +348,7 @@ dependencies {
   implementation group: 'jakarta.xml.bind', name: 'jakarta.xml.bind-api', version: '3.0.1'
   implementation group: 'org.glassfish.jaxb', name: 'jaxb-runtime', version: '3.0.0'
 
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.6.1'
+  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '5.6.3'
 
   testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.0.0'
   testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '4.0.0'

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -64,7 +64,7 @@ idam:
 
 document_management:
   userRoles: "caseworker-civil,caseworker-civil-solicitor"
-  secured: false
+  secured: true
 
 bankHolidays:
   api:


### PR DESCRIPTION
Bumped following dependency versions:
```
dependencycheck 6.3.2 -> 6.4.1.1
flyway 8.0.0 -> 8.0.1
camunda-external-task-client 7.15.0 -> 7.16.0
camunda-engine-rest-core 7.14.0 -> 7.15.0
launchdarkly-java-server-sdk 5.6.1 -> 5.6.3
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
