### PR TITLE
fix: CMC-1996 - Fail payments when we receive 422 and 504s

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/payment/PaymentsCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/payment/PaymentsCallbackHandler.java
@@ -98,7 +98,7 @@ public class PaymentsCallbackHandler extends CallbackHandler {
 
         } catch (FeignException e) {
             log.info(String.format("Http Status %s ", e.status()), e);
-            if (e.status() == 403) {
+            if (e.status() == 403 || e.status() == 422 || e.status() == 504) {
                 caseData = updateWithBusinessError(caseData, e);
             } else {
                 errors.add(ERROR_MESSAGE);

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentsService.java
@@ -23,11 +23,6 @@ public class PaymentsService {
     private final OrganisationService organisationService;
 
     public PaymentDto createCreditAccountPayment(CaseData caseData, String authToken) throws FeignException {
-        // To be removed, only used for simulating 422 error for testing locally
-        //        Request request = Request.create(Request.HttpMethod.GET, "url",
-        //                                         new HashMap<>(), null, new RequestTemplate());
-        //        throw new FeignException.UnprocessableEntity("", request, null);
-
         return paymentsClient.createCreditAccountPayment(authToken, buildRequest(caseData));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentsService.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.civil.service;
 
 import feign.FeignException;
+import feign.Request;
+import feign.RequestTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.config.PaymentsConfiguration;
@@ -11,6 +13,8 @@ import uk.gov.hmcts.reform.payments.client.models.FeeDto;
 import uk.gov.hmcts.reform.payments.client.models.PaymentDto;
 import uk.gov.hmcts.reform.payments.request.CreditAccountPaymentRequest;
 import uk.gov.hmcts.reform.prd.model.Organisation;
+
+import java.util.HashMap;
 
 import static java.util.Optional.ofNullable;
 
@@ -23,7 +27,10 @@ public class PaymentsService {
     private final OrganisationService organisationService;
 
     public PaymentDto createCreditAccountPayment(CaseData caseData, String authToken) throws FeignException {
-        return paymentsClient.createCreditAccountPayment(authToken, buildRequest(caseData));
+        Request request = Request.create(Request.HttpMethod.GET, "url", new HashMap<>(), null, new RequestTemplate());
+        throw new FeignException.UnprocessableEntity("", request, null);
+
+        //return paymentsClient.createCreditAccountPayment(authToken, buildRequest(caseData));
     }
 
     private CreditAccountPaymentRequest buildRequest(CaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentsService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.service;
 
+import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.config.PaymentsConfiguration;
@@ -21,7 +22,12 @@ public class PaymentsService {
     private final PaymentsConfiguration paymentsConfiguration;
     private final OrganisationService organisationService;
 
-    public PaymentDto createCreditAccountPayment(CaseData caseData, String authToken) {
+    public PaymentDto createCreditAccountPayment(CaseData caseData, String authToken) throws FeignException {
+        // To be removed, only used for simulating 422 error for testing locally
+        //        Request request = Request.create(Request.HttpMethod.GET, "url",
+        //                                         new HashMap<>(), null, new RequestTemplate());
+        //        throw new FeignException.UnprocessableEntity("", request, null);
+
         return paymentsClient.createCreditAccountPayment(authToken, buildRequest(caseData));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentsService.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.civil.service;
 
 import feign.FeignException;
-import feign.Request;
-import feign.RequestTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.config.PaymentsConfiguration;
@@ -13,8 +11,6 @@ import uk.gov.hmcts.reform.payments.client.models.FeeDto;
 import uk.gov.hmcts.reform.payments.client.models.PaymentDto;
 import uk.gov.hmcts.reform.payments.request.CreditAccountPaymentRequest;
 import uk.gov.hmcts.reform.prd.model.Organisation;
-
-import java.util.HashMap;
 
 import static java.util.Optional.ofNullable;
 
@@ -27,10 +23,7 @@ public class PaymentsService {
     private final OrganisationService organisationService;
 
     public PaymentDto createCreditAccountPayment(CaseData caseData, String authToken) throws FeignException {
-        Request request = Request.create(Request.HttpMethod.GET, "url", new HashMap<>(), null, new RequestTemplate());
-        throw new FeignException.UnprocessableEntity("", request, null);
-
-        //return paymentsClient.createCreditAccountPayment(authToken, buildRequest(caseData));
+        return paymentsClient.createCreditAccountPayment(authToken, buildRequest(caseData));
     }
 
     private CreditAccountPaymentRequest buildRequest(CaseData caseData) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/payment/PaymentsCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/payment/PaymentsCallbackHandlerTest.java
@@ -99,7 +99,7 @@ class PaymentsCallbackHandlerTest extends BaseCallbackHandlerTest {
 
         @ParameterizedTest
         @ValueSource(ints = {403, 422, 504})
-        void shouldUpdateFailureReason_whenForbiddenExceptionThrown(int status) {
+        void shouldUpdateFailureReason_whenSpecificFeignExceptionsThrown(int status) {
             doThrow(buildFeignException(status)).when(paymentsService).createCreditAccountPayment(any(), any());
 
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/payment/PaymentsCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/payment/PaymentsCallbackHandlerTest.java
@@ -98,7 +98,7 @@ class PaymentsCallbackHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @ParameterizedTest
-        @ValueSource(ints = {403})
+        @ValueSource(ints = {403, 422, 504})
         void shouldUpdateFailureReason_whenForbiddenExceptionThrown(int status) {
             doThrow(buildFeignException(status)).when(paymentsService).createCreditAccountPayment(any(), any());
 
@@ -127,7 +127,7 @@ class PaymentsCallbackHandlerTest extends BaseCallbackHandlerTest {
         }
 
         @ParameterizedTest
-        @ValueSource(ints = {404, 422, 504})
+        @ValueSource(ints = {401, 404, 409})
         void shouldAddError_whenOtherExceptionThrown(int status) {
             doThrow(buildFeignException(status)).when(paymentsService).createCreditAccountPayment(any(), any());
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-1996


### Change description ###
- When we receive 422 and 504s from CCD Data Store API continue along with Payment Failure stateflow, which allows the user to manually retry


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
