### PR TITLE
fix: show document link under correct heading in Claim Documents

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
@@ -474,24 +474,24 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
         Optional.ofNullable(caseData.getRespondent1ClaimResponseDocument())
             .map(ResponseDocument::getFile).ifPresent(respondent1ClaimDocument -> defendantUploads.add(
                 buildElemCaseDocument(respondent1ClaimDocument, "Defendant",
-                                      caseData.getRespondent1ResponseDate(), DocumentType.DEFENDANT_DEFENCE
+                    updatedCaseData.build().getRespondent1ResponseDate(), DocumentType.DEFENDANT_DEFENCE
                 )));
         Optional.ofNullable(caseData.getRespondent1DQ())
             .map(Respondent1DQ::getRespondent1DQDraftDirections)
             .ifPresent(respondent1DQ -> defendantUploads.add(
                 buildElemCaseDocument(respondent1DQ, "Defendant",
-                                      caseData.getRespondent1ResponseDate(), DocumentType.DEFENDANT_DRAFT_DIRECTIONS
+                    updatedCaseData.build().getRespondent1ResponseDate(), DocumentType.DEFENDANT_DRAFT_DIRECTIONS
                 )));
         Optional.ofNullable(caseData.getRespondent2ClaimResponseDocument())
             .map(ResponseDocument::getFile).ifPresent(respondent2ClaimDocument -> defendantUploads.add(
                 buildElemCaseDocument(respondent2ClaimDocument, "Defendant 2",
-                                      caseData.getRespondent2ResponseDate(), DocumentType.DEFENDANT_DEFENCE
+                    updatedCaseData.build().getRespondent2ResponseDate(), DocumentType.DEFENDANT_DEFENCE
                 )));
         Optional.ofNullable(caseData.getRespondent2DQ())
             .map(Respondent2DQ::getRespondent2DQDraftDirections)
             .ifPresent(respondent2DQ -> defendantUploads.add(
                 buildElemCaseDocument(respondent2DQ, "Defendant 2",
-                                      caseData.getRespondent2ResponseDate(), DocumentType.DEFENDANT_DRAFT_DIRECTIONS
+                    updatedCaseData.build().getRespondent2ResponseDate(), DocumentType.DEFENDANT_DRAFT_DIRECTIONS
                 )));
         if (!defendantUploads.isEmpty()) {
             updatedCaseData.defendantResponseDocuments(defendantUploads);

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandlerTest.java
@@ -869,6 +869,7 @@ class RespondToClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
 
         @Test
         void shouldSetDefendantResponseDocuments() {
+            when(time.now()).thenReturn(LocalDateTime.of(2022, 2, 18, 12, 10, 55));
             when(coreCaseUserService.userHasCaseRole(any(), any(), eq(RESPONDENTSOLICITORTWO))).thenReturn(false);
             CaseData caseData = CaseDataBuilder.builder()
                 .multiPartyClaimTwoDefendantSolicitors()
@@ -890,14 +891,13 @@ class RespondToClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
                 .contains("createdBy=Defendant")
                 .contains("documentName=defendant1-defence.pdf")
                 .contains("documentSize=0")
-                .contains("createdDatetime")
+                .contains("createdDatetime=2022-02-18T12:10:55")
                 .contains("documentLink={document_url=http://dm-store:4506/documents/73526424-8434-4b1f-acca-bd33a3f8338f")
                 .contains("documentType=DEFENDANT_DEFENCE")
                 .contains("documentName=defendant2-defence.pdf")
                 .contains("documentName=defendant1-directions.pdf")
                 .contains("documentName=defendant2-directions.pdf")
                 .contains("createdBy=Defendant 2")
-                .contains("createdDatetime")
                 .contains("documentType=DEFENDANT_DRAFT_DIRECTIONS");
         }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1967


### Change description ###
Fix to show document link under correct heading in Claim Documents tab


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
