### PR TITLE
[NO-TICKET] changes so that SuperClaimType and CaseCategory play along

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/enums/SuperClaimType.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/enums/SuperClaimType.java
@@ -3,8 +3,14 @@ package uk.gov.hmcts.reform.civil.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+/**
+ * spec and unspec claim.
+ *
+ * @deprecated replaced by CaseCategory
+ */
 @Getter
 @RequiredArgsConstructor
+@Deprecated
 public enum SuperClaimType {
     UNSPEC_CLAIM,
     SPEC_CLAIM;

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateDirectionsQuestionnaireCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateDirectionsQuestionnaireCallbackHandler.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.civil.callback.Callback;
 import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.MultiPartyScenario;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -68,7 +69,7 @@ public class GenerateDirectionsQuestionnaireCallbackHandler extends CallbackHand
             caseData.getSystemGeneratedCaseDocuments();
         systemGeneratedCaseDocuments.add(element(directionsQuestionnaire));
         caseDataBuilder.systemGeneratedCaseDocuments(systemGeneratedCaseDocuments);
-        if (isSpecCaseCategory(caseData, featureToggleService.isAccessProfilesEnabled())) {
+        if (caseData.getCaseAccessCategory() == CaseCategory.SPEC_CLAIM) {
             caseDataBuilder.respondent1GeneratedResponseDocument(directionsQuestionnaire);
         }
     }
@@ -87,7 +88,7 @@ public class GenerateDirectionsQuestionnaireCallbackHandler extends CallbackHand
         CaseData.CaseDataBuilder<?, ?> caseDataBuilder = caseData.toBuilder();
 
         MultiPartyScenario scenario = MultiPartyScenario.getMultiPartyScenario(caseData);
-        if (!isSpecCaseCategory(caseData, featureToggleService.isAccessProfilesEnabled())
+        if (caseData.getCaseAccessCategory() != CaseCategory.SPEC_CLAIM
             || DirectionsQuestionnaireGenerator.isClaimantResponse(caseData)
             || scenario == MultiPartyScenario.ONE_V_ONE
             || scenario == MultiPartyScenario.TWO_V_ONE) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimCallbackHandler.java
@@ -16,7 +16,6 @@ import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.config.ClaimIssueConfiguration;
 import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.MultiPartyScenario;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
@@ -540,7 +539,7 @@ public class CreateClaimCallbackHandler extends CallbackHandler implements Parti
     private CallbackResponse setSuperClaimType(CallbackParams callbackParams) {
         CaseData caseData = callbackParams.getCaseData();
         CaseData.CaseDataBuilder caseDataBuilder = caseData.toBuilder();
-        caseDataBuilder.superClaimType(SuperClaimType.UNSPEC_CLAIM);
+        caseDataBuilder.caseAccessCategory(CaseCategory.UNSPEC_CLAIM);
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(caseDataBuilder.build().toMap(objectMapper))
             .build();

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimSpecCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateClaimSpecCallbackHandler.java
@@ -74,7 +74,6 @@ import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CallbackVersion.V_1;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_CLAIM_SPEC;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.getMultiPartyScenario;
-import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.helpers.DateFormatHelper.DATE_TIME_AT;
@@ -682,7 +681,7 @@ public class CreateClaimSpecCallbackHandler extends CallbackHandler implements P
     private CallbackResponse setSuperClaimType(CallbackParams callbackParams) {
         CaseData caseData = callbackParams.getCaseData();
         CaseData.CaseDataBuilder caseDataBuilder = caseData.toBuilder();
-        caseDataBuilder.superClaimType(SPEC_CLAIM);
+        caseDataBuilder.caseAccessCategory(CaseCategory.SPEC_CLAIM);
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(caseDataBuilder.build().toMap(objectMapper))
             .build();

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceSpecCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceSpecCallbackHandler.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.constants.SpecJourneyConstantLRSpec;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.user.spec.CaseDataToTextGenerator;
 import uk.gov.hmcts.reform.civil.handler.callback.user.spec.RespondToResponseConfirmationHeaderGenerator;
@@ -40,7 +41,6 @@ import static uk.gov.hmcts.reform.civil.callback.CallbackVersion.V_1;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CLAIMANT_RESPONSE_SPEC;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.TWO_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.getMultiPartyScenario;
-import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 
 @Service
@@ -166,7 +166,7 @@ public class RespondToDefenceSpecCallbackHandler extends CallbackHandler
             updatedCaseData = caseData.toBuilder()
                 .respondent1Copy(caseData.getRespondent1())
                 .claimantResponseScenarioFlag(getMultiPartyScenario(caseData))
-                .superClaimType(SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .build();
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicate.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicate.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.civil.service.flowstate;
 
 import uk.gov.hmcts.reform.civil.enums.AllocatedTrack;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseType;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
@@ -569,7 +570,7 @@ public class FlowPredicate {
             && caseData.getRespondent1ClaimResponseTypeForSpec() == responseType;
         boolean predicate = false;
 
-        if (!isSpecCaseCategory(caseData, caseData.getCaseAccessCategory() != null)) {
+        if (caseData.getCaseAccessCategory() != CaseCategory.SPEC_CLAIM) {
             return false;
         }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseCategoryUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseCategoryUtils.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.civil.utils;
 
 import uk.gov.hmcts.reform.civil.enums.CaseCategory;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 
 public class CaseCategoryUtils {
@@ -10,11 +9,14 @@ public class CaseCategoryUtils {
         //NO-OP
     }
 
+    /**
+     * When accessProfiles is released and accessProfilesEnabled is always true, this method won't be needed.
+     *
+     * @param caseData                case data
+     * @param isAccessProfilesEnabled value of flag isAccessProfilesEnabled
+     * @return true if claim is spec, false otherwise
+     */
     public static boolean isSpecCaseCategory(CaseData caseData, boolean isAccessProfilesEnabled) {
-        if (isAccessProfilesEnabled) {
-            return CaseCategory.SPEC_CLAIM.equals(caseData.getCaseAccessCategory());
-        } else {
-            return SuperClaimType.SPEC_CLAIM.equals(caseData.getSuperClaimType());
-        }
+        return CaseCategory.SPEC_CLAIM.equals(caseData.getCaseAccessCategory());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateDirectionsQuestionnaireCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateDirectionsQuestionnaireCallbackHandlerTest.java
@@ -11,8 +11,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
@@ -104,7 +104,7 @@ class GenerateDirectionsQuestionnaireCallbackHandlerTest extends BaseCallbackHan
     @Test
     void shouldAddDocumentToSystemGeneratedDocuments_whenSameLRDiffResponseRespondent1DQ() {
         CaseData caseData = CaseDataBuilder.builder().atStateRespondentFullDefence().build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent2(mock(Party.class))
             .respondent2SameLegalRepresentative(YesOrNo.YES)
             .respondentResponseIsSame(YesOrNo.NO)
@@ -130,7 +130,7 @@ class GenerateDirectionsQuestionnaireCallbackHandlerTest extends BaseCallbackHan
     void shouldAddDocumentToSystemGeneratedDocuments_whenSameLRDiffResponseRespondent2DQ() {
         CaseData caseData = CaseDataBuilder.builder()
             .atStateRespondentAdmitPartOfClaimFastTrack().build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent2(mock(Party.class))
             .respondent2SameLegalRepresentative(YesOrNo.YES)
             .respondentResponseIsSame(YesOrNo.NO)
@@ -258,7 +258,7 @@ class GenerateDirectionsQuestionnaireCallbackHandlerTest extends BaseCallbackHan
         for (RespondentResponseTypeSpec responseType : EnumSet.of(RespondentResponseTypeSpec.FULL_DEFENCE,
                                                                   RespondentResponseTypeSpec.PART_ADMISSION)) {
             CaseData caseData = CaseDataBuilder.builder().atStateRespondentFullDefence().build().toBuilder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .respondent2SameLegalRepresentative(YesOrNo.NO)
                 .respondent2DQ(Respondent2DQ.builder().build())
                 .respondent2ClaimResponseTypeForSpec(responseType)
@@ -284,7 +284,7 @@ class GenerateDirectionsQuestionnaireCallbackHandlerTest extends BaseCallbackHan
     @Test
     void shouldAddDocumentToSystemGeneratedDocuments_when1v2DiffSolBothRespondents() {
         CaseData caseData = CaseDataBuilder.builder().atStateRespondentFullDefence().build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent2(mock(Party.class))
             .respondent2SameLegalRepresentative(YesOrNo.NO)
             .respondent1DQ(Respondent1DQ.builder().build())

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/DefendantResponseApplicantNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/DefendantResponseApplicantNotificationHandlerTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.config.properties.notification.NotificationsProperties;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -37,7 +38,6 @@ import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.toStringValueForEma
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.ONE_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.TWO_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.getMultiPartyScenario;
-import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.DefendantResponseApplicantNotificationHandler.TASK_ID;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.DefendantResponseApplicantNotificationHandler.TASK_ID_CC;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.DefendantResponseApplicantNotificationHandler.TASK_ID_CC_RESP1;
@@ -159,7 +159,7 @@ class DefendantResponseApplicantNotificationHandlerTest extends BaseCallbackHand
                 CaseData caseData = CaseDataBuilder.builder()
                     .atStateNotificationAcknowledged()
                     .build();
-                caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM).build();
+                caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
                 CallbackParams params = CallbackParamsBuilder.builder().of(ABOUT_TO_SUBMIT, caseData).request(
                         CallbackRequest.builder().eventId("NOTIFY_APPLICANT_SOLICITOR1_FOR_DEFENDANT_RESPONSE").build())
                     .build();
@@ -182,7 +182,7 @@ class DefendantResponseApplicantNotificationHandlerTest extends BaseCallbackHand
             void shouldNotifyRespondentSolicitorSpec_whenInvokedWithCcEvent() {
                 CaseData caseData = CaseDataBuilder.builder()
                     .atStateNotificationAcknowledged().build();
-                caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM)
+                caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .respondent1DQ(Respondent1DQ.builder().build())
                     .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
                     .build();
@@ -205,7 +205,7 @@ class DefendantResponseApplicantNotificationHandlerTest extends BaseCallbackHand
             void shouldNotifyRespondentSolicitorSpecDef1_whenInvokedWithCcEvent() {
                 CaseData caseData = CaseDataBuilder.builder()
                     .atStateNotificationAcknowledged().build();
-                caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM)
+                caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .respondent1DQ(Respondent1DQ.builder().build())
                     .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
                     .build();
@@ -228,7 +228,7 @@ class DefendantResponseApplicantNotificationHandlerTest extends BaseCallbackHand
             void shouldNotifyRespondentSolicitorSpecDef1SecondScenerio_whenInvokedWithCcEvent() {
                 CaseData caseData = CaseDataBuilder.builder()
                     .atStateNotificationAcknowledged().build();
-                caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM)
+                caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .respondent2DQ(Respondent2DQ.builder().build())
                     .respondent2ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
                     .respondent2(Party.builder().type(Party.Type.COMPANY).companyName("my company").build())
@@ -432,7 +432,7 @@ class DefendantResponseApplicantNotificationHandlerTest extends BaseCallbackHand
     void shoulldReturnPartyInformation_whenCaseEventIsInvoked() {
         CaseData caseData = CaseDataBuilder.builder()
             .atStateNotificationAcknowledged().build();
-        caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM)
+        caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent2DQ(Respondent2DQ.builder().build())
             .respondent2ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
             .respondent2(Party.builder().type(Party.Type.COMPANY).companyName("my company").build())
@@ -449,7 +449,7 @@ class DefendantResponseApplicantNotificationHandlerTest extends BaseCallbackHand
     void shoulldReturnPartyInformationSecondScenerio_whenCaseEventIsInvoked() {
         CaseData caseData = CaseDataBuilder.builder()
             .atStateNotificationAcknowledged().build();
-        caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM)
+        caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent2DQ(Respondent2DQ.builder().build())
             .respondent2ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
             .respondent2(Party.builder().type(Party.Type.COMPANY).companyName("my company").build())
@@ -466,7 +466,7 @@ class DefendantResponseApplicantNotificationHandlerTest extends BaseCallbackHand
     void shoulldReturnPartyInformationThirdScenerio_whenCaseEventIsInvoked() {
         CaseData caseData = CaseDataBuilder.builder()
             .atStateNotificationAcknowledged().build();
-        caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM)
+        caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent1DQ(Respondent1DQ.builder().build())
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
             .respondent1(Party.builder().type(Party.Type.COMPANY).companyName("my company").build())

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/DefendantResponseCaseHandedOfflineApplicantNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/DefendantResponseCaseHandedOfflineApplicantNotificationHandlerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.properties.notification.NotificationsProperties;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -28,7 +29,6 @@ import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.ONE_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.TWO_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.getMultiPartyScenario;
 import static uk.gov.hmcts.reform.civil.enums.RespondentResponseType.PART_ADMISSION;
-import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.DefendantResponseCaseHandedOfflineApplicantNotificationHandler.TASK_ID_APPLICANT1;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.CLAIM_REFERENCE_NUMBER;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.PARTY_REFERENCES;
@@ -184,7 +184,7 @@ class DefendantResponseCaseHandedOfflineApplicantNotificationHandlerTest extends
                     .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.COUNTER_CLAIM)
                     .build();
                 caseData = caseData
-                    .toBuilder().superClaimType(SPEC_CLAIM)
+                    .toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .build();
                 CallbackParams params = CallbackParamsBuilder.builder().of(ABOUT_TO_SUBMIT, caseData).request(
                         CallbackRequest.builder().eventId(

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/DefendantResponseCaseHandedOfflineRespondentNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/DefendantResponseCaseHandedOfflineRespondentNotificationHandlerTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.config.properties.notification.NotificationsProperties;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseType;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
@@ -35,7 +36,6 @@ import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.ONE_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.TWO_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.getMultiPartyScenario;
 import static uk.gov.hmcts.reform.civil.enums.RespondentResponseType.PART_ADMISSION;
-import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.DefendantResponseCaseHandedOfflineRespondentNotificationHandler.TASK_ID_RESPONDENT1;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.DefendantResponseCaseHandedOfflineRespondentNotificationHandler.TASK_ID_RESPONDENT2;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.CLAIM_REFERENCE_NUMBER;
@@ -512,7 +512,7 @@ class DefendantResponseCaseHandedOfflineRespondentNotificationHandlerTest extend
                     .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.COUNTER_CLAIM)
                     .build();
                 caseData = caseData
-                    .toBuilder().superClaimType(SPEC_CLAIM)
+                    .toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .build();
                 CallbackParams params = CallbackParamsBuilder.builder().of(ABOUT_TO_SUBMIT, caseData).request(
                         CallbackRequest.builder().eventId(
@@ -540,7 +540,7 @@ class DefendantResponseCaseHandedOfflineRespondentNotificationHandlerTest extend
                     .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.COUNTER_CLAIM)
                     .build();
                 caseData = caseData
-                    .toBuilder().superClaimType(SPEC_CLAIM)
+                    .toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .build();
                 CallbackParams params = CallbackParamsBuilder.builder().of(ABOUT_TO_SUBMIT, caseData).request(
                         CallbackRequest.builder().eventId(

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/robotics/NotifyRoboticsOnCaseHandedOfflineHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/robotics/NotifyRoboticsOnCaseHandedOfflineHandlerTest.java
@@ -11,7 +11,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -90,7 +90,7 @@ class NotifyRoboticsOnCaseHandedOfflineHandlerTest extends BaseCallbackHandlerTe
         @Test
         void shouldNotNotifyRobotics_whenLrDisabled() {
             CaseData caseData = CaseDataBuilder.builder().atStateProceedsOfflineAdmissionOrCounterClaim().build()
-                .toBuilder().superClaimType(SuperClaimType.SPEC_CLAIM).build();
+                .toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
             CallbackParams params = CallbackParamsBuilder.builder().of(ABOUT_TO_SUBMIT, caseData).build();
             boolean multiPartyScenario = isMultiPartyScenario(caseData);
             assertThrows(UnsupportedOperationException.class, () -> handler.handle(params));

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/robotics/NotifyRoboticsOnContinuousFeedHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/robotics/NotifyRoboticsOnContinuousFeedHandlerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -40,7 +41,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
-import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.SPEC_CLAIM;
 
 @SpringBootTest(classes = {
     NotifyRoboticsOnContinuousFeedHandler.class,
@@ -94,7 +94,7 @@ class NotifyRoboticsOnContinuousFeedHandlerTest extends BaseCallbackHandlerTest 
                 .atStateRespondentAdmitPartOfClaimFastTrack()
                 .build();
             when(featureToggleService.isLrSpecEnabled()).thenReturn(true);
-            caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM).build();
+            caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
             CallbackParams params = CallbackParamsBuilder.builder().of(ABOUT_TO_SUBMIT, caseData).build();
             handler.handle(params);
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/InformAgreedExtensionDateCallbackHandlerTest.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.ExitSurveyConfiguration;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -280,7 +280,7 @@ class InformAgreedExtensionDateCallbackHandlerTest extends BaseCallbackHandlerTe
             CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotifiedTimeExtension()
                 .extensionDate(RESPONSE_DEADLINE.toLocalDate().plusDays(14))
                 .build().toBuilder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .businessProcess(BusinessProcess.builder()
                                      .camundaEvent(InformAgreedExtensionDateCallbackHandler
                                                        .SPEC_ACKNOWLEDGEMENT_OF_SERVICE)
@@ -527,7 +527,7 @@ class InformAgreedExtensionDateCallbackHandlerTest extends BaseCallbackHandlerTe
             LocalDateTime responseDeadline = now().atTime(END_OF_BUSINESS_DAY);
             CaseData caseData = CaseDataBuilder.builder()
                 .respondent1ResponseDeadline(responseDeadline)
-                .build().toBuilder().superClaimType(SuperClaimType.SPEC_CLAIM)
+                .build().toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .build();
             when(featureToggleService.isLrSpecEnabled()).thenReturn(true);
             CallbackParams params = callbackParamsOf(caseData, SUBMITTED);

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ResubmitClaimCallbackHandlerTest.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.ExitSurveyConfiguration;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -68,7 +68,7 @@ class ResubmitClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
         @Test
         void shouldUpdateBusinessProcess_whenInvoked_spec() {
             CaseData caseData = CaseDataBuilder.builder().atStateProceedsOfflineAdmissionOrCounterClaim()
-                .build().toBuilder().superClaimType(SuperClaimType.SPEC_CLAIM).build();
+                .build().toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
             Mockito.when(featureToggleService.isLrSpecEnabled()).thenReturn(true);
@@ -89,7 +89,7 @@ class ResubmitClaimCallbackHandlerTest extends BaseCallbackHandlerTest {
         @Test
         void shouldUpdateBusinessProcess_whenInvoked_spec_blocked() {
             CaseData caseData = CaseDataBuilder.builder().atStateProceedsOfflineAdmissionOrCounterClaim()
-                .build().toBuilder().superClaimType(SuperClaimType.SPEC_CLAIM).build();
+                .build().toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
             Mockito.when(featureToggleService.isLrSpecEnabled()).thenReturn(false);

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/spec/RespondToResponseConfirmationHeaderGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/spec/RespondToResponseConfirmationHeaderGeneratorTest.java
@@ -1,8 +1,8 @@
 package uk.gov.hmcts.reform.civil.handler.callback.user.spec;
 
 import org.apache.commons.lang3.tuple.Pair;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.user.spec.proceed.confirmation.AdmitNotProceedConfHeader;
 import uk.gov.hmcts.reform.civil.handler.callback.user.spec.proceed.confirmation.AdmitProceedConfHeader;
@@ -36,7 +36,7 @@ public class RespondToResponseConfirmationHeaderGeneratorTest implements CaseDat
 
     public static CaseData buildFullDefenceProceedCaseData() {
         return CaseData.builder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .legacyCaseReference("claimNumber")
             .applicant1ProceedWithClaim(YesOrNo.YES)
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
@@ -45,7 +45,7 @@ public class RespondToResponseConfirmationHeaderGeneratorTest implements CaseDat
 
     public static CaseData buildFullDefenceNotProceedCaseData() {
         return CaseData.builder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .legacyCaseReference("claimNumber")
             .applicant1ProceedWithClaim(YesOrNo.NO)
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
@@ -54,7 +54,7 @@ public class RespondToResponseConfirmationHeaderGeneratorTest implements CaseDat
 
     public static CaseData buildFullAdmitProceedCaseData() {
         return CaseData.builder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .legacyCaseReference("claimNumber")
             .applicant1ProceedWithClaim(YesOrNo.YES)
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_ADMISSION)
@@ -63,7 +63,7 @@ public class RespondToResponseConfirmationHeaderGeneratorTest implements CaseDat
 
     public static CaseData buildFullAdmitNotProceedCaseData() {
         return CaseData.builder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .legacyCaseReference("claimNumber")
             .applicant1ProceedWithClaim(YesOrNo.NO)
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_ADMISSION)
@@ -72,7 +72,7 @@ public class RespondToResponseConfirmationHeaderGeneratorTest implements CaseDat
 
     public static CaseData buildPartAdmitProceedCaseData() {
         return CaseData.builder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .legacyCaseReference("claimNumber")
             .applicant1ProceedWithClaim(YesOrNo.YES)
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.PART_ADMISSION)
@@ -81,7 +81,7 @@ public class RespondToResponseConfirmationHeaderGeneratorTest implements CaseDat
 
     public static CaseData buildPartAdmitNotProceedCaseData() {
         return CaseData.builder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .legacyCaseReference("claimNumber")
             .applicant1ProceedWithClaim(YesOrNo.NO)
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.PART_ADMISSION)

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/CaseDataTest.java
@@ -2,7 +2,10 @@ package uk.gov.hmcts.reform.civil.model;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
+import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
+import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 
 public class CaseDataTest {
 
@@ -20,5 +23,34 @@ public class CaseDataTest {
             .applicant1ProceedWithClaimSpec2v1(YesOrNo.YES)
             .build();
         Assertions.assertEquals(YesOrNo.YES, caseData.getApplicant1ProceedsWithClaimSpec());
+    }
+
+    /**
+     * to ensure that there won't be any problem or NPE-risk when accessing super claim type
+     * before it gets removed.
+     */
+    @Test
+    public void superClaimType_replacedby_caseCategory() {
+        CaseData data = new CaseDataBuilder().build();
+        Assertions.assertEquals(CaseCategory.UNSPEC_CLAIM, data.getCaseAccessCategory());
+        Assertions.assertEquals(SuperClaimType.UNSPEC_CLAIM, data.getSuperClaimType());
+
+        CaseDataBuilder builder = new CaseDataBuilder();
+        builder.setSuperClaimTypeToSpecClaim();
+        data = builder.build();
+        Assertions.assertEquals(CaseCategory.SPEC_CLAIM, data.getCaseAccessCategory());
+        Assertions.assertEquals(SuperClaimType.SPEC_CLAIM, data.getSuperClaimType());
+
+        data = CaseData.builder().build();
+        Assertions.assertEquals(CaseCategory.UNSPEC_CLAIM, data.getCaseAccessCategory());
+        Assertions.assertEquals(SuperClaimType.UNSPEC_CLAIM, data.getSuperClaimType());
+
+        data = CaseData.builder().superClaimType(SuperClaimType.SPEC_CLAIM).build();
+        Assertions.assertEquals(CaseCategory.SPEC_CLAIM, data.getCaseAccessCategory());
+        Assertions.assertEquals(SuperClaimType.SPEC_CLAIM, data.getSuperClaimType());
+
+        data = CaseData.builder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
+        Assertions.assertEquals(CaseCategory.SPEC_CLAIM, data.getCaseAccessCategory());
+        Assertions.assertEquals(SuperClaimType.SPEC_CLAIM, data.getSuperClaimType());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -103,7 +103,6 @@ import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS;
 import static uk.gov.hmcts.reform.civil.enums.PersonalInjuryType.ROAD_ACCIDENT;
 import static uk.gov.hmcts.reform.civil.enums.ResponseIntention.FULL_DEFENCE;
 import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.SPEC_CLAIM;
-import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.UNSPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.enums.dq.HearingLength.ONE_DAY;
@@ -3269,7 +3268,7 @@ public class CaseDataBuilder {
             .caseNotes(caseNotes)
             //ui field
             .uiStatementOfTruth(uiStatementOfTruth)
-            .superClaimType(superClaimType == null ? UNSPEC_CLAIM : superClaimType)
+            .caseAccessCategory(superClaimType == SPEC_CLAIM ? CaseCategory.SPEC_CLAIM : CaseCategory.UNSPEC_CLAIM)
             .caseBundles(caseBundles)
             .respondToClaim(respondToClaim)
             //spec route

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDetailsBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDetailsBuilder.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 
 import java.time.LocalDateTime;
@@ -113,7 +113,7 @@ public class CaseDetailsBuilder {
 
     public CaseDetailsBuilder atStateFullDefenceSpec() {
         CaseData caseData = CaseDataBuilder.builder().atStateRespondentFullDefence().build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent1ResponseDate(LocalDateTime.now())
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
             .ccdState(AWAITING_APPLICANT_INTENTION)
@@ -125,7 +125,7 @@ public class CaseDetailsBuilder {
 
     public CaseDetailsBuilder atStateFullAdmitSpec() {
         CaseData caseData = CaseDataBuilder.builder().atStateRespondentFullDefence().build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent1ResponseDate(LocalDateTime.now())
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_ADMISSION)
             .ccdState(AWAITING_APPLICANT_INTENTION)
@@ -137,7 +137,7 @@ public class CaseDetailsBuilder {
 
     public CaseDetailsBuilder atStatePartAdmitSpec() {
         CaseData caseData = CaseDataBuilder.builder().atStateRespondentFullDefence().build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent1ResponseDate(LocalDateTime.now())
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.PART_ADMISSION)
             .ccdState(AWAITING_APPLICANT_INTENTION)

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/GeneralApplicationDetailsBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/GeneralApplicationDetailsBuilder.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import uk.gov.hmcts.reform.ccd.model.Organisation;
 import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.CaseRole;
 import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.model.CaseData;
@@ -531,7 +532,8 @@ public class GeneralApplicationDetailsBuilder {
     public CaseData getTestCaseDataSPEC(SuperClaimType claimType) {
         return CaseData.builder()
             .ccdCaseReference(1234L)
-            .superClaimType(claimType)
+            .caseAccessCategory(claimType == SuperClaimType.SPEC_CLAIM
+                                    ? CaseCategory.SPEC_CLAIM : CaseCategory.UNSPEC_CLAIM)
             .respondent2OrganisationPolicy(OrganisationPolicy.builder()
                                                .organisation(uk.gov.hmcts.reform.ccd.model.Organisation.builder()
                                                                  .organisationID(STRING_CONSTANT).build())

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/PaymentsServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/PaymentsServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
 import uk.gov.hmcts.reform.civil.config.PaymentsConfiguration;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -28,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static uk.gov.hmcts.reform.civil.enums.SuperClaimType.SPEC_CLAIM;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {
@@ -126,7 +126,7 @@ class PaymentsServiceTest {
             CaseData caseData = CaseDataBuilder.builder().atStateClaimSubmitted()
                 .applicant1OrganisationPolicy(OrganisationPolicy.builder().organisation(orgId).build())
                 .build();
-            caseData = caseData.toBuilder().superClaimType(SPEC_CLAIM).build();
+            caseData = caseData.toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
 
             var expectedCreditAccountPaymentRequest = getExpectedCreditAccountPaymentRequest(caseData);
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/RepresentativeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/RepresentativeServiceTest.java
@@ -10,7 +10,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.civil.enums.CaseCategory;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.Address;
@@ -195,7 +194,6 @@ class RepresentativeServiceTest {
             CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued()
                 .applicantSolicitor1ServiceAddress(applicantSolicitorServiceAddress)
                 .build().toBuilder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
                 .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .specRespondentCorrespondenceAddressdetails(respondentSolicitorServiceAddress)
                 .build();

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/dq/DirectionsQuestionnaireGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/dq/DirectionsQuestionnaireGeneratorTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.civil.constants.SpecJourneyConstantLRSpec;
 import uk.gov.hmcts.reform.civil.enums.AllocatedTrack;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.ExpertReportsSent;
 import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
@@ -255,9 +256,10 @@ class DirectionsQuestionnaireGeneratorTest {
             ).thenReturn(CASE_DOCUMENT_DEFENDANT);
 
             CaseData caseData = CaseDataBuilder.builder()
+                .setSuperClaimTypeToSpecClaim()
                 .atStateRespondentFullDefence()
                 .build().toBuilder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .build();
 
             CaseDocument caseDocument = generator.generate(caseData, BEARER_TOKEN);
@@ -314,7 +316,7 @@ class DirectionsQuestionnaireGeneratorTest {
                                          .camundaEvent("CLAIMANT_RESPONSE_SPEC").build())
                     .applicant1LitigationFriend(LitigationFriend.builder().fullName("applicant LF").build())
                     .respondent1LitigationFriend(LitigationFriend.builder().fullName("respondent LF").build())
-                    .superClaimType(SuperClaimType.SPEC_CLAIM)
+                    .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .build();
 
                 DirectionsQuestionnaireForm templateData = generator.getTemplateData(caseData);
@@ -338,7 +340,7 @@ class DirectionsQuestionnaireGeneratorTest {
                                          .camundaEvent("CLAIMANT_RESPONSE_SPEC").build())
                     .applicant1LitigationFriend(LitigationFriend.builder().fullName("applicant LF").build())
                     .respondent1LitigationFriend(LitigationFriend.builder().fullName("respondent LF").build())
-                    .superClaimType(SuperClaimType.SPEC_CLAIM)
+                    .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .applicant1ProceedWithClaimSpec2v1(YES)
                     .addApplicant2(YES)
                     .build();
@@ -366,7 +368,7 @@ class DirectionsQuestionnaireGeneratorTest {
                     .applicant1LitigationFriend(LitigationFriend.builder().fullName("applicant LF").build())
                     .respondent1LitigationFriend(LitigationFriend.builder().fullName("respondent LF").build())
                     .applicant1ProceedWithClaim(YES)
-                    .superClaimType(SuperClaimType.SPEC_CLAIM)
+                    .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .respondent2SameLegalRepresentative(YES)
                     .respondentResponseIsSame(YES)
                     .build();
@@ -392,7 +394,7 @@ class DirectionsQuestionnaireGeneratorTest {
                     .applicant1LitigationFriend(LitigationFriend.builder().fullName("applicant LF").build())
                     .respondent1LitigationFriend(LitigationFriend.builder().fullName("respondent LF").build())
                     .applicant1ProceedWithClaim(YES)
-                    .superClaimType(SuperClaimType.SPEC_CLAIM)
+                    .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .respondent2SameLegalRepresentative(NO)
                     .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicateTest.java
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.civil.enums.AllocatedTrack;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseType;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
@@ -507,7 +507,7 @@ class FlowPredicateTest {
                 CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotified().build().toBuilder()
                     .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
                     .respondent1ResponseDate(LocalDateTime.now())
-                    .superClaimType(SuperClaimType.SPEC_CLAIM)
+                    .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                     .build();
                 assertTrue(fullDefenceSpec.test(caseData));
             }
@@ -1978,7 +1978,7 @@ class FlowPredicateTest {
                 @Test
                 void shouldReturnTrue_whenResponsesToBothApplicants() {
                     CaseData caseData = caseDataBuilder.build().toBuilder()
-                        .superClaimType(SuperClaimType.SPEC_CLAIM)
+                        .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                         .respondent1ResponseDate(LocalDateTime.now())
                         .claimant1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
                         .claimant2ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
@@ -2105,7 +2105,7 @@ class FlowPredicateTest {
         @Test
         public void whenNotSmall_false() {
             CaseData caseData = CaseData.builder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .build();
             Assertions.assertFalse(FlowPredicate.allAgreedToMediation.test(caseData));
         }
@@ -2113,7 +2113,7 @@ class FlowPredicateTest {
         @Test
         public void when1v1() {
             CaseData caseData = CaseData.builder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .responseClaimTrack(AllocatedTrack.SMALL_CLAIM.name())
                 .build();
 
@@ -2139,7 +2139,7 @@ class FlowPredicateTest {
         @Test
         public void when1v2ss() {
             CaseData caseData = CaseData.builder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .responseClaimTrack(AllocatedTrack.SMALL_CLAIM.name())
                 .respondent2(Party.builder().build())
                 .respondent2SameLegalRepresentative(YES)
@@ -2167,7 +2167,7 @@ class FlowPredicateTest {
         @Test
         public void when1v2ds() {
             CaseData caseData = CaseData.builder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .responseClaimTrack(AllocatedTrack.SMALL_CLAIM.name())
                 .respondent2(Party.builder().build())
                 .respondent2SameLegalRepresentative(NO)
@@ -2200,7 +2200,7 @@ class FlowPredicateTest {
         @Test
         public void when2v1() {
             CaseData caseData = CaseData.builder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .responseClaimTrack(AllocatedTrack.SMALL_CLAIM.name())
                 .build();
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/StateFlowEngineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/StateFlowEngineTest.java
@@ -13,9 +13,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.enums.AllocatedTrack;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseType;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -499,7 +499,7 @@ class StateFlowEngineTest {
                     .atStateClaimIssued1v1UnrepresentedDefendant()
                     .addLegalRepDeadline(LocalDateTime.now().plusDays(14))
                     .build().toBuilder()
-                    .superClaimType(SuperClaimType.SPEC_CLAIM).build();
+                    .caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
                 StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
 
                 assertThat(stateFlow.getState())
@@ -627,7 +627,7 @@ class StateFlowEngineTest {
                     .atStateClaimIssuedUnrepresentedDefendant2()
                     .addLegalRepDeadline(LocalDateTime.now().plusDays(14))
                     .build().toBuilder()
-                    .superClaimType(SuperClaimType.SPEC_CLAIM).build();
+                    .caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
 
                 StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
 
@@ -717,7 +717,7 @@ class StateFlowEngineTest {
             @Test
             void shouldReturnProceedsWithOfflineJourney_whenRespondentsNotRegisteredSpec() {
                 CaseData caseData = CaseDataBuilder.builder().atStateProceedsOfflineUnregisteredDefendants().build()
-                    .toBuilder().superClaimType(SuperClaimType.SPEC_CLAIM).build();
+                    .toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
 
                 StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
 
@@ -3396,7 +3396,7 @@ class StateFlowEngineTest {
         @Test
         void claimIssue_fullAdmitAndDivergentRespondGoOffline() {
             CaseData caseData = CaseData.builder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .applicant1(Party.builder().build())
                 .respondent1(Party.builder().build())
                 .respondent2(Party.builder().build())
@@ -3479,7 +3479,7 @@ class StateFlowEngineTest {
 
         private CaseData.CaseDataBuilder<?, ?> claim1v1Submitted() {
             return CaseData.builder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 .applicant1(Party.builder().build())
                 .respondent1(Party.builder().build())
                 .submittedDate(LocalDateTime.now());
@@ -3522,7 +3522,7 @@ class StateFlowEngineTest {
         void fullDefenceNoMediationSpec() {
             CaseData caseData = CaseData.builder()
                 // spec claim
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 // claim submitted
                 .submittedDate(LocalDateTime.now())
                 .respondent1Represented(YES)
@@ -3554,7 +3554,7 @@ class StateFlowEngineTest {
         void fullDefencePartialMediationSpec() {
             CaseData caseData = CaseData.builder()
                 // spec claim
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 // claim submitted
                 .submittedDate(LocalDateTime.now())
                 .respondent1Represented(YES)
@@ -3594,7 +3594,7 @@ class StateFlowEngineTest {
         void fullDefenceAllMediationSpec() {
             CaseData caseData = CaseData.builder()
                 // spec claim
-                .superClaimType(SuperClaimType.SPEC_CLAIM)
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM)
                 // claim submitted
                 .submittedDate(LocalDateTime.now())
                 .respondent1Represented(YES)
@@ -3640,7 +3640,7 @@ class StateFlowEngineTest {
                 .atSpecAoSApplicantCorrespondenceAddressRequired(NO)
                 .atSpecAoSApplicantCorrespondenceAddressDetails(AddressBuilder.defaults().build())
                 .build().toBuilder()
-                .superClaimType(SuperClaimType.SPEC_CLAIM).build();
+                .caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
 
             StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/RoboticsNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/RoboticsNotificationServiceTest.java
@@ -14,8 +14,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
 import uk.gov.hmcts.reform.civil.config.PrdAdminUserConfiguration;
 import uk.gov.hmcts.reform.civil.config.properties.robotics.RoboticsEmailConfiguration;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.ResponseIntention;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
@@ -148,7 +148,7 @@ class RoboticsNotificationServiceTest {
     @SneakyThrows
     void shouldSendNotificationEmailLRSpec_whenCaseDataIsProvided() {
         CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotified().build()
-            .toBuilder().superClaimType(SuperClaimType.SPEC_CLAIM).build();
+            .toBuilder().caseAccessCategory(CaseCategory.SPEC_CLAIM).build();
         if (caseData.getRespondent2OrgRegistered() != null
             && caseData.getRespondent2Represented() == null) {
             caseData = caseData.toBuilder()
@@ -269,7 +269,7 @@ class RoboticsNotificationServiceTest {
     @SneakyThrows
     void shouldSendNotificationEmailForMultiPartySpec_whenCaseDataIsProvided() {
         CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotified().build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent2(PartyBuilder.builder().individual().build())
             .addRespondent2(YES)
             .respondent2SameLegalRepresentative(NO)
@@ -307,7 +307,7 @@ class RoboticsNotificationServiceTest {
     @Test
     void shouldFailGracefully_whenLDException() {
         CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotified().build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent2(PartyBuilder.builder().individual().build())
             .addRespondent2(YES)
             .respondent2SameLegalRepresentative(NO)

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapperTest.java
@@ -7,11 +7,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.enums.MultiPartyScenario;
 import uk.gov.hmcts.reform.civil.enums.PartyRole;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.enums.ResponseIntention;
-import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleService;
@@ -5635,7 +5635,7 @@ class EventHistoryMapperTest {
         CaseData caseData = CaseDataBuilder.builder()
             .atStateClaimIssued1v2UnrepresentedDefendant()
             .build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .build();
         when(featureToggleService.isSpecRpaContinuousFeedEnabled()).thenReturn(true);
         when(featureToggleService.isNoticeOfChangeEnabled()).thenReturn(false);
@@ -5690,7 +5690,7 @@ class EventHistoryMapperTest {
                            .note("my note")
                            .build())
             .build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent1LitigationFriendCreatedDate(LocalDateTime.now())
             .build();
         when(featureToggleService.isSpecRpaContinuousFeedEnabled()).thenReturn(true);
@@ -5757,7 +5757,7 @@ class EventHistoryMapperTest {
                            .note("my note")
                            .build())
             .build().toBuilder()
-            .superClaimType(SuperClaimType.SPEC_CLAIM)
+            .caseAccessCategory(CaseCategory.SPEC_CLAIM)
             .respondent2(Party.builder()
                              .type(Party.Type.COMPANY)
                              .companyName("Company Name")


### PR DESCRIPTION
### Change description ###
while access profiles is not merged, other PRs that might be using super claim type in civil-service may still use it despite it being replaced by CaseCategory. These changes try to remove the impact on those PRs until the field can be finally removed


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
