### PR TITLE
Move idam calls to cache - its blocking master with 429 failures in logs 

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/RpaConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/RpaConsumerTest.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.civil.sampledata.CaseDataMinEdgeCasesBuilder;
 import uk.gov.hmcts.reform.civil.sendgrid.SendGridClient;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
 import uk.gov.hmcts.reform.civil.service.Time;
+import uk.gov.hmcts.reform.civil.service.UserService;
 import uk.gov.hmcts.reform.civil.service.flowstate.FlowState;
 import uk.gov.hmcts.reform.civil.service.flowstate.StateFlowEngine;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.AddressLinesMapper;
@@ -28,7 +29,6 @@ import uk.gov.hmcts.reform.civil.service.robotics.mapper.EventHistoryMapper;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.EventHistorySequencer;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.RoboticsAddressMapper;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.RoboticsDataMapper;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.prd.client.OrganisationApi;
 
 import java.time.LocalDateTime;
@@ -70,7 +70,7 @@ class RpaConsumerTest extends BaseRpaTest {
     @MockBean
     AuthTokenGenerator authTokenGenerator;
     @MockBean
-    IdamClient idamClient;
+    UserService userService;
     @MockBean
     PrdAdminUserConfiguration userConfig;
     @MockBean

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/RpaContinuousFeedConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/RpaContinuousFeedConsumerTest.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.civil.sampledata.CaseDataMinEdgeCasesBuilder;
 import uk.gov.hmcts.reform.civil.sendgrid.SendGridClient;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
 import uk.gov.hmcts.reform.civil.service.Time;
+import uk.gov.hmcts.reform.civil.service.UserService;
 import uk.gov.hmcts.reform.civil.service.flowstate.FlowState;
 import uk.gov.hmcts.reform.civil.service.flowstate.StateFlowEngine;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.AddressLinesMapper;
@@ -29,7 +30,6 @@ import uk.gov.hmcts.reform.civil.service.robotics.mapper.EventHistoryMapper;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.EventHistorySequencer;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.RoboticsAddressMapper;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.RoboticsDataMapper;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.prd.client.OrganisationApi;
 
 import java.time.LocalDate;
@@ -66,7 +66,7 @@ class RpaContinuousFeedConsumerTest extends BaseRpaTest {
     @MockBean
     FeatureToggleService featureToggleService;
     @MockBean
-    IdamClient idamClient;
+    UserService userService;
     @MockBean
     PrdAdminUserConfiguration userConfig;
     @MockBean

--- a/src/main/java/uk/gov/hmcts/reform/civil/controllers/testingsupport/AssignCaseSupportController.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/controllers/testingsupport/AssignCaseSupportController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.reform.civil.enums.CaseRole;
 import uk.gov.hmcts.reform.civil.service.CoreCaseUserService;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
+import uk.gov.hmcts.reform.civil.service.UserService;
 import uk.gov.hmcts.reform.prd.model.Organisation;
 
 import java.util.Optional;
@@ -33,7 +33,7 @@ import java.util.Optional;
 public class AssignCaseSupportController {
 
     private final CoreCaseUserService coreCaseUserService;
-    private final IdamClient idamClient;
+    private final UserService userService;
     private final OrganisationService organisationService;
 
     @PostMapping(value = {"/assign-case/{caseId}", "/assign-case/{caseId}/{caseRole}"})
@@ -41,7 +41,7 @@ public class AssignCaseSupportController {
     public void assignCase(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorisation,
                            @PathVariable("caseId") String caseId,
                            @PathVariable("caseRole") Optional<CaseRole> caseRole) {
-        String userId = idamClient.getUserInfo(authorisation).getUid();
+        String userId = userService.getUserInfo(authorisation).getUid();
 
         String organisationId = organisationService.findOrganisation(authorisation)
             .map(Organisation::getOrganisationIdentifier).orElse(null);

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataService.java
@@ -15,7 +15,6 @@ import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.search.Query;
 import uk.gov.hmcts.reform.civil.service.data.UserAuthContent;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -27,11 +26,11 @@ import static uk.gov.hmcts.reform.civil.CaseDefinitionConstants.JURISDICTION;
 @RequiredArgsConstructor
 public class CoreCaseDataService {
 
-    private final IdamClient idamClient;
     private final CoreCaseDataApi coreCaseDataApi;
     private final SystemUpdateUserConfiguration userConfig;
     private final AuthTokenGenerator authTokenGenerator;
     private final CaseDetailsConverter caseDetailsConverter;
+    private final UserService userService;
 
     public void triggerEvent(Long caseId, CaseEvent eventName) {
         triggerEvent(caseId, eventName, Map.of());
@@ -73,18 +72,18 @@ public class CoreCaseDataService {
     }
 
     public SearchResult searchCases(Query query) {
-        String userToken = idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+        String userToken = userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         return coreCaseDataApi.searchCases(userToken, authTokenGenerator.generate(), CASE_TYPE, query.toString());
     }
 
     public CaseDetails getCase(Long caseId) {
-        String userToken = idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+        String userToken = userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         return coreCaseDataApi.getCase(userToken, authTokenGenerator.generate(), caseId.toString());
     }
 
     private UserAuthContent getSystemUpdateUser() {
-        String userToken = idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
-        String userId = idamClient.getUserInfo(userToken).getUid();
+        String userToken = userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+        String userId = userService.getUserInfo(userToken).getUid();
         return UserAuthContent.builder().userToken(userToken).userId(userId).build();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/CoreCaseUserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/CoreCaseUserService.java
@@ -12,7 +12,6 @@ import uk.gov.hmcts.reform.ccd.model.CaseAssignedUserRolesRequest;
 import uk.gov.hmcts.reform.ccd.model.CaseAssignedUserRolesResource;
 import uk.gov.hmcts.reform.civil.config.CrossAccessUserConfiguration;
 import uk.gov.hmcts.reform.civil.enums.CaseRole;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 
 import java.util.List;
 
@@ -25,7 +24,7 @@ public class CoreCaseUserService {
     Logger log = LoggerFactory.getLogger(CoreCaseUserService.class);
 
     private final CaseAccessDataStoreApi caseAccessDataStoreApi;
-    private final IdamClient idamClient;
+    private final UserService userService;
     private final CrossAccessUserConfiguration crossAccessUserConfiguration;
     private final AuthTokenGenerator authTokenGenerator;
 
@@ -63,7 +62,7 @@ public class CoreCaseUserService {
     }
 
     private String getCaaAccessToken() {
-        return idamClient.getAccessToken(
+        return userService.getAccessToken(
             crossAccessUserConfiguration.getUserName(),
             crossAccessUserConfiguration.getPassword()
         );

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/OrganisationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/OrganisationService.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.prd.client.OrganisationApi;
 import uk.gov.hmcts.reform.prd.model.Organisation;
 
@@ -21,7 +20,7 @@ public class OrganisationService {
 
     private final OrganisationApi organisationApi;
     private final AuthTokenGenerator authTokenGenerator;
-    private final IdamClient idamClient;
+    private final UserService userService;
     private final PrdAdminUserConfiguration userConfig;
 
     //WARNING! below function findOrganisation is being used by both damages and specified claims,
@@ -40,7 +39,7 @@ public class OrganisationService {
     //WARNING! below function findOrganisationById is being used by both damages and specified claims,
     // changes to this code may break one of the claim journeys, check with respective teams before changing it
     public Optional<Organisation> findOrganisationById(String id) {
-        String authToken = idamClient.getAccessToken(userConfig.getUsername(), userConfig.getPassword());
+        String authToken = userService.getAccessToken(userConfig.getUsername(), userConfig.getPassword());
         try {
             return ofNullable(organisationApi.findOrganisationById(authToken, authTokenGenerator.generate(), id));
         } catch (FeignException.NotFound ex) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/UserService.java
@@ -20,4 +20,9 @@ public class UserService {
     public UserInfo getUserInfo(String bearerToken) {
         return idamClient.getUserInfo(bearerToken);
     }
+
+    @Cacheable(value = "accessTokenCache")
+    public String getAccessToken(String username, String password) {
+        return idamClient.getAccessToken(username, password);
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -21,7 +21,7 @@ spring:
   main:
     allow-bean-definition-overriding: true
   cache:
-    cache-names: userInfoCache
+    cache-names: userInfoCache, accessTokenCache
     caffeine:
       spec: expireAfterAccess=3600s
   datasource:

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataServiceTest.java
@@ -26,7 +26,6 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.search.Query;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.util.List;
@@ -59,7 +58,7 @@ class CoreCaseDataServiceTest {
     private CoreCaseDataApi coreCaseDataApi;
 
     @MockBean
-    private IdamClient idamClient;
+    private UserService userService;
 
     @MockBean
     private AuthTokenGenerator authTokenGenerator;
@@ -73,9 +72,9 @@ class CoreCaseDataServiceTest {
     @BeforeEach
     void init() {
         clearInvocations(authTokenGenerator);
-        clearInvocations(idamClient);
+        clearInvocations(userService);
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
-        when(idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).thenReturn(USER_AUTH_TOKEN);
+        when(userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).thenReturn(USER_AUTH_TOKEN);
     }
 
     @Nested
@@ -95,7 +94,7 @@ class CoreCaseDataServiceTest {
 
         @BeforeEach
         void setUp() {
-            when(idamClient.getUserInfo(USER_AUTH_TOKEN)).thenReturn(UserInfo.builder().uid(USER_ID).build());
+            when(userService.getUserInfo(USER_AUTH_TOKEN)).thenReturn(UserInfo.builder().uid(USER_ID).build());
 
             when(coreCaseDataApi.startEventForCaseWorker(USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, USER_ID, JURISDICTION,
                                                          CASE_TYPE, CASE_ID, EVENT_ID
@@ -159,7 +158,7 @@ class CoreCaseDataServiceTest {
 
             assertThat(casesFound).isEqualTo(cases);
             verify(coreCaseDataApi).searchCases(USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, CASE_TYPE, query.toString());
-            verify(idamClient).getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+            verify(userService).getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         }
     }
 
@@ -176,7 +175,7 @@ class CoreCaseDataServiceTest {
 
             assertThat(caseDetails).isEqualTo(expectedCaseDetails);
             verify(coreCaseDataApi).getCase(USER_AUTH_TOKEN, SERVICE_AUTH_TOKEN, "1");
-            verify(idamClient).getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+            verify(userService).getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataServiceTest.java
@@ -74,7 +74,9 @@ class CoreCaseDataServiceTest {
         clearInvocations(authTokenGenerator);
         clearInvocations(userService);
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
-        when(userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).thenReturn(USER_AUTH_TOKEN);
+        when(userService.getAccessToken(userConfig.getUserName(),
+                                        userConfig.getPassword()))
+            .thenReturn(USER_AUTH_TOKEN);
     }
 
     @Nested

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/CoreCaseUserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/CoreCaseUserServiceTest.java
@@ -17,7 +17,6 @@ import uk.gov.hmcts.reform.ccd.model.CaseAssignedUserRolesRequest;
 import uk.gov.hmcts.reform.ccd.model.CaseAssignedUserRolesResource;
 import uk.gov.hmcts.reform.civil.config.CrossAccessUserConfiguration;
 import uk.gov.hmcts.reform.civil.enums.CaseRole;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 
 import java.util.List;
 
@@ -48,7 +47,7 @@ class CoreCaseUserServiceTest {
     private CaseAccessDataStoreApi caseAccessDataStoreApi;
 
     @MockBean
-    private IdamClient idamClient;
+    private UserService userService;
 
     @MockBean
     private AuthTokenGenerator authTokenGenerator;
@@ -59,9 +58,9 @@ class CoreCaseUserServiceTest {
     @BeforeEach
     void init() {
         clearInvocations(authTokenGenerator);
-        clearInvocations(idamClient);
+        clearInvocations(userService);
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
-        when(idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).thenReturn(
+        when(userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).thenReturn(
             CAA_USER_AUTH_TOKEN);
     }
 
@@ -181,7 +180,7 @@ class CoreCaseUserServiceTest {
 
         @BeforeEach
         void setup() {
-            when(idamClient.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).thenReturn(
+            when(userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword())).thenReturn(
                 CAA_USER_AUTH_TOKEN);
             CaseAssignedUserRolesResource caseAssignedUserRolesResource = CaseAssignedUserRolesResource.builder()
                 .caseAssignedUserRoles(List.of(

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/OrganisationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/OrganisationServiceTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mock;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.prd.client.OrganisationApi;
 import uk.gov.hmcts.reform.prd.model.Organisation;
 
@@ -49,7 +48,7 @@ class OrganisationServiceTest {
     private AuthTokenGenerator authTokenGenerator;
 
     @Mock
-    private IdamClient idamClient;
+    private UserService userService;
 
     @Mock
     private PrdAdminUserConfiguration userConfig;
@@ -62,7 +61,7 @@ class OrganisationServiceTest {
         given(organisationApi.findUserOrganisation(any(), any())).willReturn(expectedOrganisation);
         given(organisationApi.findOrganisationById(any(), any(), any())).willReturn(expectedOrganisation);
         given(authTokenGenerator.generate()).willReturn(SERVICE_AUTH_TOKEN);
-        when(idamClient.getAccessToken(userConfig.getUsername(), userConfig.getPassword())).thenReturn(
+        when(userService.getAccessToken(userConfig.getUsername(), userConfig.getPassword())).thenReturn(
             PRD_ADMIN_AUTH_TOKEN);
     }
 
@@ -94,7 +93,7 @@ class OrganisationServiceTest {
         void shouldReturnOrganisation_whenInvoked() {
             var organisation = organisationService.findOrganisationById(ORG_ID);
 
-            verify(idamClient).getAccessToken(userConfig.getUsername(), userConfig.getPassword());
+            verify(userService).getAccessToken(userConfig.getUsername(), userConfig.getPassword());
             verify(organisationApi).findOrganisationById(PRD_ADMIN_AUTH_TOKEN, SERVICE_AUTH_TOKEN, ORG_ID);
             assertThat(organisation).isEqualTo(Optional.of(expectedOrganisation));
         }
@@ -104,7 +103,7 @@ class OrganisationServiceTest {
             given(organisationApi.findOrganisationById(any(), any(), any())).willThrow(notFoundFeignException);
             var organisation = organisationService.findOrganisationById(ORG_ID);
 
-            verify(idamClient).getAccessToken(userConfig.getUsername(), userConfig.getPassword());
+            verify(userService).getAccessToken(userConfig.getUsername(), userConfig.getPassword());
             verify(organisationApi).findOrganisationById(PRD_ADMIN_AUTH_TOKEN, SERVICE_AUTH_TOKEN, ORG_ID);
             assertThat(organisation).isEmpty();
         }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/UserServiceTest.java
@@ -44,12 +44,11 @@ class UserServiceTest {
     @BeforeEach
     public void setup() {
         userService = new UserService(idamClient);
-        when(idamClient.getUserInfo(AUTHORISATION)).thenReturn(userInfo);
-        when(idamClient.getAccessToken(SUB, PASSWORD)).thenReturn(AUTHORISATION);
     }
 
     @Test
     void shouldReturnUserInfo_whenValidAuthToken() {
+        when(idamClient.getUserInfo(AUTHORISATION)).thenReturn(userInfo);
         UserInfo found = userService.getUserInfo(AUTHORISATION);
 
         assertThat(found.getSub()).isEqualTo(SUB);
@@ -62,6 +61,7 @@ class UserServiceTest {
 
     @Test
     void shouldReturnAccessToken_whenValidUserDetailsAreGiven() {
+        when(idamClient.getAccessToken(SUB, PASSWORD)).thenReturn(AUTHORISATION);
         String accessToken = userService.getAccessToken(SUB, PASSWORD);
 
         assertThat(accessToken).isEqualTo(AUTHORISATION);

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/UserServiceTest.java
@@ -60,7 +60,6 @@ class UserServiceTest {
         assertThat(found.getRoles()).isEqualTo(ROLES);
     }
 
-
     @Test
     void shouldReturnAccessToken_whenValidUserDetailsAreGiven() {
         String accessToken = userService.getAccessToken(SUB, PASSWORD);

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/UserServiceTest.java
@@ -25,6 +25,7 @@ class UserServiceTest {
     private static final List<String> ROLES = Lists.newArrayList("citizen");
 
     private static final String AUTHORISATION = "Bearer I am a valid token";
+    private static final String PASSWORD = "User password";
 
     private static final UserInfo userInfo = UserInfo.builder()
         .sub(SUB)
@@ -44,6 +45,7 @@ class UserServiceTest {
     public void setup() {
         userService = new UserService(idamClient);
         when(idamClient.getUserInfo(AUTHORISATION)).thenReturn(userInfo);
+        when(idamClient.getAccessToken(SUB, PASSWORD)).thenReturn(AUTHORISATION);
     }
 
     @Test
@@ -56,5 +58,13 @@ class UserServiceTest {
         assertThat(found.getGivenName()).isEqualTo(GIVEN_NAME);
         assertThat(found.getFamilyName()).isEqualTo(FAMILY_NAME);
         assertThat(found.getRoles()).isEqualTo(ROLES);
+    }
+
+
+    @Test
+    void shouldReturnAccessToken_whenValidUserDetailsAreGiven() {
+        String accessToken = userService.getAccessToken(SUB, PASSWORD);
+
+        assertThat(accessToken).isEqualTo(AUTHORISATION);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/RoboticsNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/RoboticsNotificationServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.civil.sendgrid.EmailData;
 import uk.gov.hmcts.reform.civil.sendgrid.SendGridClient;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
 import uk.gov.hmcts.reform.civil.service.Time;
+import uk.gov.hmcts.reform.civil.service.UserService;
 import uk.gov.hmcts.reform.civil.service.flowstate.StateFlowEngine;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.AddressLinesMapper;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.EventHistoryMapper;
@@ -30,7 +31,6 @@ import uk.gov.hmcts.reform.civil.service.robotics.mapper.EventHistorySequencer;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.RoboticsAddressMapper;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.RoboticsDataMapper;
 import uk.gov.hmcts.reform.civil.service.robotics.mapper.RoboticsDataMapperForSpec;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.prd.client.OrganisationApi;
 
 import java.time.LocalDateTime;
@@ -86,7 +86,7 @@ class RoboticsNotificationServiceTest {
     @MockBean
     AuthTokenGenerator authTokenGenerator;
     @MockBean
-    IdamClient idamClient;
+    UserService userService;
     @MockBean
     PrdAdminUserConfiguration userConfig;
     @MockBean

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperTest.java
@@ -21,8 +21,8 @@ import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.PartyBuilder;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
 import uk.gov.hmcts.reform.civil.service.Time;
+import uk.gov.hmcts.reform.civil.service.UserService;
 import uk.gov.hmcts.reform.civil.service.flowstate.StateFlowEngine;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.prd.client.OrganisationApi;
 import uk.gov.hmcts.reform.prd.model.ContactInformation;
 import uk.gov.hmcts.reform.prd.model.DxAddress;
@@ -73,7 +73,7 @@ class RoboticsDataMapperTest {
     @MockBean
     AuthTokenGenerator authTokenGenerator;
     @MockBean
-    IdamClient idamClient;
+    UserService userService;
     @MockBean
     FeatureToggleService featureToggleService;
     @MockBean


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CMC-1873

**Root cause:** From E2E we check for ongoing business process for every event with max retries of 300. For every retry you  make a call to idam to get access token causing idam flooded with civil service calls. So, caching idam access token for 60min per user.

<img width="1350" alt="Screenshot 2022-02-01 at 11 56 24" src="https://user-images.githubusercontent.com/43175082/151972354-adcaf682-40cf-4285-acc6-96a3ea9fdf45.png">
