### PR TITLE
CIV-5128 use different template depending on spec or unspec claim

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/config/properties/notification/NotificationsProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/properties/notification/NotificationsProperties.java
@@ -97,6 +97,9 @@ public class NotificationsProperties {
     private String sdoOrdered;
 
     @NotEmpty
+    private String sdoOrderedSpec;
+
+    @NotEmpty
     private String claimantSolicitorConfirmsNotToProceedSpec;
 
     @NotEmpty

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/CreateSDOApplicantsNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/CreateSDOApplicantsNotificationHandler.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.config.properties.notification.NotificationsProperties;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.NotificationService;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
@@ -56,7 +57,9 @@ public class CreateSDOApplicantsNotificationHandler extends CallbackHandler impl
 
         notificationService.sendMail(
             caseData.getApplicantSolicitor1UserDetails().getEmail(),
-            notificationsProperties.getSdoOrdered(),
+            caseData.getCaseAccessCategory() == CaseCategory.SPEC_CLAIM
+                ? notificationsProperties.getSdoOrderedSpec()
+                : notificationsProperties.getSdoOrdered(),
             addProperties(caseData),
             String.format(REFERENCE_TEMPLATE, caseData.getLegacyCaseReference())
         );

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/CreateSDORespondent1NotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/CreateSDORespondent1NotificationHandler.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.config.properties.notification.NotificationsProperties;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.NotificationService;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
@@ -56,7 +57,9 @@ public class CreateSDORespondent1NotificationHandler extends CallbackHandler imp
 
         notificationService.sendMail(
             caseData.getRespondentSolicitor1EmailAddress(),
-            notificationsProperties.getSdoOrdered(),
+            caseData.getCaseAccessCategory() == CaseCategory.SPEC_CLAIM
+                ? notificationsProperties.getSdoOrderedSpec()
+                : notificationsProperties.getSdoOrdered(),
             addProperties(caseData),
             String.format(REFERENCE_TEMPLATE, caseData.getLegacyCaseReference())
         );

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/CreateSDORespondent2NotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/CreateSDORespondent2NotificationHandler.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.config.properties.notification.NotificationsProperties;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.NotificationService;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
@@ -57,7 +58,9 @@ public class CreateSDORespondent2NotificationHandler extends CallbackHandler imp
         if (caseData.getRespondentSolicitor2EmailAddress() != null) {
             notificationService.sendMail(
                 caseData.getRespondentSolicitor2EmailAddress(),
-                notificationsProperties.getSdoOrdered(),
+                caseData.getCaseAccessCategory() == CaseCategory.SPEC_CLAIM
+                    ? notificationsProperties.getSdoOrderedSpec()
+                    : notificationsProperties.getSdoOrdered(),
                 addProperties(caseData),
                 String.format(REFERENCE_TEMPLATE, caseData.getLegacyCaseReference())
             );

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -163,6 +163,7 @@ notifications:
   respondentSolicitorDefendantResponseForSpec: "9527f77e-b346-4527-b93c-c2affd39fa51"
   respondentDefendantResponseForSpec: "94c71894-9590-4995-aae0-edea94fc4594"
   sdoOrdered: "1518a883-d035-46c8-9dc0-a52538ca4545"
+  sdoOrderedSpec: "1c1a200c-b3c1-45eb-9768-aeea56857420"
   claimantSolicitorConfirmsNotToProceedSpec: "156b71f5-30ac-4398-aad2-72dfd424c6f2"
   respondentSolicitorNotifyNotToProceedSpec: "4dc0b5bb-674f-401e-8a39-05686dc0302e"
   claimantSolicitorConfirmsToProceedSpec: "99786d26-ab90-43c7-aa20-9d450d8ce4eb"


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-5128


### Change description ###
Use different template for sdo notification depending on claim spec/unspec


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
