### PR TITLE
fix/bumping java chart to 4.0.4

### DIFF
--- a/charts/civil-service/Chart.yaml
+++ b/charts/civil-service/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 
 dependencies:
   - name: java
-    version: 4.0.2
+    version: 4.0.4
     repository: 'https://hmctspublic.azurecr.io/helm/v1/repo/'
   - name: ccd
     version: 8.0.17


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Bump java chart from 4.0.2 -> 4.0.4


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
