### PR TITLE
 information missing on DQ PDF from what has been input on the digita…

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/dq/DirectionsQuestionnaireGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/dq/DirectionsQuestionnaireGenerator.java
@@ -365,8 +365,7 @@ public class DirectionsQuestionnaireGenerator implements TemplateDataGenerator<D
                     .map(FurtherInformation::getReasonForFutureApplications)
             ).filter(Optional::isPresent).findFirst().map(Optional::get).orElse(null);
 
-        String furtherJudgeInfo = NO.equals(wantMore) ? null :
-            Stream.of(
+        String furtherJudgeInfo = Stream.of(
                 Optional.ofNullable(caseData.getAdditionalInformationForJudge()),
                 dqFurtherInformation
                     .map(FurtherInformation::getOtherInformationForJudge)


### PR DESCRIPTION
### Change description ###
More information was mapped to flag `wantMore`. Even if user doesnt click it they can enter more information and it will be visible in the document


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
