### PR TITLE
Feat/global search changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -332,7 +332,7 @@ dependencies {
   implementation group: 'io.github.openfeign', name: 'feign-httpclient', version: '11.8'
   implementation group: 'org.springframework.retry', name: 'spring-retry'
 
-  implementation group: 'uk.gov.hmcts.reform', name: 'core-case-data-store-client', version: '4.7.6'
+  implementation group: 'com.github.hmcts', name: 'ccd-client', version: '4.8.6'
   implementation group: 'uk.gov.hmcts.reform', name: 'document-management-client', version: '7.0.0'
   implementation group: 'com.github.hmcts', name: 'fees-java-client', version: '0.0.6'
   implementation group: 'com.github.hmcts', name: 'payments-java-client', version: '1.4.1'

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserForSpecHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserForSpecHandler.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.civil.handler.callback.camunda.caseassignment;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 import uk.gov.hmcts.reform.civil.callback.Callback;
@@ -26,7 +25,6 @@ import java.util.Map;
 
 import static java.util.Collections.singletonMap;
 import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
-import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.ASSIGN_CASE_TO_APPLICANT_SOLICITOR1_SPEC;
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserHandler.java
@@ -9,15 +9,20 @@ import uk.gov.hmcts.reform.civil.callback.Callback;
 import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.config.PaymentsConfiguration;
 import uk.gov.hmcts.reform.civil.enums.CaseRole;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.IdamUserDetails;
+import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 import uk.gov.hmcts.reform.civil.service.CoreCaseUserService;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.singletonMap;
+import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.ASSIGN_CASE_TO_APPLICANT_SOLICITOR1;
 
@@ -31,6 +36,8 @@ public class AssignCaseToUserHandler extends CallbackHandler {
     private final CoreCaseUserService coreCaseUserService;
     private final CaseDetailsConverter caseDetailsConverter;
     private final ObjectMapper objectMapper;
+    private final CoreCaseDataService coreCaseDataService;
+    private final PaymentsConfiguration paymentsConfiguration;
 
     @Override
     protected Map<String, Callback> callbacks() {
@@ -58,7 +65,19 @@ public class AssignCaseToUserHandler extends CallbackHandler {
 
         coreCaseUserService.assignCase(caseId, submitterId, organisationId, CaseRole.APPLICANTSOLICITORONE);
         coreCaseUserService.removeCreatorRoleCaseAssignment(caseId, submitterId, organisationId);
+        // This sets the "supplementary_data" value "HmctsServiceId to the Unspec service ID AAA7
+        setSupplementaryData(caseData.getCcdCaseReference(), callbackParams);
 
         return SubmittedCallbackResponse.builder().build();
+    }
+
+    private void setSupplementaryData(Long caseId, CallbackParams callbackParams) {
+        String authorisation = callbackParams.getParams().get(BEARER_TOKEN).toString();
+        Map<String, Map<String, Map<String, Object>>> supplementaryDataCivil = new HashMap<>();
+        supplementaryDataCivil.put("supplementary_data_updates",
+                                   singletonMap("$set", singletonMap("HMCTSServiceId",
+                                                                     paymentsConfiguration.getSiteId())));
+        coreCaseDataService.setSupplementaryData(authorisation, caseId, supplementaryDataCivil);
+
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataService.java
@@ -93,4 +93,11 @@ public class CoreCaseDataService {
         String userId = userService.getUserInfo(userToken).getUid();
         return UserAuthContent.builder().userToken(userToken).userId(userId).build();
     }
+
+    public CaseDetails setSupplementaryData(String authorisation, Long caseId, Map<String, Map<String,
+        Map<String, Object>>> supplementaryData) {
+        return coreCaseDataApi.submitSupplementaryData(authorisation, authTokenGenerator.generate(),
+                                                       caseId.toString(), supplementaryData);
+    }
+
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserForSpecHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserForSpecHandlerTest.java
@@ -1,43 +1,100 @@
 package uk.gov.hmcts.reform.civil.handler.callback.camunda.caseassignment;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.hmcts.reform.civil.callback.CallbackParams;
+import uk.gov.hmcts.reform.civil.callback.CallbackType;
+import uk.gov.hmcts.reform.civil.config.PaymentsConfiguration;
+import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
+import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 import uk.gov.hmcts.reform.civil.service.CoreCaseUserService;
 
-@RunWith(SpringRunner.class)
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 @SpringBootTest(classes = {
-    AssignCaseToUserForSpecHandler.class
+    AssignCaseToUserForSpecHandler.class,
+    JacksonAutoConfiguration.class,
+    CaseDetailsConverter.class
 })
-public class AssignCaseToUserForSpecHandlerTest {
+class AssignCaseToUserForSpecHandlerTest extends BaseCallbackHandlerTest {
 
     @Autowired
-    private AssignCaseToUserForSpecHandler handler;
+    private AssignCaseToUserForSpecHandler assignCaseToUserForSpecHandler;
 
     @MockBean
     private CoreCaseUserService coreCaseUserService;
 
     @MockBean
-    private CaseDetailsConverter caseDetailsConverter;
+    private CoreCaseDataService coreCaseDataService;
 
     @MockBean
+    private PaymentsConfiguration paymentsConfiguration;
+
+    @Autowired
     private ObjectMapper objectMapper;
 
     @MockBean
     private FeatureToggleService toggleService;
 
+    private CallbackParams params;
+
     @Test
     public void ldBlock() {
-        Mockito.when(toggleService.isLrSpecEnabled()).thenReturn(false, true);
-        Assert.assertTrue(handler.handledEvents().isEmpty());
-        Assert.assertFalse(handler.handledEvents().isEmpty());
+        when(toggleService.isLrSpecEnabled()).thenReturn(false, true);
+        Assert.assertTrue(assignCaseToUserForSpecHandler.handledEvents().isEmpty());
+        Assert.assertFalse(assignCaseToUserForSpecHandler.handledEvents().isEmpty());
     }
+
+    @Nested
+    class AssignHmctsServiceId {
+        @BeforeEach
+        void setup() {
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimSubmitted().build();
+            when(paymentsConfiguration.getSpecSiteId()).thenReturn("AAA6");
+
+            Map<String, Object> dataMap = objectMapper.convertValue(caseData, new TypeReference<>() {
+            });
+            params = callbackParamsOf(dataMap, CallbackType.SUBMITTED);
+        }
+
+        @Test
+        void shouldReturnSupplementaryDataOnSubmitted() {
+            assignCaseToUserForSpecHandler.handle(params);
+            verify(coreCaseDataService).setSupplementaryData(any(), any(), eq(supplementaryData()));
+        }
+
+        private Map<String, Map<String, Map<String, Object>>> supplementaryData() {
+            Map<String, Object> hmctsServiceIdMap = new HashMap<>();
+            hmctsServiceIdMap.put("HMCTSServiceId", "AAA6");
+
+            Map<String, Map<String, Object>> supplementaryDataRequestMap = new HashMap<>();
+            supplementaryDataRequestMap.put("$set", hmctsServiceIdMap);
+
+            Map<String, Map<String, Map<String, Object>>> supplementaryDataUpdates = new HashMap<>();
+            supplementaryDataUpdates.put("supplementary_data_updates", supplementaryDataRequestMap);
+
+            return supplementaryDataUpdates;
+        }
+
+    }
+
 }
+

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/caseassignment/AssignCaseToUserHandlerTest.java
@@ -61,6 +61,27 @@ class AssignCaseToUserHandlerTest extends BaseCallbackHandlerTest {
     private CaseData caseData;
 
     @Nested
+    class AssignHmctsServiceId {
+
+        @BeforeEach
+        void setup() {
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimSubmitted().build();
+            when(paymentsConfiguration.getSiteId()).thenReturn("AAA7");
+
+            Map<String, Object> dataMap = objectMapper.convertValue(caseData, new TypeReference<>() {
+            });
+            params = callbackParamsOf(dataMap, CallbackType.SUBMITTED);
+        }
+
+        @Test
+        void shouldReturnSupplementaryDataOnSubmitted() {
+            assignCaseToUserHandler.handle(params);
+            verify(coreCaseDataService).setSupplementaryData(any(), any(), eq(supplementaryData()));
+        }
+
+    }
+
+    @Nested
     class AssignRolesIn1v1CasesRegisteredAndRespresented {
 
         @BeforeEach
@@ -81,31 +102,9 @@ class AssignCaseToUserHandlerTest extends BaseCallbackHandlerTest {
                                                    .build())
                 .build();
 
-            when(paymentsConfiguration.getSiteId()).thenReturn("AAA7");
-
             Map<String, Object> dataMap = objectMapper.convertValue(caseData, new TypeReference<>() {
             });
             params = callbackParamsOf(dataMap, CallbackType.SUBMITTED);
-        }
-
-        @Test
-        void shouldReturnSuppleDataOnSubmitted() {
-            assignCaseToUserHandler.handle(params);
-
-            verify(coreCaseDataService).setSupplementaryData(any(), any(), eq(supplementaryData()));
-        }
-
-        private Map<String, Map<String, Map<String, Object>>> supplementaryData() {
-            Map<String, Object> hmctsServiceIdMap = new HashMap<>();
-            hmctsServiceIdMap.put("HMCTSServiceId", "AAA7");
-
-            Map<String, Map<String, Object>> supplementaryDataRequestMap = new HashMap<>();
-            supplementaryDataRequestMap.put("$set", hmctsServiceIdMap);
-
-            Map<String, Map<String, Map<String, Object>>> supplementaryDataUpdates = new HashMap<>();
-            supplementaryDataUpdates.put("supplementary_data_updates", supplementaryDataRequestMap);
-
-            return supplementaryDataUpdates;
         }
 
         @Test
@@ -267,5 +266,18 @@ class AssignCaseToUserHandlerTest extends BaseCallbackHandlerTest {
             "OrgId1"
         );
 
+    }
+
+    private Map<String, Map<String, Map<String, Object>>> supplementaryData() {
+        Map<String, Object> hmctsServiceIdMap = new HashMap<>();
+        hmctsServiceIdMap.put("HMCTSServiceId", "AAA7");
+
+        Map<String, Map<String, Object>> supplementaryDataRequestMap = new HashMap<>();
+        supplementaryDataRequestMap.put("$set", hmctsServiceIdMap);
+
+        Map<String, Map<String, Map<String, Object>>> supplementaryDataUpdates = new HashMap<>();
+        supplementaryDataUpdates.put("supplementary_data_updates", supplementaryDataRequestMap);
+
+        return supplementaryDataUpdates;
     }
 }


### PR DESCRIPTION
Changes relating to global search to add "HmctsServiceId" within "supplementary_data" to cases on creation


https://tools.hmcts.net/jira/browse/CIV-3125

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
