### PR TITLE
Fix flaky unit test and refactor

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/config/JacksonConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/JacksonConfiguration.java
@@ -11,6 +11,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class JacksonConfiguration {
+
     public static final String DATE_FORMAT = "yyyy-MM-dd";
     public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/config/JacksonConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/JacksonConfiguration.java
@@ -1,0 +1,28 @@
+package uk.gov.hmcts.reform.civil.config;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfiguration {
+    public static final String DATE_FORMAT = "yyyy-MM-dd";
+    public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT, Locale.UK);
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT, Locale.UK);
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jsonDateTimeFormatCustomizer() {
+        return builder -> {
+            builder.simpleDateFormat(DATE_TIME_FORMAT);
+            builder.serializers(new LocalDateSerializer(DATE_FORMATTER));
+            builder.serializers(new LocalDateTimeSerializer(DATE_TIME_FORMATTER));
+        };
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/config/JacksonConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/JacksonConfiguration.java
@@ -1,13 +1,13 @@
 package uk.gov.hmcts.reform.civil.config;
 
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
-
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 @Configuration
 public class JacksonConfiguration {
@@ -16,7 +16,8 @@ public class JacksonConfiguration {
     public static final String DATE_TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
 
     public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT, Locale.UK);
-    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern(DATE_TIME_FORMAT, Locale.UK);
+    public static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+        .ofPattern(DATE_TIME_FORMAT, Locale.UK);
 
     @Bean
     public Jackson2ObjectMapperBuilderCustomizer jsonDateTimeFormatCustomizer() {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/NotSuitableSDOCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/NotSuitableSDOCallbackHandlerTest.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.civil.handler.callback.user;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,6 +13,7 @@ import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.ClaimIssueConfiguration;
+import uk.gov.hmcts.reform.civil.config.JacksonConfiguration;
 import uk.gov.hmcts.reform.civil.config.MockDatabaseConfiguration;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
@@ -40,9 +40,10 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.NotSuitable_SDO;
     JacksonAutoConfiguration.class,
     CaseDetailsConverter.class,
     ClaimIssueConfiguration.class,
+    JacksonConfiguration.class,
     MockDatabaseConfiguration.class,
     ValidationAutoConfiguration.class})
-public class NotSuitableSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
+class NotSuitableSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
 
     @MockBean
     private Time time;
@@ -60,42 +61,28 @@ public class NotSuitableSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
     class AboutToStartCallback {
 
         private CallbackParams params;
-        private CaseData caseData;
-        private String userId;
 
         private static final String EMAIL = "example@email.com";
-        private LocalDateTime startedDate;
 
         @BeforeEach
         void setup() {
-            caseData = CaseDataBuilder.builder().atStateClaimDraft().build();
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimDraft().build();
             params = callbackParamsOf(caseData, ABOUT_TO_START);
-            userId = UUID.randomUUID().toString();
+            String userId = UUID.randomUUID().toString();
 
             given(idamClient.getUserDetails(any()))
                 .willReturn(UserDetails.builder().email(EMAIL).id(userId).build());
 
-            startedDate = LocalDateTime.now();
-            startedDate = LocalDateTime.of(startedDate.getYear(), startedDate.getMonth(), startedDate.getDayOfMonth(),
-                             startedDate.getHour(), startedDate.getMinute(), startedDate.getSecond(),
-                             0);  // set to avoid elision of zeroes to cause random test errors.
-
-            given(time.now()).willReturn(startedDate);
+            given(time.now()).willReturn(LocalDateTime.now());
 
         }
 
-        @SuppressWarnings("unchecked")
         @Test
         void checkUnsuitableSDODate() {
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
 
-            int lengthToCheck = "yyyy-MM-ddThh:mm:ss".length();
-            String timeString = time.now().toString().substring(0, lengthToCheck);
-            assertThat(response.getData()).extracting("unsuitableSDODate")
-                .is(new Condition<>(
-                    (Object o) -> o.toString().startsWith(timeString),
-                    "Date matches"
-                ));
+            String timeString = time.now().format(JacksonConfiguration.DATE_TIME_FORMATTER);
+            assertThat(response.getData()).extracting("unsuitableSDODate").isEqualTo(timeString);
 
         }
     }
@@ -104,22 +91,19 @@ public class NotSuitableSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
     class AboutToSubmitCallback {
 
         private CallbackParams params;
-        private CaseData caseData;
-        private String userId;
 
         private static final String EMAIL = "example@email.com";
-        private final LocalDateTime submittedDate = LocalDateTime.now();
 
         @BeforeEach
         void setup() {
-            caseData = CaseDataBuilder.builder().atStateClaimDraft().build();
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimDraft().build();
             params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
-            userId = UUID.randomUUID().toString();
+            String userId = UUID.randomUUID().toString();
 
             given(idamClient.getUserDetails(any()))
                 .willReturn(UserDetails.builder().email(EMAIL).id(userId).build());
 
-            given(time.now()).willReturn(submittedDate);
+            given(time.now()).willReturn(LocalDateTime.now());
 
         }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
- Fix: unit test random failure due to date/time conversion
- New: JacksonConfiguration to define how date/time conversion is supposed to be handled by jackson (prevents date/time values to have variable lengths depending on second and microsecond values)
- Other: minor refactor of test class to reduce amount of linting issues

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
