### PR TITLE
fix/CMC-2032: update rpa text for 1v2 same solictior full defence response

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapper.java
@@ -198,36 +198,32 @@ public class EventHistoryMapper {
             buildRespondentResponseEvent(builder, caseData, caseData.getRespondent1ClaimResponseType(),
                                          respondent1ResponseDate, RESPONDENT_ID);
 
-            if (caseData.getRespondent1ClaimResponseType() != RespondentResponseType.FULL_DEFENCE) {
-                miscText = prepareRespondentResponseText(caseData, caseData.getRespondent1(), true);
-                builder.miscellaneous((Event.builder()
-                    .eventSequence(prepareEventSequence(builder.build()))
-                    .eventCode(MISCELLANEOUS.getCode())
-                    .dateReceived(respondent1ResponseDate)
-                    .eventDetailsText(miscText)
-                    .eventDetails(EventDetails.builder()
-                                      .miscText(miscText)
-                                      .build())
-                    .build()));
-            }
+            miscText = prepareRespondentResponseText(caseData, caseData.getRespondent1(), true);
+            builder.miscellaneous((Event.builder()
+                .eventSequence(prepareEventSequence(builder.build()))
+                .eventCode(MISCELLANEOUS.getCode())
+                .dateReceived(respondent1ResponseDate)
+                .eventDetailsText(miscText)
+                .eventDetails(EventDetails.builder()
+                                  .miscText(miscText)
+                                  .build())
+                .build()));
         }
 
         if (defendant2ResponseExists.test(caseData)) {
             buildRespondentResponseEvent(builder, caseData, caseData.getRespondent2ClaimResponseType(),
                                          respondent2ResponseDate, RESPONDENT2_ID);
 
-            if (caseData.getRespondent2ClaimResponseType() != RespondentResponseType.FULL_DEFENCE) {
-                miscText = prepareRespondentResponseText(caseData, caseData.getRespondent2(), false);
-                builder.miscellaneous((Event.builder()
-                    .eventSequence(prepareEventSequence(builder.build()))
-                    .eventCode(MISCELLANEOUS.getCode())
-                    .dateReceived(respondent2ResponseDate)
-                    .eventDetailsText(miscText)
-                    .eventDetails(EventDetails.builder()
-                                      .miscText(miscText)
-                                      .build())
-                    .build()));
-            }
+            miscText = prepareRespondentResponseText(caseData, caseData.getRespondent2(), false);
+            builder.miscellaneous((Event.builder()
+                .eventSequence(prepareEventSequence(builder.build()))
+                .eventCode(MISCELLANEOUS.getCode())
+                .dateReceived(respondent2ResponseDate)
+                .eventDetailsText(miscText)
+                .eventDetails(EventDetails.builder()
+                                  .miscText(miscText)
+                                  .build())
+                .build()));
         }
     }
 
@@ -323,7 +319,7 @@ public class EventHistoryMapper {
                 paginatedMessage = getPaginatedMessageFor1v2SameSolicitor(caseData, isRespondent1);
             }
             defaultText = (format(
-                "RPA Reason: %sDefendant: %s has responded: %s;",
+                "RPA Reason: %sDefendant: %s has responded: %s",
                 paginatedMessage,
                 respondent.getPartyName(),
                 getResponseTypeForRespondent(caseData, respondent)

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapper.java
@@ -323,7 +323,7 @@ public class EventHistoryMapper {
                 paginatedMessage = getPaginatedMessageFor1v2SameSolicitor(caseData, isRespondent1);
             }
             defaultText = (format(
-                "RPA Reason:%s Defendant: %s has responded: %s;",
+                "RPA Reason: %sDefendant: %s has responded: %s;",
                 paginatedMessage,
                 respondent.getPartyName(),
                 getResponseTypeForRespondent(caseData, respondent)
@@ -808,29 +808,20 @@ public class EventHistoryMapper {
     }
 
     public String prepareFullDefenceEventText(DQ dq, CaseData caseData, boolean isRespondent1, Party respondent) {
-        String defaultText;
         MultiPartyScenario scenario = getMultiPartyScenario(caseData);
+        String paginatedMessage = "";
         if (scenario.equals(ONE_V_TWO_ONE_LEGAL_REP)) {
-            String paginatedMessage = getPaginatedMessageFor1v2SameSolicitor(caseData, isRespondent1);
-            defaultText = (format(
-                "RPA Reason:%s Defendant: %s has responded: %s; "
-                    + "preferredCourtCode: %s; stayClaim: %s",
-                paginatedMessage,
-                respondent.getPartyName(),
-                getResponseTypeForRespondent(caseData, respondent),
-                getPreferredCourtCode(dq),
-                isStayClaim(dq)
-            ));
-        } else {
-            defaultText = format(
-                "RPA Reason: Defendant: %s has responded: %s; preferredCourtCode: %s; stayClaim: %s",
-                respondent.getPartyName(),
-                getResponseTypeForRespondent(caseData, respondent),
-                getPreferredCourtCode(dq),
-                isStayClaim(dq)
-            );
+            paginatedMessage = getPaginatedMessageFor1v2SameSolicitor(caseData, isRespondent1);
         }
-        return defaultText;
+        return (format(
+            "%sDefendant: %s has responded: %s; "
+                + "preferredCourtCode: %s; stayClaim: %s",
+            paginatedMessage,
+            respondent.getPartyName(),
+            getResponseTypeForRespondent(caseData, respondent),
+            getPreferredCourtCode(dq),
+            isStayClaim(dq)
+        ));
     }
 
     private String getPaginatedMessageFor1v2SameSolicitor(CaseData caseData, boolean isRespondent1) {
@@ -841,7 +832,7 @@ public class EventHistoryMapper {
             index = isRespondent1 ? 1 : 2;
         }
         return format(
-            " [%d of 2 - %s] ",
+            "[%d of 2 - %s] ",
             index,
             time.now().toLocalDate().toString()
         );

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/RoboticsNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/RoboticsNotificationServiceTest.java
@@ -302,7 +302,7 @@ class RoboticsNotificationServiceTest {
             "Multiparty claim data for %s - %s", reference, caseData.getCcdState()
         );
         String subject = format("Multiparty claim data for %s - %s - %s", reference, caseData.getCcdState(),
-                                "RPA Reason: [2 of 2 - 2020-08-01]  Defendant: Mr. John Rambo has responded: "
+                                "[2 of 2 - 2020-08-01] Defendant: Mr. John Rambo has responded: "
                                     + "FULL_DEFENCE; preferredCourtCode: ; stayClaim: false");
 
         assertThat(capturedEmailData.getSubject()).isEqualTo(subject);

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapperTest.java
@@ -1313,10 +1313,10 @@ class EventHistoryMapperTest {
                 .eventSequence(2)
                 .eventCode("999")
                 .dateReceived(caseData.getRespondent1ResponseDate())
-                .eventDetailsText("RPA Reason: [1 of 2 - 2020-08-01] Defendant: Mr. Sole Trader has responded: null;")
+                .eventDetailsText("RPA Reason: [1 of 2 - 2020-08-01] Defendant: Mr. Sole Trader has responded: null")
                 .eventDetails(EventDetails.builder()
                                   .miscText("RPA Reason: [1 of 2 - 2020-08-01] "
-                                                + "Defendant: Mr. Sole Trader has responded: null;")
+                                                + "Defendant: Mr. Sole Trader has responded: null")
                                   .build())
                 .build();
 
@@ -2334,6 +2334,8 @@ class EventHistoryMapperTest {
 
             String respondent1MiscText =
                 mapper.prepareRespondentResponseText(caseData, caseData.getRespondent1(), true);
+            String respondent2MiscText =
+                mapper.prepareRespondentResponseText(caseData, caseData.getRespondent2(), false);
 
             Event expectedReceiptOfAdmission = Event.builder()
                 .eventSequence(2)
@@ -2382,6 +2384,15 @@ class EventHistoryMapperTest {
                     .eventDetails(EventDetails.builder()
                                       .miscText(respondent1MiscText)
                                       .build())
+                    .build(),
+                Event.builder()
+                    .eventSequence(6)
+                    .eventCode("999")
+                    .dateReceived(caseData.getRespondent2ResponseDate())
+                    .eventDetailsText(respondent2MiscText)
+                    .eventDetails(EventDetails.builder()
+                                      .miscText(respondent2MiscText)
+                                      .build())
                     .build()
             );
 
@@ -2396,7 +2407,8 @@ class EventHistoryMapperTest {
                 .containsExactly(expectedDirectionsQuestionnaireFiled);
             assertThat(eventHistory).extracting("miscellaneous").asList()
                 .containsExactly(expectedMiscellaneousEvents.get(0),
-                                 expectedMiscellaneousEvents.get(1));
+                                 expectedMiscellaneousEvents.get(1),
+                                 expectedMiscellaneousEvents.get(2));
 
             assertEmptyEvents(
                 eventHistory,
@@ -2545,7 +2557,17 @@ class EventHistoryMapperTest {
                     .eventDetails(EventDetails.builder()
                                       .miscText(respondent1MiscText)
                                       .build())
-                    .build());
+                    .build(),
+                Event.builder()
+                    .eventSequence(6)
+                    .eventCode("999")
+                    .dateReceived(caseData.getRespondent2ResponseDate())
+                    .eventDetailsText(respondent2MiscText)
+                    .eventDetails(EventDetails.builder()
+                                      .miscText(respondent2MiscText)
+                                      .build())
+                    .build()
+                );
 
             var eventHistory = mapper.buildEvents(caseData);
 
@@ -2558,7 +2580,8 @@ class EventHistoryMapperTest {
                 .containsExactly(expectedDirectionsQuestionnaireFiled);
             assertThat(eventHistory).extracting("miscellaneous").asList()
                 .containsExactly(expectedMiscellaneousEvents.get(0),
-                                 expectedMiscellaneousEvents.get(1));
+                                 expectedMiscellaneousEvents.get(1),
+                                 expectedMiscellaneousEvents.get(2));
 
             assertEmptyEvents(
                 eventHistory,
@@ -2654,9 +2677,9 @@ class EventHistoryMapperTest {
                         .eventSequence(3)
                         .eventCode("999")
                         .dateReceived(caseData.getRespondent1ResponseDate())
-                        .eventDetailsText("RPA Reason: Defendant: Mr. Sole Trader has responded: FULL_ADMISSION;")
+                        .eventDetailsText("RPA Reason: Defendant: Mr. Sole Trader has responded: FULL_ADMISSION")
                         .eventDetails(EventDetails.builder()
-                            .miscText("RPA Reason: Defendant: Mr. Sole Trader has responded: FULL_ADMISSION;")
+                            .miscText("RPA Reason: Defendant: Mr. Sole Trader has responded: FULL_ADMISSION")
                                           .build())
                         .build()
                 );
@@ -2705,9 +2728,9 @@ class EventHistoryMapperTest {
                         .eventSequence(3)
                         .eventCode("999")
                         .dateReceived(caseData.getRespondent1ResponseDate())
-                        .eventDetailsText("RPA Reason: Defendant: Mr. Sole Trader has responded: PART_ADMISSION;")
+                        .eventDetailsText("RPA Reason: Defendant: Mr. Sole Trader has responded: PART_ADMISSION")
                         .eventDetails(EventDetails.builder()
-                            .miscText("RPA Reason: Defendant: Mr. Sole Trader has responded: PART_ADMISSION;")
+                            .miscText("RPA Reason: Defendant: Mr. Sole Trader has responded: PART_ADMISSION")
                                           .build())
                         .build()
                 );

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapperTest.java
@@ -1313,9 +1313,9 @@ class EventHistoryMapperTest {
                 .eventSequence(2)
                 .eventCode("999")
                 .dateReceived(caseData.getRespondent1ResponseDate())
-                .eventDetailsText("RPA Reason: [1 of 2 - 2020-08-01]  Defendant: Mr. Sole Trader has responded: null;")
+                .eventDetailsText("RPA Reason: [1 of 2 - 2020-08-01] Defendant: Mr. Sole Trader has responded: null;")
                 .eventDetails(EventDetails.builder()
-                                  .miscText("RPA Reason: [1 of 2 - 2020-08-01]  "
+                                  .miscText("RPA Reason: [1 of 2 - 2020-08-01] "
                                                 + "Defendant: Mr. Sole Trader has responded: null;")
                                   .build())
                 .build();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-2032

### Change description ###

- remove RPA reason text for non misc event
- send 999 event even if there's a full defense response in divergent response scenario
- update test

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
