### PR TITLE
chore: upgrade dependency version of tomcat-embed-core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -330,7 +330,7 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.14.1'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.14.1'
 
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.0.12'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.12'
 
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.15.1'


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Upgrade tomcat-embed-core to rectify CVE-2021-42340


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
