### PR TITLE
fix/CIV-2054 - Remove event summary field on BS Enter/Lift Events

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/breathing/BreathingSpaceEnterInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/breathing/BreathingSpaceEnterInfo.java
@@ -17,7 +17,5 @@ public class BreathingSpaceEnterInfo {
 
     private final LocalDate expectedEnd;
 
-    private final String event;
-
     private final String eventDescription;
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/breathing/BreathingSpaceLiftInfo.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/breathing/BreathingSpaceLiftInfo.java
@@ -11,7 +11,5 @@ public class BreathingSpaceLiftInfo {
 
     private final LocalDate expectedEnd;
 
-    private final String event;
-
     private final String eventDescription;
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-2054


### Change description ###
- Remove "event summary" field on BS Enter/Lift Events

Linked to -> https://github.com/hmcts/civil-ccd-definition/pull/752

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
