### PR TITLE
fix: use docstore response for document created time

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/LocalDateTimeHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/LocalDateTimeHelper.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.civil.helpers;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+public class LocalDateTimeHelper {
+
+    public static final ZoneId UTC_ZONE = ZoneId.of("UTC");
+    public static final ZoneId LOCAL_ZONE = ZoneId.of("Europe/London");
+
+    private LocalDateTimeHelper() {
+    }
+
+    public static LocalDateTime fromUTC(LocalDateTime input) {
+        return input.atZone(UTC_ZONE)
+            .withZoneSameInstant(LOCAL_ZONE)
+            .toLocalDateTime();
+    }
+
+    public static LocalDateTime nowInLocalZone() {
+        return LocalDateTime.now(LOCAL_ZONE);
+    }
+
+    public static LocalDateTime nowInUTC() {
+        return LocalDateTime.now(UTC_ZONE);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/documentmanagement/SecuredDocumentManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/documentmanagement/SecuredDocumentManagementService.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.ccd.document.am.model.Document;
 import uk.gov.hmcts.reform.ccd.document.am.model.DocumentUploadRequest;
 import uk.gov.hmcts.reform.ccd.document.am.model.UploadResponse;
 import uk.gov.hmcts.reform.civil.config.DocumentManagementConfiguration;
+import uk.gov.hmcts.reform.civil.helpers.LocalDateTimeHelper;
 import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.service.UserService;
@@ -84,11 +85,10 @@ public class SecuredDocumentManagementService implements DocumentManagementServi
                                   .build())
                 .documentName(originalFileName)
                 .documentType(pdf.getDocumentType())
-                .createdDatetime(
-                    document.createdOn
-                        .toInstant()
-                        .atZone(ZoneId.systemDefault())
-                        .toLocalDateTime())
+                .createdDatetime(LocalDateTimeHelper.fromUTC(document.createdOn
+                                                                 .toInstant()
+                                                                 .atZone(ZoneId.systemDefault())
+                                                                 .toLocalDateTime()))
                 .documentSize(document.size)
                 .createdBy(CREATED_BY)
                 .build();

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/documentmanagement/SecuredDocumentManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/documentmanagement/SecuredDocumentManagementService.java
@@ -25,7 +25,7 @@ import uk.gov.hmcts.reform.document.utils.InMemoryMultipartFile;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
@@ -84,7 +84,11 @@ public class SecuredDocumentManagementService implements DocumentManagementServi
                                   .build())
                 .documentName(originalFileName)
                 .documentType(pdf.getDocumentType())
-                .createdDatetime(LocalDateTime.now())
+                .createdDatetime(
+                    document.createdOn
+                        .toInstant()
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDateTime())
                 .documentSize(document.size)
                 .createdBy(CREATED_BY)
                 .build();

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/documentmanagement/UnsecuredDocumentManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/documentmanagement/UnsecuredDocumentManagementService.java
@@ -25,7 +25,7 @@ import uk.gov.hmcts.reform.document.utils.InMemoryMultipartFile;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.net.URI;
-import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import static java.util.Collections.singletonList;
@@ -78,7 +78,10 @@ public class UnsecuredDocumentManagementService implements DocumentManagementSer
                                   .build())
                 .documentName(originalFileName)
                 .documentType(pdf.getDocumentType())
-                .createdDatetime(LocalDateTime.now())
+                .createdDatetime(document.createdOn
+                                     .toInstant()
+                                     .atZone(ZoneId.systemDefault())
+                                     .toLocalDateTime())
                 .documentSize(document.size)
                 .createdBy(CREATED_BY)
                 .build();

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/documentmanagement/UnsecuredDocumentManagementService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/documentmanagement/UnsecuredDocumentManagementService.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.civil.config.DocumentManagementConfiguration;
+import uk.gov.hmcts.reform.civil.helpers.LocalDateTimeHelper;
 import uk.gov.hmcts.reform.civil.model.documents.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.documents.PDF;
 import uk.gov.hmcts.reform.civil.service.UserService;
@@ -78,10 +79,10 @@ public class UnsecuredDocumentManagementService implements DocumentManagementSer
                                   .build())
                 .documentName(originalFileName)
                 .documentType(pdf.getDocumentType())
-                .createdDatetime(document.createdOn
-                                     .toInstant()
-                                     .atZone(ZoneId.systemDefault())
-                                     .toLocalDateTime())
+                .createdDatetime(LocalDateTimeHelper.fromUTC(document.createdOn
+                                                                  .toInstant()
+                                                                  .atZone(ZoneId.systemDefault())
+                                                                  .toLocalDateTime()))
                 .documentSize(document.size)
                 .createdBy(CREATED_BY)
                 .build();

--- a/src/test/java/uk/gov/hmcts/reform/civil/helpers/LocalDateTimeHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/helpers/LocalDateTimeHelperTest.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.civil.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LocalDateTimeHelperTest {
+
+    @Test
+    void utcTimeShouldBeBehindByAnHour() {
+        LocalDateTime utcTime = LocalDateTimeHelper.nowInUTC();
+        LocalDateTime localTime = LocalDateTimeHelper.nowInLocalZone();
+
+        assertThat(localTime.getHour() - utcTime.getHour()).isEqualTo(1);
+    }
+
+    @Test
+    void utcTimeToLocalTimeConversionShouldIncrementByAnHour() {
+        LocalDateTime utcTime = LocalDateTimeHelper.nowInUTC();
+
+        assertThat(LocalDateTimeHelper.fromUTC(utcTime).getHour() - utcTime.getHour()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CMC-2020


### Change description ###
- Use docstore response `createdOn` for the document timestamps, instead of generating our own
- Introduce `LocalDateTimeHelper` to convert from UTC for timestamps


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
