### PR TITLE
build/bump-charts: Update java charts to v3.7.2

### DIFF
--- a/charts/civil-service/Chart.yaml
+++ b/charts/civil-service/Chart.yaml
@@ -28,6 +28,6 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: postgresql.enabled
   - name: camunda-bpm
-    version: 0.0.18
+    version: 0.0.23
     repository: '@hmctspublic'
     condition: camunda-bpm.enabled

--- a/charts/civil-service/Chart.yaml
+++ b/charts/civil-service/Chart.yaml
@@ -8,10 +8,10 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 3.7.3
+    version: 3.7.2
     repository: '@hmctspublic'
   - name: ccd
-    version: 6.0.0
+    version: 7.0.0
     repository: '@hmctspublic'
     tags:
       - civil-ccd-stack

--- a/charts/civil-service/Chart.yaml
+++ b/charts/civil-service/Chart.yaml
@@ -11,7 +11,7 @@ dependencies:
     version: 3.7.2
     repository: '@hmctspublic'
   - name: ccd
-    version: 7.0.0
+    version: 6.0.0
     repository: '@hmctspublic'
     tags:
       - civil-ccd-stack

--- a/charts/civil-service/Chart.yaml
+++ b/charts/civil-service/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 3.7.1
+    version: 3.7.3
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0

--- a/charts/civil-service/Chart.yaml
+++ b/charts/civil-service/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 3.7.2
+    version: 3.7.1
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0

--- a/charts/civil-service/Chart.yaml
+++ b/charts/civil-service/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.3
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0

--- a/charts/civil-service/Chart.yaml
+++ b/charts/civil-service/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 3.7.3
+    version: 3.7.2
     repository: '@hmctspublic'
   - name: ccd
     version: 6.0.0


### PR DESCRIPTION
### JIRA link (if applicable) ###
- Bump java charts to v3.7.2
- Bump camunda-bpm to 0.0.23


### Change description ###
N/A


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
