### PR TITLE
feat/CIV-1468 jackson-databind changed to 2.13.1 to avoid sec issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -379,6 +379,8 @@ dependencies {
   contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-junit5_2.12', version: versions.pact
   contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-java8_2.12', version: versions.pact
   contractTestCompile group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
+  contractTestCompile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.1'
+  contractTestCompile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.1'
 
   contractTestCompile("org.junit.jupiter:junit-jupiter-api:5.7.0")
   contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.7.0")

--- a/build.gradle
+++ b/build.gradle
@@ -347,7 +347,11 @@ dependencies {
   implementation group: 'org.camunda.bpm.extension.rest', name: 'camunda-rest-client-spring-boot-starter', version: '0.0.4'
   implementation group: 'org.camunda.bpm', name: 'camunda-engine-rest-core', version: '7.16.0'
   implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+  implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-parameter-names', version: '2.13.1'
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.1'
+  implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jdk8', version: '2.13.1'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.1'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.1'
 
   // JAX-B dependencies for JDK 9+
   implementation group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1'

--- a/sendgrid-client/build.gradle
+++ b/sendgrid-client/build.gradle
@@ -43,6 +43,9 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter'
   implementation group: 'org.springframework.retry', name: 'spring-retry'
   implementation group: 'com.sendgrid', name: 'sendgrid-java', version: '4.8.3'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.1'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.1'
+  implementation group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: '2.13.1'
 
   annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
   compileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok


### PR DESCRIPTION
### Change description ###
jackson databind dependencies raised to 2.13.1 to avoid sec issue


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
