### PR TITLE
Fix CVE-2022-25647

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,6 +94,13 @@ allprojects {
       ) {
         entry 'snakeyaml'
       }
+
+      dependencySet(
+        group: 'org.camunda.bpm',
+        version: '7.17.0'
+      ) {
+        entry 'camunda-engine'
+      }
     }
     imports {
       mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.4'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -32,9 +32,7 @@
     <cve>CVE-2014-0054</cve>
     <cve>CVE-2022-22965</cve>
     <cve>CVE-2022-22968</cve>
-    <cve>CVE-2022-25647</cve>
     <cve>CVE-2016-1000027</cve>
-    <cve>CVE-2022-25647</cve>
   </suppress>
   <suppress until="2022-07-01">
     <notes>latest spring security core 5.6.5 still has internal dependencies which are causing the Vulnerability</notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-4857


### Change description ###
The package com.google.code.gson:gson before 2.8.9 are vulnerable to Deserialization of Untrusted Data via the writeReplace() method in internal classes, which may lead to DoS attacks.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
