### PR TITLE
fix: configuring smoke test source set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -130,6 +130,15 @@ sourceSets {
     }
     resources.srcDir file('src/contractTest/resources')
   }
+
+  smokeTest {
+    java {
+      compileClasspath += main.output
+      runtimeClasspath += main.output
+      srcDir file('src/smokeTest/java')
+    }
+    resources.srcDir file('src/smokeTest/resources')
+  }
 }
 
 tasks.withType(JavaCompile) {


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Configuring `smokeTest` in sourceSets to address gradle depreciation warnings


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
