### PR TITLE
Fix State flow listener ambiguous transitions

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandler.java
@@ -257,9 +257,9 @@ public class CreateClaimCallbackHandler extends CallbackHandler implements Parti
         // second idam call is workaround for null pointer when hiding field in getIdamEmail callback
         CaseData.CaseDataBuilder dataBuilder = getSharedData(callbackParams);
 
-        if (caseData.getRespondent1OrgRegistered() == YES &&
-            caseData.getRespondent1Represented() == YES &&
-            caseData.getRespondent2SameLegalRepresentative() == YES) {
+        if (caseData.getRespondent1OrgRegistered() == YES
+            && caseData.getRespondent1Represented() == YES
+            && caseData.getRespondent2SameLegalRepresentative() == YES) {
 
             // Predicate: Def1 registered, Def 2 unregistered.
             // This is required to ensure mutual exclusion in 1v2 same solicitor case.

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandler.java
@@ -257,6 +257,15 @@ public class CreateClaimCallbackHandler extends CallbackHandler implements Parti
         // second idam call is workaround for null pointer when hiding field in getIdamEmail callback
         CaseData.CaseDataBuilder dataBuilder = getSharedData(callbackParams);
 
+        if (caseData.getRespondent1OrgRegistered() == YES &&
+            caseData.getRespondent1Represented() == YES &&
+            caseData.getRespondent2SameLegalRepresentative() == YES) {
+
+            // Predicate: Def1 registered, Def 2 unregistered.
+            // This is required to ensure mutual exclusion in 1v2 same solicitor case.
+            dataBuilder.respondent2OrgRegistered(YES);
+        }
+
         // moving statement of truth value to correct field, this was not possible in mid event.
         // resetting statement of truth to make sure it's empty the next time it appears in the UI.
         StatementOfTruth statementOfTruth = caseData.getUiStatementOfTruth();

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandlerTest.java
@@ -991,6 +991,33 @@ class CreateClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @Nested
+        class Respondent1HaveLegalRepresentation1V2SameSolicitor {
+
+            @Test
+            void shouldReturnExpectedSubmittedCallbackResponse_whenRespondent1HasRepresentation() {
+                CaseData caseData = CaseDataBuilder.builder()
+                    .atStateClaimDetailsNotified()
+                    .multiPartyClaimOneDefendantSolicitor().build();
+                CallbackParams params = callbackParamsOf(caseData, SUBMITTED);
+                SubmittedCallbackResponse response = (SubmittedCallbackResponse) handler.handle(params);
+
+                String body = format(
+                    CONFIRMATION_SUMMARY,
+                    format("/cases/case-details/%s#CaseDocuments", CASE_ID)
+                ) + exitSurveyContentService.applicantSurvey();
+
+                assertThat(response).usingRecursiveComparison().isEqualTo(
+                    SubmittedCallbackResponse.builder()
+                        .confirmationHeader(format(
+                            "# Your claim has been received%n## Claim number: %s",
+                            REFERENCE_NUMBER
+                        ))
+                        .confirmationBody(body)
+                        .build());
+            }
+        }
+
+        @Nested
         class Respondent1DoesNotHaveLegalRepresentation {
 
             @Test


### PR DESCRIPTION

### Change description ###

2021-12-01T16:04:04.899 INFO [http-nio-4000-exec-4] u.g.h.r.c.s.d.SecuredDocumentManagementService Uploading file sealed_claim_form_000DC015.pdf2021-12-01T16:04:04.899 INFO [http-nio-4000-exec-4] u.g.h.r.c.s.d.SecuredDocumentManagementService Uploading file sealed_claim_form_000DC015.pdf2021-12-01T16:04:05.276 ERROR [TopicSubscriptionManager] u.g.hmcts.reform.civil.stateflow.StateFlowListener Ambiguous transitions permitting state [MAIN.CLAIM_ISSUED_PAYMENT_SUCCESSFUL] to move to more than one next states [MAIN.PENDING_CLAIM_ISSUED,MAIN.PENDING_CLAIM_ISSUED_UNREGISTERED_DEFENDANT].2021-12-01T16:04:05.277

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
