### PR TITLE
fix: feat/CIV-335 got all changes of CIV-335

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Respondent1DQ.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/dq/Respondent1DQ.java
@@ -38,6 +38,9 @@ public class Respondent1DQ implements DQ {
     private final YesOrNo respondent1DQCarerAllowanceCredit;
     private final List<Element<RecurringIncomeLRspec>> respondent1DQRecurringIncome;
     private final List<Element<RecurringExpenseLRspec>> respondent1DQRecurringExpenses;
+    private final YesOrNo respondent1DQCarerAllowanceCreditFullAdmission;
+    private final List<Element<RecurringIncomeLRspec>> respondent1DQRecurringIncomeFA;
+    private final List<Element<RecurringExpenseLRspec>> respondent1DQRecurringExpensesFA;
 
     @Override
     @JsonProperty("respondent1DQFileDirectionsQuestionnaire")


### PR DESCRIPTION
LR vs LR: Admits and Pay: provide screen to capture defendants income and expenses.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-335


### Change description ###
LR vs LR: Admits and Pay: provide screen to capture defendants income and expenses.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
