### PR TITLE
CIV-2690: Remove cve redundant 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -357,8 +357,8 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.2'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.2'
 
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.58'
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.17'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.62'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.0.21'
 
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.15.2'
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-2690

- Upgrade apache.tomcat versions
- Removed redundant cve suppressions

https://nvd.nist.gov/vuln/detail/CVE-2022-29885