### PR TITLE
refactor: remove V1 callback to V0 in the PaymentsCallbackHandler (1/2)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/payment/PaymentsCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/payment/PaymentsCallbackHandler.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import static java.util.Optional.ofNullable;
 import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
-import static uk.gov.hmcts.reform.civil.callback.CallbackVersion.V_1;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.MAKE_PBA_PAYMENT;
 import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.FAILED;
 import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS;
@@ -55,43 +54,13 @@ public class PaymentsCallbackHandler extends CallbackHandler {
     @Override
     protected Map<String, Callback> callbacks() {
         return Map.of(
-            callbackKey(ABOUT_TO_SUBMIT), this::makePbaPaymentBackwardsCompatible,
-            callbackKey(V_1, ABOUT_TO_SUBMIT), this::makePbaPayment
+            callbackKey(ABOUT_TO_SUBMIT), this::makePbaPayment
         );
     }
 
     @Override
     public List<CaseEvent> handledEvents() {
         return EVENTS;
-    }
-
-    private CallbackResponse makePbaPaymentBackwardsCompatible(CallbackParams callbackParams) {
-        var caseData = callbackParams.getCaseData();
-        var authToken = callbackParams.getParams().get(BEARER_TOKEN).toString();
-        List<String> errors = new ArrayList<>();
-        try {
-            var paymentReference = paymentsService.createCreditAccountPayment(caseData, authToken).getReference();
-            caseData = caseData.toBuilder()
-                .paymentDetails(PaymentDetails.builder().status(SUCCESS).reference(paymentReference).build())
-                .paymentSuccessfulDate(time.now())
-                .build();
-        } catch (FeignException e) {
-            if (e.status() == 403) {
-                caseData = updateWithBusinessErrorBackwardsCompatible(caseData, e);
-            } else {
-                errors.add(ERROR_MESSAGE);
-            }
-        } catch (InvalidPaymentRequestException e) {
-            log.error(String.format("Duplicate Payment error status code 400 for case: %s, response body: %s",
-                                    caseData.getCcdCaseReference(), e.getMessage()
-            ));
-            caseData = updateWithDuplicatePaymentErrorBackwardsCompatible(caseData, e);
-        }
-
-        return AboutToStartOrSubmitCallbackResponse.builder()
-            .data(caseData.toMap(objectMapper))
-            .errors(errors)
-            .build();
     }
 
     private CaseData updateWithDuplicatePaymentError(CaseData caseData, InvalidPaymentRequestException e) {
@@ -104,17 +73,6 @@ public class PaymentsCallbackHandler extends CallbackHandler {
             .build();
 
         return caseData.toBuilder().claimIssuedPaymentDetails(paymentDetails).build();
-    }
-
-    private CaseData updateWithDuplicatePaymentErrorBackwardsCompatible(CaseData caseData,
-                                                                        InvalidPaymentRequestException e) {
-        var paymentDetails = PaymentDetails.builder()
-            .status(FAILED)
-            .errorMessage(DUPLICATE_PAYMENT_MESSAGE)
-            .errorCode(null)
-            .build();
-
-        return caseData.toBuilder().paymentDetails(paymentDetails).build();
     }
 
     private CallbackResponse makePbaPayment(CallbackParams callbackParams) {
@@ -156,25 +114,6 @@ public class PaymentsCallbackHandler extends CallbackHandler {
             .data(caseData.toMap(objectMapper))
             .errors(errors)
             .build();
-    }
-
-    private CaseData updateWithBusinessErrorBackwardsCompatible(CaseData caseData, FeignException e) {
-        try {
-            var paymentDto = objectMapper.readValue(e.contentUTF8(), PaymentDto.class);
-            var statusHistory = paymentDto.getStatusHistories()[0];
-            return caseData.toBuilder()
-                .paymentDetails(PaymentDetails.builder()
-                                    .status(FAILED)
-                                    .errorCode(statusHistory.getErrorCode())
-                                    .errorMessage(statusHistory.getErrorMessage())
-                                    .build())
-                .build();
-        } catch (JsonProcessingException jsonException) {
-            log.error(String.format("Unknown payment error for case: %s, response body: %s",
-                                    caseData.getCcdCaseReference(), e.contentUTF8()
-            ));
-            throw e;
-        }
     }
 
     private CaseData updateWithBusinessError(CaseData caseData, FeignException e) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Move V1 callback to V0 
- CCD currently points to V1 callback, which will default to V0


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
