### PR TITLE
Fix response document appearing under defendant one in 1v2 same solicitor scenario

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceCallbackHandler.java
@@ -85,6 +85,10 @@ public class RespondToDefenceCallbackHandler extends CallbackHandler implements 
         CaseData.CaseDataBuilder updatedData = caseData.toBuilder()
             .claimantResponseScenarioFlag(getMultiPartyScenario(caseData));
 
+        if ((getMultiPartyScenario(caseData) == ONE_V_TWO_ONE_LEGAL_REP)) {
+            updatedData.respondentSharedClaimResponseDocument(caseData.getRespondent1ClaimResponseDocument());
+        }
+
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(updatedData.build().toMap(objectMapper))
             .build();
@@ -216,6 +220,10 @@ public class RespondToDefenceCallbackHandler extends CallbackHandler implements 
         }
 
         assembleResponseDocuments(caseData, builder);
+
+        if (multiPartyScenario == ONE_V_TWO_ONE_LEGAL_REP) {
+            builder.respondentSharedClaimResponseDocument(null);
+        }
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(builder.build().toMap(objectMapper))

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -148,6 +148,7 @@ public class CaseData implements MappableObject {
     private final RespondentResponseType respondent1ClaimResponseTypeToApplicant2;
     private final ResponseDocument respondent1ClaimResponseDocument;
     private final ResponseDocument respondent2ClaimResponseDocument;
+    private final ResponseDocument respondentSharedClaimResponseDocument;
     private final CaseDocument respondent1GeneratedResponseDocument;
     private final CaseDocument respondent2GeneratedResponseDocument;
     private final List<Element<CaseDocument>> defendantResponseDocuments;

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -140,6 +140,7 @@ public class CaseDataBuilder {
     // Defendant Response Defendant 1
     protected RespondentResponseType respondent1ClaimResponseType;
     protected ResponseDocument respondent1ClaimResponseDocument;
+    protected ResponseDocument respondentSharedClaimResponseDocument;
     protected Respondent1DQ respondent1DQ;
     protected Respondent2DQ respondent2DQ;
     protected Applicant1DQ applicant1DQ;


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CMC-2002

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
