### PR TITLE
Fix same unregistered solicitor scenario

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandler.java
@@ -264,15 +264,17 @@ public class CreateClaimCallbackHandler extends CallbackHandler implements Parti
 
     private void addOrgPolicy2ForSameLegalRepresentative(CaseData caseData, CaseData.CaseDataBuilder caseDataBuilder) {
         if (caseData.getRespondent2SameLegalRepresentative() == YES) {
-            OrganisationPolicy respondent1OrganisationPolicy = caseData.getRespondent1OrganisationPolicy();
+            OrganisationPolicy.OrganisationPolicyBuilder organisationPolicy2Builder = OrganisationPolicy.builder();
 
-            OrganisationPolicy organisationPolicy2 = OrganisationPolicy.builder()
-                .organisation(respondent1OrganisationPolicy.getOrganisation())
-                .orgPolicyCaseAssignedRole("[RESPONDENTSOLICITORTWO]")
-                .orgPolicyReference(respondent1OrganisationPolicy.getOrgPolicyReference())
-                .build();
+            if (caseData.getRespondent1OrgRegistered() == YES) {
+                OrganisationPolicy respondent1OrganisationPolicy = caseData.getRespondent1OrganisationPolicy();
+                organisationPolicy2Builder.organisation(respondent1OrganisationPolicy.getOrganisation())
+                    .orgPolicyReference(respondent1OrganisationPolicy.getOrgPolicyReference())
+                    .build();
+            }
 
-            caseDataBuilder.respondent2OrganisationPolicy(organisationPolicy2);
+            organisationPolicy2Builder.orgPolicyCaseAssignedRole("[RESPONDENTSOLICITORTWO]");
+            caseDataBuilder.respondent2OrganisationPolicy(organisationPolicy2Builder.build());
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandlerTest.java
@@ -844,6 +844,38 @@ class CreateClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
                 .doesNotContainEntry("claimStarted", YES);
         }
 
+        @Test
+        void shouldCopyRespondent1OrgPolicyReferenceForSameRegisteredSolicitorScenario_whenInvoked() {
+            caseData = CaseDataBuilder.builder().atStateClaimIssued1v2AndSameRepresentative().build();
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(
+                callbackParamsOf(
+                    caseData,
+                    ABOUT_TO_SUBMIT
+                ));
+            var respondent2OrgPolicy = response.getData().get("respondent2OrganisationPolicy");
+
+            assertThat(respondent2OrgPolicy).extracting("OrgPolicyReference").isEqualTo("org1PolicyReference");
+            assertThat(respondent2OrgPolicy)
+                .extracting("Organisation").extracting("OrganisationID")
+                .isEqualTo("org1");
+        }
+
+        @Test
+        void shouldNotCopyRespondent1OrgPolicyDetailsFor1v2SameUnregisteredSolicitorScenario_whenInvoked() {
+            caseData = CaseDataBuilder.builder().atStateClaimIssued1v2AndSameUnregisteredRepresentative().build();
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(
+                callbackParamsOf(
+                    caseData,
+                    ABOUT_TO_SUBMIT
+                ));
+
+            var respondent2OrgPolicy = response.getData().get("respondent2OrganisationPolicy");
+
+            assertThat(respondent2OrgPolicy).extracting("OrgPolicyReference").isNull();
+            assertThat(respondent2OrgPolicy).extracting("Organisation").isNull();
+        }
+
         @Nested
         class IdamEmail {
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -1168,6 +1168,18 @@ public class CaseDataBuilder {
         addRespondent2 = YES;
         respondent2Represented = YES;
         respondent2SameLegalRepresentative = YES;
+        respondent1OrganisationPolicy =
+            OrganisationPolicy.builder()
+                .organisation(Organisation.builder().organisationID("org1").build())
+                .orgPolicyCaseAssignedRole("[RESPONDENTSOLICITORONE]")
+                .orgPolicyReference("org1PolicyReference")
+                .build();
+        return this;
+    }
+
+    public CaseDataBuilder atStateClaimIssued1v2AndSameUnregisteredRepresentative() {
+        atStateClaimIssued1v2AndSameRepresentative();
+        respondent1OrgRegistered = NO;
         return this;
     }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/SNI-680

For 1v2 same solicitor scenarios we always copy over respondent1OrganisationPolicy details as respondent2OrganisationPolicy details. Since in this scenario the respondent1 rep is unregistered we don't have an org policy for them so will get a null pointer when trying to copy over details. Fix is to ensure respondent1 rep is registered before trying to copy over the org policy details.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
