### PR TITLE
fix/Individual DoB format when sending to Docmosis was not correct

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/TimelineOfEventDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/TimelineOfEventDetails.java
@@ -12,7 +12,7 @@ import java.time.LocalDate;
 @Builder
 public class TimelineOfEventDetails {
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy")
     private final LocalDate timelineDate;
     @JsonFormat(shape = JsonFormat.Shape.STRING)
     private final String timelineDescription;

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/docmosis/common/SpecifiedParty.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/docmosis/common/SpecifiedParty.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.model.docmosis.common;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.reform.civil.model.Address;
@@ -14,5 +15,6 @@ public class SpecifiedParty {
     private final String name;
     private final Address primaryAddress;
     private final Representative representative;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy")
     private final LocalDate individualDateOfBirth;
 }


### PR DESCRIPTION
### Change description ###
Individual's Date of Birth was sent with a wrong date format, so the template showed a wrong date


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
