### PR TITLE
feat: retain solicitor references otherwise lost upon defendant response

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToClaimCallbackHandler.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
 import uk.gov.hmcts.reform.civil.model.ResponseDocument;
+import uk.gov.hmcts.reform.civil.model.SolicitorReferences;
 import uk.gov.hmcts.reform.civil.model.StatementOfTruth;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
@@ -43,6 +44,7 @@ import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -447,6 +449,7 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
         }
         updatedData.isRespondent1(null);
         assembleResponseDocuments(caseData, updatedData);
+        retainSolicitorReferences(callbackParams.getRequest().getCaseDetailsBefore().getData(), updatedData);
         if (getMultiPartyScenario(caseData) == ONE_V_TWO_TWO_LEGAL_REP
             && isAwaitingAnotherDefendantResponse(caseData)) {
 
@@ -459,6 +462,23 @@ public class RespondToClaimCallbackHandler extends CallbackHandler implements Ex
             .data(updatedData.build().toMap(objectMapper))
             .state("AWAITING_APPLICANT_INTENTION")
             .build();
+    }
+
+    private void retainSolicitorReferences(Map<String, Object> beforeCaseData, CaseData.CaseDataBuilder updatedData) {
+        @SuppressWarnings("unchecked")
+        Map<String, String> solicitorRefs = ofNullable(beforeCaseData.get("solicitorReferences"))
+            .map(refs -> objectMapper.convertValue(refs, HashMap.class))
+                .orElse(null);
+        SolicitorReferences solicitorReferences = ofNullable(solicitorRefs)
+            .map(refMap -> SolicitorReferences.builder()
+                    .applicantSolicitor1Reference(refMap.getOrDefault("applicantSolicitor1Reference", null))
+                    .respondentSolicitor1Reference(refMap.getOrDefault("respondentSolicitor1Reference", null))
+                    .respondentSolicitor2Reference(refMap.getOrDefault("respondentSolicitor2Reference", null))
+                    .build())
+                .orElse(null);
+        updatedData.solicitorReferences(solicitorReferences);
+        updatedData.respondentSolicitor2Reference(ofNullable(beforeCaseData.get("respondentSolicitor2Reference"))
+            .map(Object::toString).orElse(null));
     }
 
     private void assembleResponseDocuments(CaseData caseData, CaseData.CaseDataBuilder updatedCaseData) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/BaseCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/BaseCallbackHandlerTest.java
@@ -51,6 +51,11 @@ public abstract class BaseCallbackHandlerTest {
         );
     }
 
+    public CallbackParams callbackParamsOf(CaseData caseData, CallbackType type, Map<String, Object> beforeCaseData) {
+        return callbackParamsOf(caseData, type, null, null, Map.of(Params.BEARER_TOKEN,
+            "BEARER_TOKEN"), beforeCaseData);
+    }
+
     public CallbackParams callbackParamsOf(CaseData caseData, CallbackType type) {
         return callbackParamsOf(caseData, type, null, null, Map.of(Params.BEARER_TOKEN, "BEARER_TOKEN"));
     }
@@ -79,6 +84,29 @@ public abstract class BaseCallbackHandlerTest {
                                            CallbackType type,
                                            CallbackVersion version,
                                            String pageId,
+                                           Map<Params, Object> params,
+                                           Map<String, Object> beforeCaseData
+    ) {
+        return CallbackParams.builder()
+            .type(type)
+            .pageId(pageId)
+            .request(CallbackRequest.builder()
+                         .caseDetails(CaseDetails.builder().data(new HashMap<>()).id(CASE_ID).build())
+                         .caseDetailsBefore(CaseDetails.builder()
+                                                .data(beforeCaseData)
+                                                .id(CASE_ID)
+                                                .build())
+                         .build())
+            .caseData(caseData)
+            .version(version)
+            .params(params)
+            .build();
+    }
+
+    public CallbackParams callbackParamsOf(CaseData caseData,
+                                           CallbackType type,
+                                           CallbackVersion version,
+                                           String pageId,
                                            Map<Params, Object> params
     ) {
         return CallbackParams.builder()
@@ -86,6 +114,7 @@ public abstract class BaseCallbackHandlerTest {
             .pageId(pageId)
             .request(CallbackRequest.builder()
                          .caseDetails(CaseDetails.builder().data(new HashMap<>()).id(CASE_ID).build())
+                         .caseDetailsBefore(CaseDetails.builder().data(new HashMap<>()).id(CASE_ID).build())
                          .build())
             .caseData(caseData)
             .version(version)

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -104,6 +104,7 @@ public class CaseDataBuilder {
     // Create Claim
     protected Long ccdCaseReference;
     protected SolicitorReferences solicitorReferences;
+    protected String respondentSolicitor2Reference;
     protected CourtLocation courtLocation;
     protected Party applicant1;
     protected Party applicant2;
@@ -1959,6 +1960,7 @@ public class CaseDataBuilder {
         this.addRespondent2 = YES;
         this.respondent2 = PartyBuilder.builder().individual().build();
         this.respondent2SameLegalRepresentative = NO;
+        this.respondentSolicitor2Reference = "01234";
         return this;
     }
 
@@ -2206,6 +2208,7 @@ public class CaseDataBuilder {
                 applicant1ProceedWithClaimAgainstRespondent1MultiParty1v2)
             .applicant1ProceedWithClaimAgainstRespondent2MultiParty1v2(
                 applicant1ProceedWithClaimAgainstRespondent2MultiParty1v2)
+            .respondentSolicitor2Reference(respondentSolicitor2Reference)
             .build();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1985


### Change description ###
Retain solicitor references otherwise lost in defendant response journey (1v2 diff solicitor). solicitorReferences (which contains applicant solicitor reference and defendant 1 solicitor reference) was being set to null when defendant 2 responded. Similarly respondentSolicitor2Reference field was being set to null when defendant 1 was responding.
The change  done is to pick all the solicitor references from the caseDetailsBefore field in callbackParams in the callback handler method for about-to-submit of Defendant Response journey in civil-service.


All the original solicitor references values from the caseDetailsBefore are again set to the about-to-submit casedata so that no reference is lost.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
