### PR TITLE
bugfix/CMC-1974 Null pointer exception on generating DQ

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.civil.enums.CaseRole;
 import uk.gov.hmcts.reform.civil.enums.MultiPartyResponseTypeFlags;
 import uk.gov.hmcts.reform.civil.enums.MultiPartyScenario;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseType;
+import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
@@ -258,17 +259,10 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
             isRespondent1 = NO;
         }
 
-        if ((caseData.getRespondent1ClaimResponseType() != null
-                && caseData.getRespondent1ClaimResponseType().equals(
-                RespondentResponseType.FULL_DEFENCE)
-                && isRespondent1.equals(YES))
-            || (caseData.getRespondent2ClaimResponseType() != null
-                && caseData.getRespondent2ClaimResponseType().equals(
-                RespondentResponseType.FULL_DEFENCE))
-            || (TWO_V_ONE.equals(getMultiPartyScenario(caseData))
-                && (RespondentResponseType.FULL_DEFENCE.equals(caseData.getRespondent1ClaimResponseType())
-                || RespondentResponseType.FULL_DEFENCE.equals(caseData
-                .getRespondent1ClaimResponseTypeToApplicant2())))) {
+        if (isSolicitor1AndRespondent1ResponseIsFullDefence(caseData, isRespondent1)
+            || isSolicitor2AndRespondent2ResponseIsFullDefence(caseData, isRespondent1)
+            || isSameSolicitorAndAnyRespondentResponseIsFullDefence(caseData)
+            || is2v1AndRespondent1ResponseIsFullDefenceToAnyApplicant(caseData)) {
             updatedData.multiPartyResponseTypeFlags(MultiPartyResponseTypeFlags.FULL_DEFENCE)
                 .build();
         }
@@ -583,5 +577,31 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
             return true;
         }
         return false;
+    }
+
+    private boolean is2v1AndRespondent1ResponseIsFullDefenceToAnyApplicant(CaseData caseData) {
+        return TWO_V_ONE.equals(getMultiPartyScenario(caseData))
+            && (RespondentResponseType.FULL_DEFENCE.equals(caseData.getRespondent1ClaimResponseType())
+            || RespondentResponseType.FULL_DEFENCE.equals(caseData.getRespondent1ClaimResponseTypeToApplicant2()));
+    }
+
+    private boolean isSameSolicitorAndAnyRespondentResponseIsFullDefence(CaseData caseData) {
+        return respondent2HasSameLegalRep(caseData)
+            && (RespondentResponseType.FULL_DEFENCE.equals(caseData.getRespondent1ClaimResponseType())
+            || RespondentResponseType.FULL_DEFENCE.equals(caseData.getRespondent2ClaimResponseType()));
+    }
+
+    private boolean isSolicitor2AndRespondent2ResponseIsFullDefence(CaseData caseData, YesOrNo isRespondent1) {
+        return caseData.getRespondent2ClaimResponseType() != null
+            && caseData.getRespondent2ClaimResponseType().equals(
+            RespondentResponseType.FULL_DEFENCE)
+            && isRespondent1.equals(NO);
+    }
+
+    private boolean isSolicitor1AndRespondent1ResponseIsFullDefence(CaseData caseData, YesOrNo isRespondent1) {
+        return caseData.getRespondent1ClaimResponseType() != null
+            && caseData.getRespondent1ClaimResponseType().equals(
+            RespondentResponseType.FULL_DEFENCE)
+            && isRespondent1.equals(YES);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
@@ -264,8 +264,7 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
                 && isRespondent1.equals(YES))
             || (caseData.getRespondent2ClaimResponseType() != null
                 && caseData.getRespondent2ClaimResponseType().equals(
-                RespondentResponseType.FULL_DEFENCE)
-                && isRespondent1.equals(NO))
+                RespondentResponseType.FULL_DEFENCE))
             || (TWO_V_ONE.equals(getMultiPartyScenario(caseData))
                 && (RespondentResponseType.FULL_DEFENCE.equals(caseData.getRespondent1ClaimResponseType())
                 || RespondentResponseType.FULL_DEFENCE.equals(caseData

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
@@ -593,15 +593,13 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
 
     private boolean isSolicitor2AndRespondent2ResponseIsFullDefence(CaseData caseData, YesOrNo isRespondent1) {
         return caseData.getRespondent2ClaimResponseType() != null
-            && caseData.getRespondent2ClaimResponseType().equals(
-            RespondentResponseType.FULL_DEFENCE)
+            && caseData.getRespondent2ClaimResponseType().equals(RespondentResponseType.FULL_DEFENCE)
             && isRespondent1.equals(NO);
     }
 
     private boolean isSolicitor1AndRespondent1ResponseIsFullDefence(CaseData caseData, YesOrNo isRespondent1) {
         return caseData.getRespondent1ClaimResponseType() != null
-            && caseData.getRespondent1ClaimResponseType().equals(
-            RespondentResponseType.FULL_DEFENCE)
+            && caseData.getRespondent1ClaimResponseType().equals(RespondentResponseType.FULL_DEFENCE)
             && isRespondent1.equals(YES);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandlerTest.java
@@ -1181,6 +1181,26 @@ class RespondToClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @Test
+        void shouldSetMultiPartyResponseTypeFlags_when1v2SameSolicitorsAndRespondent2IsFullDefence() {
+            when(mockedStateFlow.isFlagSet(any())).thenReturn(true);
+            when(stateFlowEngine.evaluate(any(CaseData.class))).thenReturn(mockedStateFlow);
+            when(userService.getUserInfo(anyString())).thenReturn(UserInfo.builder().uid("uid").build());
+            when(coreCaseUserService.userHasCaseRole(any(), any(), eq(CaseRole.RESPONDENTSOLICITORTWO)))
+                .thenReturn(false);
+
+            CaseData caseData = CaseDataBuilder.builder()
+                .atStateRespondentFullDefence_1v2_Resp1CounterClaimAndResp2FullDefence()
+                .multiPartyClaimOneDefendantSolicitor()
+                .build();
+
+            CallbackParams params = callbackParamsOf(caseData, MID, PAGE_ID);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            assertThat(response.getData()).extracting("multiPartyResponseTypeFlags").isEqualTo("FULL_DEFENCE");
+        }
+
+        @Test
         void shouldSetMultiPartyResponseTypeFlags_2v1Only1FullDefence() {
             CaseData caseData = CaseDataBuilder.builder().multiPartyClaimTwoApplicants().build().toBuilder()
                 .respondent1ClaimResponseType(COUNTER_CLAIM)

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -1337,6 +1337,19 @@ public class CaseDataBuilder {
         return this;
     }
 
+    public CaseDataBuilder atStateRespondentFullDefence_1v2_Resp1CounterClaimAndResp2FullDefence() {
+        atStateRespondentFullDefence();
+        respondent1ClaimResponseType = RespondentResponseType.COUNTER_CLAIM;
+        respondent1ResponseDate = LocalDateTime.now();
+        respondent2ClaimResponseType = RespondentResponseType.FULL_DEFENCE;
+        respondent2ResponseDate = LocalDateTime.now();
+        respondent2ClaimResponseDocument = ResponseDocument.builder()
+            .file(DocumentBuilder.builder().documentName("defendant-response.pdf").build())
+            .build();
+        respondent2DQ();
+        return this;
+    }
+
     public CaseDataBuilder atStateDivergentResponseWithFullDefence1v2SameSol_NotSingleDQ() {
         atStateRespondentFullDefence();
         respondent2ClaimResponseType = RespondentResponseType.COUNTER_CLAIM;


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1974


### Change description ###
Added a check for same solicitor and if any of the respondents response is full defence:

_1v2 Same solicitor
For defendant 1 chose Response: Admit claim
For defendant 2 chose Response: Reject claim_

MultiPartyResponseTypeFlags should be FULL_DEFENCE, so solicitor is able to fill in the DQs. Hence there won't be a null pointer exception.


**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[x] No
```
