### PR TITLE
fix: feat/CIV-633 implementing lenghtOfRepayment plan

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/RepaymentPlanLRspec.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/RepaymentPlanLRspec.java
@@ -18,7 +18,6 @@ public class RepaymentPlanLRspec {
     private final BigDecimal paymentAmount;
     private final PaymentFrequencyLRspec repaymentFrequency;
     private final LocalDate firstRepaymentDate;
-
-
+    private int lengthOfPaymentPlan;
 
 }


### PR DESCRIPTION
Admits Part: to split the defendant repayment plan screen.


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-633


### Change description ###
Admits Part: to split the defendant repayment plan screen.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
