### PR TITLE
fixed security issue

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/config/LaunchDarklyConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/LaunchDarklyConfiguration.java
@@ -90,7 +90,7 @@ public class LaunchDarklyConfiguration {
             if (file.startsWith("/")) {
                 flagFile = Paths.get(file);
             } else {
-                flagFile = Paths.get(System.getProperty("user.dir"), file);
+                flagFile = Paths.get("").resolve(file);
             }
             if (Files.exists(flagFile)) {
                 return Optional.of(flagFile);


### PR DESCRIPTION
### JIRA link (if applicable) ###
No JIRA


### Change description ###
fixed security issue due to System.get(), which could be overridden by an attacker
Attackers can control the file system path argument to get() at LaunchDarklyConfiguration.java line 93, which allows them to access or modify otherwise protected files.Allowing user input to control paths used in file system operations could enable an attacker to access or modify otherwise protected system resources.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
