### PR TITLE
Fix/spec rpauat/1v2ss divergent rpa2

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/PredicateUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/PredicateUtils.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.utils;
 
+import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 
 import java.util.function.Predicate;
@@ -19,7 +20,7 @@ public class PredicateUtils {
             && caseData.getRespondentSolicitor2AgreedDeadlineExtension() != null;
 
     public static final Predicate<CaseData> defendant1AckExists = caseData ->
-        caseData.getRespondent1AcknowledgeNotificationDate()  != null;
+        caseData.getRespondent1AcknowledgeNotificationDate() != null;
 
     public static final Predicate<CaseData> defendant2AckExists = caseData ->
         caseData.getRespondent2AcknowledgeNotificationDate() != null;
@@ -28,5 +29,7 @@ public class PredicateUtils {
         caseData.getRespondent1ResponseDate() != null;
 
     public static final Predicate<CaseData> defendant2ResponseExists = caseData ->
-        caseData.getRespondent2() != null && caseData.getRespondent2ResponseDate() != null;
+        caseData.getRespondent2() != null && (caseData.getRespondent2ResponseDate() != null
+            || (caseData.getRespondent2SameLegalRepresentative() == YesOrNo.YES
+            && caseData.getRespondent1ResponseDate() != null));
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/PredicateUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/PredicateUtilsTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.civil.enums.ResponseIntention;
-import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
 import uk.gov.hmcts.reform.civil.model.dq.Respondent2DQ;

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/PredicateUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/PredicateUtilsTest.java
@@ -1,9 +1,12 @@
 package uk.gov.hmcts.reform.civil.utils;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.civil.enums.ResponseIntention;
+import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.Party;
 import uk.gov.hmcts.reform.civil.model.dq.Respondent2DQ;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.flowstate.FlowState;
@@ -132,6 +135,29 @@ public class PredicateUtilsTest {
                 .respondent1AcknowledgeNotificationDate(null)
                 .build();
             assertFalse(defendant2ResponseExists.test(caseData));
+        }
+    }
+
+    @Nested
+    class Defendant2ResponseExists {
+
+        @Test
+        public void when1v2differentSol_thenExists() {
+            CaseData caseData = CaseData.builder()
+                .respondent2(Party.builder().build())
+                .respondent2ResponseDate(LocalDateTime.now())
+                .build();
+            Assertions.assertTrue(defendant2ResponseExists.test(caseData));
+        }
+
+        @Test
+        public void when1v2sameSol_thenExists() {
+            CaseData caseData = CaseData.builder()
+                .respondent2(Party.builder().build())
+                .respondent2SameLegalRepresentative(YES)
+                .respondent1ResponseDate(LocalDateTime.now())
+                .build();
+            Assertions.assertTrue(defendant2ResponseExists.test(caseData));
         }
     }
 }


### PR DESCRIPTION
### Change description ###
In claim 1v2, same sol, response date is null for defendant 2, but even if the response is divergent, it has been provided. Condition fixed to account for that


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
