### PR TITLE
fix/CMC-1931: CaseFlag updated to now check for that users response

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
@@ -154,12 +154,13 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
 
         var isRespondent1 = YES;
         if (solicitorRepresentsOnlyOneOrBothRespondents(callbackParams, RESPONDENTSOLICITORTWO)) {
+            //1V2 Different Solicitors + Respondent 2 only
             isRespondent1 = NO;
         }
 
         var updatedCaseData = caseData.toBuilder()
             .respondent1Copy(caseData.getRespondent1())
-                .isRespondent1(isRespondent1);
+            .isRespondent1(isRespondent1);
 
         updatedCaseData.respondent1DetailsForClaimDetailsTab(caseData.getRespondent1());
 
@@ -262,12 +263,20 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
         CaseData.CaseDataBuilder updatedData =
             caseData.toBuilder().multiPartyResponseTypeFlags(MultiPartyResponseTypeFlags.NOT_FULL_DEFENCE);
 
+        var isRespondent1 = YES;
+        if (solicitorRepresentsOnlyOneOrBothRespondents(callbackParams, RESPONDENTSOLICITORTWO)) {
+            //1V2 Different Solicitors + Respondent 2 only
+            isRespondent1 = NO;
+        }
+
         if ((caseData.getRespondent1ClaimResponseType() != null
                 && caseData.getRespondent1ClaimResponseType().equals(
-                RespondentResponseType.FULL_DEFENCE))
+                RespondentResponseType.FULL_DEFENCE)
+                && isRespondent1.equals(YES))
             || (caseData.getRespondent2ClaimResponseType() != null
                 && caseData.getRespondent2ClaimResponseType().equals(
-                RespondentResponseType.FULL_DEFENCE))
+                RespondentResponseType.FULL_DEFENCE)
+                && isRespondent1.equals(NO))
             || (TWO_V_ONE.equals(getMultiPartyScenario(caseData))
                 && (RespondentResponseType.FULL_DEFENCE.equals(caseData.getRespondent1ClaimResponseType())
                 || RespondentResponseType.FULL_DEFENCE.equals(caseData

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandlerTest.java
@@ -1271,6 +1271,12 @@ class RespondToClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
     @Nested
     class MidEventSetGenericResponseTypeFlagCallback {
 
+        @BeforeEach
+        void setup() {
+            when(mockedStateFlow.isFlagSet(any())).thenReturn(false);
+            when(stateFlowEngine.evaluate(any(CaseData.class))).thenReturn(mockedStateFlow);
+        }
+
         private static final String PAGE_ID = "set-generic-response-type-flag";
 
         @Test
@@ -1285,10 +1291,16 @@ class RespondToClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @Test
-        void shouldSetMultiPartyResponseTypeFlags_Respondent2IsFullDefence() {
-            CaseData caseData = CaseDataBuilder.builder().atStateRespondentFullDefence().build().toBuilder()
-                .respondent1ClaimResponseType(null)
-                .respondent2ClaimResponseType(FULL_DEFENCE)
+        void shouldSetMultiPartyResponseTypeFlags_when1v2DifferentSolicitorsAndRespondent2IsFullDefence() {
+            when(mockedStateFlow.isFlagSet(any())).thenReturn(true);
+            when(stateFlowEngine.evaluate(any(CaseData.class))).thenReturn(mockedStateFlow);
+            when(userService.getUserInfo(anyString())).thenReturn(UserInfo.builder().uid("uid").build());
+            when(coreCaseUserService.userHasCaseRole(any(), any(), eq(CaseRole.RESPONDENTSOLICITORTWO)))
+                .thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder()
+                .atStateRespondentFullDefenceAfterNotifyClaimDetailsAwaiting1stRespondentResponse()
+                .multiPartyClaimTwoDefendantSolicitors()
                 .build();
 
             CallbackParams params = callbackParamsOf(caseData, MID, PAGE_ID);
@@ -1300,6 +1312,9 @@ class RespondToClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
 
         @Test
         void shouldSetMultiPartyResponseTypeFlags_2v1Only1FullDefence() {
+            when(mockedStateFlow.isFlagSet(any())).thenReturn(false);
+            when(stateFlowEngine.evaluate(any(CaseData.class))).thenReturn(mockedStateFlow);
+
             CaseData caseData = CaseDataBuilder.builder().multiPartyClaimTwoApplicants().build().toBuilder()
                 .respondent1ClaimResponseType(COUNTER_CLAIM)
                 .respondent1ClaimResponseTypeToApplicant2(FULL_DEFENCE)

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandlerTest.java
@@ -1312,9 +1312,6 @@ class RespondToClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
 
         @Test
         void shouldSetMultiPartyResponseTypeFlags_2v1Only1FullDefence() {
-            when(mockedStateFlow.isFlagSet(any())).thenReturn(false);
-            when(stateFlowEngine.evaluate(any(CaseData.class))).thenReturn(mockedStateFlow);
-
             CaseData caseData = CaseDataBuilder.builder().multiPartyClaimTwoApplicants().build().toBuilder()
                 .respondent1ClaimResponseType(COUNTER_CLAIM)
                 .respondent1ClaimResponseTypeToApplicant2(FULL_DEFENCE)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1931


### Change description ###
Changing logic for setting the multi party flag which is used for field / page show conditions in defendant response journey

- Logic Updated for the mid event
- It now takes into consideration the current user that is running the event. As this will enable us to see if they have just gave a FULL DEFENCE response to show additional screens
- Bug was raised as Respondent 1 could have said Full Defence, old logic would have resuled as TRUE for respondent 2. By checking the additional parameter of isRespondent1 we can identify the user who is currently running the event 
- Tests updated / refactored


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
