### PR TITLE
get rid of 504 error when inputting non int

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/sdo/JudgementSum.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/sdo/JudgementSum.java
@@ -11,10 +11,10 @@ import lombok.Data;
 public class JudgementSum {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING)
-    private final Integer judgementSum;
+    private final Double judgementSum;
 
     @JsonCreator
-    public JudgementSum(@JsonProperty("judgementSum") Integer judgementSum) {
+    public JudgementSum(@JsonProperty("judgementSum") Double judgementSum) {
         this.judgementSum = judgementSum;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
@@ -569,7 +569,7 @@ public class CreateSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
         @Test
         void shouldPrePopulateDisposalHearingJudgementDeductionValueWhenDrawDirectionsOrderIsNotNull() {
             JudgementSum tempJudgementSum = JudgementSum.builder()
-                .judgementSum(12)
+                .judgementSum(12.0)
                 .build();
 
             CaseData caseData = CaseDataBuilder.builder()
@@ -584,11 +584,11 @@ public class CreateSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
 
             assertThat(response.getData()).extracting("disposalHearingJudgementDeductionValue").extracting("value")
-                .isEqualTo("12%");
+                .isEqualTo("12.0%");
             assertThat(response.getData()).extracting("fastTrackJudgementDeductionValue").extracting("value")
-                .isEqualTo("12%");
+                .isEqualTo("12.0%");
             assertThat(response.getData()).extracting("smallClaimsJudgementDeductionValue").extracting("value")
-                .isEqualTo("12%");
+                .isEqualTo("12.0%");
         }
 
         @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-3053


### Change description ###
This PR gets rid of the 504 error when entering a non integer into the judgementsum field in teh sdo journey.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
