### PR TITLE
Bumping up log4j version from 2.15.0 to 2.17.0 to cover for latest lo…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,8 +327,8 @@ dependencies {
   implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
   implementation group: 'uk.gov.hmcts.reform', name: 'idam-client', version: '2.0.0'
 
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.15.0'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.0'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.0'
 
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.54'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.13'


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###

Bumping up log4j version from 2.15.0 to 2.17.0 to cover for latest log4j CVEs

**Does this PR introduce a breaking change?** (check one with "x")

```
[x ] Yes
[ ] No
```
