### PR TITLE
To allow a case note to be added to CCD when a claim has dropped offline

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
@@ -68,6 +68,13 @@ import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.PAST_CL
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA;
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.PAST_CLAIM_NOTIFICATION_DEADLINE_AWAITING_CAMUNDA;
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.SPEC_DRAFT;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_AFTER_CLAIM_DETAILS_NOTIFIED;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_AFTER_CLAIM_NOTIFIED;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_BY_STAFF;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_PAST_APPLICANT_RESPONSE_DEADLINE;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_UNREGISTERED_DEFENDANT;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_UNREPRESENTED_DEFENDANT;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_UNREPRESENTED_UNREGISTERED_DEFENDANT;
 
 @Service
 @RequiredArgsConstructor
@@ -388,6 +395,34 @@ public class FlowStateAllowedEventService {
             List.of(
                 DISMISS_CLAIM
             )
+        ),
+        entry(
+            TAKEN_OFFLINE_BY_STAFF.fullName(),
+            List.of(ADD_CASE_NOTE)
+        ),
+        entry(
+            TAKEN_OFFLINE_UNREGISTERED_DEFENDANT.fullName(),
+            List.of(ADD_CASE_NOTE)
+        ),
+        entry(
+            TAKEN_OFFLINE_UNREPRESENTED_DEFENDANT.fullName(),
+            List.of(ADD_CASE_NOTE)
+        ),
+        entry(
+            TAKEN_OFFLINE_UNREPRESENTED_UNREGISTERED_DEFENDANT.fullName(),
+            List.of(ADD_CASE_NOTE)
+        ),
+        entry(
+            TAKEN_OFFLINE_PAST_APPLICANT_RESPONSE_DEADLINE.fullName(),
+            List.of(ADD_CASE_NOTE)
+        ),
+        entry(
+            TAKEN_OFFLINE_AFTER_CLAIM_DETAILS_NOTIFIED.fullName(),
+            List.of(ADD_CASE_NOTE)
+        ),
+        entry(
+            TAKEN_OFFLINE_AFTER_CLAIM_NOTIFIED.fullName(),
+            List.of(ADD_CASE_NOTE)
         )
     );
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
@@ -75,6 +75,13 @@ import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.PAST_CL
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA;
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.PAST_CLAIM_NOTIFICATION_DEADLINE_AWAITING_CAMUNDA;
 import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.PENDING_CLAIM_ISSUED;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_AFTER_CLAIM_DETAILS_NOTIFIED;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_AFTER_CLAIM_NOTIFIED;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_BY_STAFF;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_PAST_APPLICANT_RESPONSE_DEADLINE;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_UNREGISTERED_DEFENDANT;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_UNREPRESENTED_DEFENDANT;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.TAKEN_OFFLINE_UNREPRESENTED_UNREGISTERED_DEFENDANT;
 
 @SpringBootTest(classes = {
     JacksonAutoConfiguration.class,
@@ -429,6 +436,48 @@ class FlowStateAllowedEventServiceTest {
                     PAST_CLAIM_DISMISSED_DEADLINE_AWAITING_CAMUNDA,
                     new CaseEvent[]{
                         DISMISS_CLAIM
+                    }
+                ),
+                of(
+                    TAKEN_OFFLINE_BY_STAFF,
+                    new CaseEvent[] {
+                        ADD_CASE_NOTE
+                    }
+                ),
+                of(
+                    TAKEN_OFFLINE_UNREGISTERED_DEFENDANT,
+                    new CaseEvent[] {
+                        ADD_CASE_NOTE
+                    }
+                ),
+                of(
+                    TAKEN_OFFLINE_UNREPRESENTED_DEFENDANT,
+                    new CaseEvent[] {
+                        ADD_CASE_NOTE
+                    }
+                ),
+                of(
+                    TAKEN_OFFLINE_UNREPRESENTED_UNREGISTERED_DEFENDANT,
+                    new CaseEvent[] {
+                        ADD_CASE_NOTE
+                    }
+                ),
+                of(
+                    TAKEN_OFFLINE_PAST_APPLICANT_RESPONSE_DEADLINE,
+                    new CaseEvent[] {
+                        ADD_CASE_NOTE
+                    }
+                ),
+                of(
+                    TAKEN_OFFLINE_AFTER_CLAIM_DETAILS_NOTIFIED,
+                    new CaseEvent[] {
+                        ADD_CASE_NOTE
+                    }
+                ),
+                of(
+                    TAKEN_OFFLINE_AFTER_CLAIM_NOTIFIED,
+                    new CaseEvent[] {
+                        ADD_CASE_NOTE
                     }
                 )
             );


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CMC-1886

Allowed 'Add case note' user event to be available for cases that have been taken offline.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
