### PR TITLE
chore: ignore LRspec.json files

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -94,7 +94,7 @@ withPipeline(type, product, component) {
       ./bin/add-roles.sh
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
       ./bin/pull-latest-release-asset.sh civil-camunda-bpmn-definition civil-camunda-bpmn-definition.zip
-      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json, *LRspec.json"
       ./bin/import-bpmn-diagram.sh .
     """
 
@@ -125,7 +125,7 @@ withPipeline(type, product, component) {
       ./bin/add-roles.sh
       ./bin/pull-latest-release-asset.sh civil-ccd-definition civil-ccd-definition.zip
       ./bin/pull-latest-release-asset.sh civil-camunda-bpmn-definition civil-camunda-bpmn-definition.zip
-      ./bin/import-ccd-definition.sh "-e *-nonprod.json"
+      ./bin/import-ccd-definition.sh "-e *-nonprod.json, *LRspec.json"
       ./bin/import-bpmn-diagram.sh .
     """
     env.URL="https://civil-service-xui-staging.aat.platform.hmcts.net"


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
Exclude all LRspec definition files from loading on civil-service PRs


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
