### PR TITLE
Improve logging on stitching service

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/stitching/BundleRequestExecutor.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/stitching/BundleRequestExecutor.java
@@ -1,5 +1,10 @@
 package uk.gov.hmcts.reform.civil.service.stitching;
 
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -15,37 +20,23 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.BundleRequest;
 import uk.gov.hmcts.reform.civil.model.CaseData;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
 
 import static java.util.Objects.requireNonNull;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class BundleRequestExecutor {
 
     private static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
 
     private final RestTemplate restTemplate;
     private final AuthTokenGenerator serviceAuthTokenGenerator;
-    private final IdamClient idamClient;
     private final CaseDetailsConverter caseDetailsConverter;
 
-    public BundleRequestExecutor(RestTemplate restTemplate,
-                                 AuthTokenGenerator serviceAuthTokenGenerator,
-                                 IdamClient idamClient,
-                                 CaseDetailsConverter caseDetailsConverter) {
-        this.restTemplate = restTemplate;
-        this.serviceAuthTokenGenerator = serviceAuthTokenGenerator;
-        this.idamClient = idamClient;
-        this.caseDetailsConverter = caseDetailsConverter;
-    }
+    private final ObjectMapper objectMapper;
 
-    public CaseData post(
-        final BundleRequest payload,
-        final String endpoint,
-        String authorisation
-    ) {
-        CaseData caseData = null;
+    public CaseData post(final BundleRequest payload, final String endpoint, String authorisation) {
         requireNonNull(payload, "payload must not be null");
         requireNonNull(endpoint, "endpoint must not be null");
 
@@ -53,33 +44,45 @@ public class BundleRequestExecutor {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
-        headers.set(
-            HttpHeaders.AUTHORIZATION,
-            authorisation
-        );
+        headers.set(HttpHeaders.AUTHORIZATION, authorisation);
         headers.set(SERVICE_AUTHORIZATION, serviceAuthorizationToken);
 
-        HttpEntity<BundleRequest> requestEntity = new HttpEntity<>(payload, headers);
-
-        ResponseEntity<CaseDetails> response1 = null;
-
         try {
-            response1 =
-                restTemplate
-                    .exchange(
-                        endpoint,
-                        HttpMethod.POST,
-                        requestEntity,
-                        CaseDetails.class
-                    );
+            ResponseEntity<CaseDetails> response1 = restTemplate.exchange(
+                endpoint,
+                HttpMethod.POST,
+                new HttpEntity<>(payload, headers),
+                CaseDetails.class
+            );
             if (response1.getStatusCode().equals(HttpStatus.OK)) {
-                caseData = caseDetailsConverter.toCaseData(response1.getBody());
+                return caseDetailsConverter.toCaseData(requireNonNull(response1.getBody()));
+            } else {
+                log.warn("The call to the endpoint with URL {} returned a non positive outcome (HTTP-{}). This may "
+                             + "cause problems down the line.", endpoint, response1.getStatusCode().value());
             }
 
         } catch (RestClientResponseException e) {
             log.debug(e.getMessage(), e);
+            log.error("The call to the endpoint with URL {} failed. This is likely to cause problems down the line.",
+                      endpoint);
+            logRelevantInfoQuietly(e);
         }
-        return caseData;
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void logRelevantInfoQuietly(RestClientResponseException e) {
+        try {
+            log.error("  ^  HTTP Error: {}", e.getRawStatusCode());
+            Map<String, Object> response = objectMapper.readValue(e.getResponseBodyAsString(), Map.class);
+
+            List<String> errors = (List<String>)response.get("errors");
+            errors.forEach(message -> log.error("  |  {}", message.substring(0, Math.min(message.length(), 250))));
+
+        } catch (Throwable t) {
+            log.warn("  ^  The details of the error could not be logged due to an exception while trying to log them."
+                         + " Maybe the output could not be parsed as JSON? Maybe the service was unreachable?");
+        }
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/stitching/BundleRequestExecutorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/stitching/BundleRequestExecutorTest.java
@@ -1,0 +1,94 @@
+package uk.gov.hmcts.reform.civil.service.stitching;
+
+import java.nio.charset.Charset;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.model.BundleRequest;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class BundleRequestExecutorTest {
+
+    @Mock
+    RestTemplate restTemplate;
+    @Mock
+    AuthTokenGenerator serviceAuthTokenGenerator;
+    @Mock
+    CaseDetailsConverter caseDetailsConverter;
+
+    BundleRequestExecutor bundleRequestExecutor;
+
+    @BeforeEach
+    void setup() {
+        bundleRequestExecutor = new BundleRequestExecutor(restTemplate, serviceAuthTokenGenerator, caseDetailsConverter, new ObjectMapper());
+    }
+
+    @Test
+    void whenPostIsCalledAndEndpointWorks_thenTheCallSucceeds() {
+        // Given
+        String endpoint = "some url";
+        CaseData expectedCaseData = CaseData.builder().build();
+        CaseDetails responseCaseDetails = CaseDetails.builder().build();
+        ResponseEntity<CaseDetails> responseEntity = new ResponseEntity<>(responseCaseDetails, HttpStatus.OK);
+        given(caseDetailsConverter.toCaseData(responseCaseDetails)).willReturn(expectedCaseData);
+        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class))).willReturn(responseEntity);
+
+        // When
+        BundleRequest request = BundleRequest.builder().build();
+        CaseData result = bundleRequestExecutor.post(request, endpoint, "not important");
+
+        // Then
+        assertThat(result).isEqualTo(expectedCaseData);
+    }
+
+    @Test
+    void whenPostIsCalledAndEndpointFails_thenReturnsNull() {
+        // Given
+        String endpoint = "some url";
+        String errorData = "{\"data\":{\"respondentClaimResponseTypeForSpecGeneric\":\"FULL_ADMISSION\"},\"errors\":[\"Stitching failed: prl-ccd-definitions-pr-662-cdam executing GET http://prl-ccd-definitions-pr-662-cdam/cases/documents/5ce8143a-9a0a-45f2-9735-6b6f9236e4d3/binary\"],\"warnings\":[],\"documentTaskId\":0}";
+        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class))).willThrow(new RestClientResponseException("random exception", 500, "Internal server error", HttpHeaders.EMPTY, errorData.getBytes(), Charset.defaultCharset()));
+        BundleRequest request = BundleRequest.builder().build();
+
+        // When
+        CaseData result = bundleRequestExecutor.post(request, endpoint, "not important");
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void whenPostIsCalledAndEndpointReturnsNon200_thenReturnsNull() {
+        // Given
+        String endpoint = "some url";
+        CaseDetails responseCaseDetails = CaseDetails.builder().build();
+        ResponseEntity<CaseDetails> responseEntity = new ResponseEntity<>(responseCaseDetails, HttpStatus.NOT_ACCEPTABLE);
+        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class))).willReturn(responseEntity);
+
+        // When
+        BundleRequest request = BundleRequest.builder().build();
+        CaseData result = bundleRequestExecutor.post(request, endpoint, "not important");
+
+        // Then
+        assertThat(result).isNull();
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/stitching/BundleRequestExecutorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/stitching/BundleRequestExecutorTest.java
@@ -39,7 +39,8 @@ class BundleRequestExecutorTest {
 
     @BeforeEach
     void setup() {
-        bundleRequestExecutor = new BundleRequestExecutor(restTemplate, serviceAuthTokenGenerator, caseDetailsConverter, new ObjectMapper());
+        bundleRequestExecutor = new BundleRequestExecutor(restTemplate, serviceAuthTokenGenerator, caseDetailsConverter,
+                                                          new ObjectMapper());
     }
 
     @Test
@@ -50,7 +51,8 @@ class BundleRequestExecutorTest {
         CaseDetails responseCaseDetails = CaseDetails.builder().build();
         ResponseEntity<CaseDetails> responseEntity = new ResponseEntity<>(responseCaseDetails, HttpStatus.OK);
         given(caseDetailsConverter.toCaseData(responseCaseDetails)).willReturn(expectedCaseData);
-        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class))).willReturn(responseEntity);
+        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class)))
+            .willReturn(responseEntity);
 
         // When
         BundleRequest request = BundleRequest.builder().build();
@@ -64,8 +66,14 @@ class BundleRequestExecutorTest {
     void whenPostIsCalledAndEndpointFails_thenReturnsNull() {
         // Given
         String endpoint = "some url";
-        String errorData = "{\"data\":{\"respondentClaimResponseTypeForSpecGeneric\":\"FULL_ADMISSION\"},\"errors\":[\"Stitching failed: prl-ccd-definitions-pr-662-cdam executing GET http://prl-ccd-definitions-pr-662-cdam/cases/documents/5ce8143a-9a0a-45f2-9735-6b6f9236e4d3/binary\"],\"warnings\":[],\"documentTaskId\":0}";
-        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class))).willThrow(new RestClientResponseException("random exception", 500, "Internal server error", HttpHeaders.EMPTY, errorData.getBytes(), Charset.defaultCharset()));
+        String errorData = "{\"data\":{\"respondentClaimResponseTypeForSpecGeneric\":\"FULL_ADMISSION\"},\"errors\":"
+            + "[\"Stitching failed: prl-ccd-definitions-pr-662-cdam executing GET "
+            + "http://prl-ccd-definitions-pr-662-cdam/cases/documents/5ce8143a-9a0a-45f2-9735-6b6f9236e4d3/binary\"],"
+            + "\"warnings\":[],\"documentTaskId\":0}";
+        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class)))
+            .willThrow(new RestClientResponseException("random exception", 500, "Internal server error",
+                                                       HttpHeaders.EMPTY, errorData.getBytes(),
+                                                       Charset.defaultCharset()));
         BundleRequest request = BundleRequest.builder().build();
 
         // When
@@ -80,8 +88,10 @@ class BundleRequestExecutorTest {
         // Given
         String endpoint = "some url";
         CaseDetails responseCaseDetails = CaseDetails.builder().build();
-        ResponseEntity<CaseDetails> responseEntity = new ResponseEntity<>(responseCaseDetails, HttpStatus.NOT_ACCEPTABLE);
-        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class))).willReturn(responseEntity);
+        ResponseEntity<CaseDetails> responseEntity = new ResponseEntity<>(responseCaseDetails,
+                                                                          HttpStatus.NOT_ACCEPTABLE);
+        given(restTemplate.exchange(eq(endpoint), eq(HttpMethod.POST), any(), eq(CaseDetails.class)))
+            .willReturn(responseEntity);
 
         // When
         BundleRequest request = BundleRequest.builder().build();


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
The stitching service uses BundleRequestExecutor to execute its cal. That service, however, is not very good with logging and in some cases it may fail without reporting any useful information in the logs.
This change improves the logging a bit in order to report failing calls without disclosing sensitive data.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
