### PR TITLE
fix CVE-2022-31197

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -314,7 +314,7 @@ dependencies {
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.0'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
 
   implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.30.0'
   implementation group: 'org.jdbi', name: 'jdbi3-spring4', version: '3.19.0'

--- a/build.gradle
+++ b/build.gradle
@@ -314,7 +314,7 @@ dependencies {
 
   implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
-  implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.1'
+  implementation group: 'org.postgresql', name: 'postgresql', version: '42.4.0'
 
   implementation group: 'org.jdbi', name: 'jdbi3-sqlobject', version: '3.30.0'
   implementation group: 'org.jdbi', name: 'jdbi3-spring4', version: '3.19.0'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -83,4 +83,8 @@
   <suppress until="2022-08-01">
     <cve>CVE-2022-31569</cve>
   </suppress>
+  <suppress until="2022-08-20">
+    <notes>org.postgresql</notes>
+    <cve>CVE-2022-31197</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

- upgrade postgresql due to 42.4.1 due to CVE-2022-31197

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
