### PR TITLE
fix: fix RPA UAT defect in 1v2 same solicitor scenario- send only one…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapper.java
@@ -107,10 +107,8 @@ public class RoboticsDataMapper {
         ofNullable(buildRespondentSolicitor(caseData, RESPONDENT_SOLICITOR_ID))
             .ifPresent(solicitorsList::add);
 
-        if (caseData.getRespondent2Represented() == YES) {
-            String respondent2SolicitorId = caseData.getRespondent2SameLegalRepresentative() == YES
-                ? RESPONDENT_SOLICITOR_ID : RESPONDENT2_SOLICITOR_ID;
-            ofNullable(buildRespondent2Solicitor(caseData, respondent2SolicitorId))
+        if (YES == caseData.getRespondent2Represented() && YES != caseData.getRespondent2SameLegalRepresentative()) {
+            ofNullable(buildRespondent2Solicitor(caseData, RESPONDENT2_SOLICITOR_ID))
                 .ifPresent(solicitorsList::add);
         }
         return solicitorsList;

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperTest.java
@@ -241,6 +241,19 @@ class RoboticsDataMapperTest {
     }
 
     @Test
+    void shouldMapToRoboticsCaseDataWhen2ndDefendantIsRepresentedSameSolicitor() {
+        CaseData caseData = CaseDataBuilder.builder().atStatePaymentSuccessful().build().toBuilder()
+            .respondent2(PartyBuilder.builder().company().build())
+            .addRespondent2(YES)
+            .respondent2Represented(YES)
+            .respondent2SameLegalRepresentative(YES)
+            .build();
+        RoboticsCaseData roboticsCaseData = mapper.toRoboticsCaseData(caseData);
+        CustomAssertions.assertThat(roboticsCaseData).isEqualTo(caseData);
+        assertThat(roboticsCaseData.getSolicitors()).hasSize(2);
+    }
+
+    @Test
     void shouldMapToRoboticsCaseDataWhen2ndDefendantIsRepresentedNotRegistered() {
         CaseData caseData = CaseDataBuilder.builder().atStatePaymentSuccessful().build().toBuilder()
             .respondent2(PartyBuilder.builder().company().build())


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-2254


### Change description ###
Remove duplicate solicitor entry in 1v2 Same solicitor scenario


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
