### PR TITLE
Build/update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id 'org.sonarqube' version '3.3'
   id 'au.com.dius.pact' version '4.2.14'
   id "io.freefair.lombok" version "5.3.3.3"
-  id "org.flywaydb.flyway" version "8.0.3"
+  id "org.flywaydb.flyway" version "8.0.4"
   id 'net.ltgt.apt' version '0.21'
 }
 
@@ -75,11 +75,11 @@ allprojects {
       dependencySet(group: 'com.google.guava', version: '31.0.1-jre') {
         entry 'guava'
       }
-      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.5.21'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.6.0'
       dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk7', version: '1.5.20'
       dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.6.0'
       dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.5.20'
-      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.5.20'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.6.0'
       // CVE-2020-29582
 
       // CVE-2021-29425
@@ -288,7 +288,7 @@ dependencies {
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
   implementation group: 'org.postgresql', name: 'postgresql', version: '42.3.1'
 
-  implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.23.0'
+  implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.24.0'
   implementation group: 'org.jdbi', name: 'jdbi3-spring4', version: '3.19.0'
 
   implementation group: 'org.flywaydb', name: 'flyway-core'
@@ -333,9 +333,9 @@ dependencies {
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.12'
 
-  implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.15.1'
+  implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.15.2'
 
-  implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.63'
+  implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.0.64'
 
   implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.16.0'
   implementation group: 'org.camunda.bpm.extension.rest', name: 'camunda-rest-client-spring-boot-starter', version: '0.0.4'

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ allprojects {
       }
       dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.5.21'
       dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk7', version: '1.5.20'
-      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.5.21'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.6.0'
       dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.5.20'
       dependency group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.5.20'
       // CVE-2020-29582


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- kotlin-stdlib-jdk8 from 1.5.21 to 1.6.0
- kotlin-stdlib-common from 1.5.21 to 1.6.0
- kotlin-reflect from 1.5.20 to 1.6.0
- json-schema-validator from 1.0.63 to 1.0.64
- org.flywaydb.flyway from 8.0.3 to 8.0.4
- elasticsearch from 7.15.1 to 7.15.2
- jdbi3-sqlobject from 3.23.0 to 3.24.0


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
