### PR TITLE
fix CIV-3128, dix the email address for Defendant for RPA JSON

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperForSpec.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperForSpec.java
@@ -135,6 +135,7 @@ public class RoboticsDataMapperForSpec {
             caseData.getRespondentSolicitor1OrganisationDetails()
         );
         if (organisationId.isEmpty() && organisationDetails.isEmpty()) {
+            System.out.println("hiya");
             return null;
         }
         var solicitorEmail = ofNullable(

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperForSpec.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperForSpec.java
@@ -135,7 +135,6 @@ public class RoboticsDataMapperForSpec {
             caseData.getRespondentSolicitor1OrganisationDetails()
         );
         if (organisationId.isEmpty() && organisationDetails.isEmpty()) {
-            System.out.println("hiya");
             return null;
         }
         var solicitorEmail = ofNullable(

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperForSpec.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/RoboticsDataMapperForSpec.java
@@ -137,10 +137,14 @@ public class RoboticsDataMapperForSpec {
         if (organisationId.isEmpty() && organisationDetails.isEmpty()) {
             return null;
         }
+        var solicitorEmail = ofNullable(
+            caseData.getRespondentSolicitor1EmailAddress()
+        );
         solicitorBuilder
             .id(id)
             .isPayee(false)
             .organisationId(organisationId.orElse(null))
+            .contactEmailAddress(solicitorEmail.orElse(null))
             .reference(ofNullable(caseData.getSolicitorReferences())
                            .map(SolicitorReferences::getRespondentSolicitor1Reference)
                            .orElse(null)


### PR DESCRIPTION
LR Spec RPA - Defendant solicitor Email address comes as null in the RPA JSON for 1v2 SS


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-3128


### Change description ###
LR Spec RPA - Defendant solicitor Email address comes as null in the RPA JSON for 1v2 SS


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
