### PR TITLE
Applicant DQ changes

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/migration/MigrateCaseDataCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/migration/MigrateCaseDataCallbackHandler.java
@@ -73,7 +73,7 @@ public class MigrateCaseDataCallbackHandler extends CallbackHandler {
                 caseDataBuilder
             );
         }
-        caseMigrationUtility.migrateRespondentAndApplicantDQUnSpec(
+        caseMigrationUtility.migrateRespondentAndApplicantDQ(
             callbackParams.getParams().get(BEARER_TOKEN).toString(),
             oldCaseData,
             caseDataBuilder,

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseMigrationUtility.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseMigrationUtility.java
@@ -88,9 +88,9 @@ public class CaseMigrationUtility {
 
     }
 
-    public void migrateRespondentAndApplicantDQUnSpec(String authToken, CaseData oldCaseData,
-                                                      CaseData.CaseDataBuilder<?, ?> caseDataBuilder,
-                                                      CaseLocation caseLocation) {
+    public void migrateRespondentAndApplicantDQ(String authToken, CaseData oldCaseData,
+                                                CaseData.CaseDataBuilder<?, ?> caseDataBuilder,
+                                                CaseLocation caseLocation) {
         log.info("CaseCategory is : {}", oldCaseData.getCaseAccessCategory());
 
         if (CaseCategory.SPEC_CLAIM.equals(oldCaseData.getCaseAccessCategory())) {
@@ -146,7 +146,8 @@ public class CaseMigrationUtility {
                                                       .build()).responseClaimCourtLocationRequired(YES).build());
 
         } else if (ofNullable(respondent1DQ).isPresent()
-            && ofNullable(respondent1DQ.getRespondent1DQExperts()).isPresent()) {
+            && (ofNullable(respondent1DQ.getRespondent1DQExperts()).isPresent()
+            || ofNullable(respondent1DQ.getRespondent1DQStatementOfTruth()).isPresent())) {
 
             caseDataBuilder.respondent1DQ(respondent1DQ.toBuilder()
                                               .respondent1DQRequestedCourt(RequestedCourt
@@ -207,7 +208,8 @@ public class CaseMigrationUtility {
                                               .build());
             caseDataBuilder.responseClaimCourtLocation2Required(YES);
         } else if (ofNullable(respondent2DQ).isPresent()
-            && ofNullable(respondent2DQ.getRespondent2DQExperts()).isPresent()) {
+            && (ofNullable(respondent2DQ.getRespondent2DQExperts()).isPresent()
+            || ofNullable(respondent2DQ.getRespondent2DQStatementOfTruth()).isPresent())) {
             caseDataBuilder.respondent2DQ(respondent2DQ.toBuilder()
                                               .respondent2DQRequestedCourt(RequestedCourt.builder()
                                                                                .caseLocation(caseLocation)
@@ -263,7 +265,8 @@ public class CaseMigrationUtility {
                                               .build());
 
         } else if (ofNullable(respondent1DQ).isPresent()
-            && ofNullable(respondent1DQ.getRespondent1DQExperts()).isPresent()) {
+            && (ofNullable(respondent1DQ.getRespondent1DQExperts()).isPresent()
+            || ofNullable(respondent1DQ.getRespondent1DQStatementOfTruth()).isPresent())) {
 
             caseDataBuilder.respondent1DQ(respondent1DQ.toBuilder()
                                               .respondent1DQRequestedCourt(RequestedCourt.builder()
@@ -306,7 +309,8 @@ public class CaseMigrationUtility {
                                                                                .caseLocation(location)
                                                                                .build()).build());
         } else if (ofNullable(respondent2DQ).isPresent()
-            && ofNullable(respondent2DQ.getRespondent2DQExperts()).isPresent()) {
+            && (ofNullable(respondent2DQ.getRespondent2DQExperts()).isPresent()
+            || ofNullable(respondent2DQ.getRespondent2DQStatementOfTruth()).isPresent())) {
             caseDataBuilder.respondent2DQ(respondent2DQ.toBuilder()
                                               .respondent2DQRequestedCourt(RequestedCourt.builder()
                                                                                .caseLocation(caseLocation)

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseMigrationUtility.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseMigrationUtility.java
@@ -273,6 +273,8 @@ public class CaseMigrationUtility {
                                                                                .caseLocation(caseLocation)
                                                                                .build()).build());
 
+        } else if (ofNullable(respondent1DQ).isPresent()) {
+            log.warn("migrateRespondent1DQUnSpec: No condition fulfilled: {}", oldCaseData.getCcdCaseReference());
         }
         log.info("Migrate respondent 1 DQ end unpec end");
     }
@@ -315,8 +317,8 @@ public class CaseMigrationUtility {
                                               .respondent2DQRequestedCourt(RequestedCourt.builder()
                                                                                .caseLocation(caseLocation)
                                                                                .build()).build());
-        } else {
-            log.warn("migrateRespondent2DQUnSpec: No if condition succeeded.");
+        } else if (ofNullable(respondent2DQ).isPresent()) {
+            log.warn("migrateRespondent2DQUnSpec: No condition fulfilled: {}", oldCaseData.getCcdCaseReference());
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseMigrationUtility.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseMigrationUtility.java
@@ -399,7 +399,7 @@ public class CaseMigrationUtility {
                      refData.getCourtLocationCode(),
                      refData.getRegionId(), refData.getEpimmsId(), oldCaseData.getCcdCaseReference()
             );
-            caseLocation = CaseLocation.builder().baseLocation(refData.getEpimmsId())
+            CaseLocation caseLocation = CaseLocation.builder().baseLocation(refData.getEpimmsId())
                 .region(refData.getRegionId()).build();
             caseDataBuilder.applicant1DQ(applicant1DQ.toBuilder()
                                              .applicant1DQRequestedCourt(

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseMigrationUtility.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseMigrationUtility.java
@@ -327,7 +327,7 @@ public class CaseMigrationUtility {
         if (CaseCategory.SPEC_CLAIM.equals(oldCaseData.getCaseAccessCategory())) {
             migrateSpecApplicant1DQ(oldCaseData, authToken, caseDataBuilder, caseLocation);
         } else {
-            migrateUnSpecApplicant1DQ(oldCaseData, authToken, caseDataBuilder, caseLocation);
+            migrateUnSpecApplicant1DQ(oldCaseData, authToken, caseDataBuilder);
         }
     }
 
@@ -381,8 +381,7 @@ public class CaseMigrationUtility {
 
     private void migrateUnSpecApplicant1DQ(CaseData oldCaseData,
                                            String authToken,
-                                           CaseData.CaseDataBuilder<?, ?> caseDataBuilder,
-                                           CaseLocation caseLocation) {
+                                           CaseData.CaseDataBuilder<?, ?> caseDataBuilder) {
         Applicant1DQ applicant1DQ = oldCaseData.getApplicant1DQ();
         //if applicant dq has been submitted for unspec then copying applicant preferred code to dq
         if (ofNullable(applicant1DQ).isPresent()

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/migration/MigrateCaseDataCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/migration/MigrateCaseDataCallbackHandlerTest.java
@@ -242,7 +242,6 @@ public class MigrateCaseDataCallbackHandlerTest extends BaseCallbackHandlerTest 
         assertThat(response.getErrors()).isNull();
     }
 
-
     @Test
     void shouldReturnNoError_whenAboutToSubmitIsInvoked_Spec() {
         CaseData caseData = CaseDataBuilder.builder()

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/migration/MigrateCaseDataCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/migration/MigrateCaseDataCallbackHandlerTest.java
@@ -12,6 +12,9 @@ import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.StatementOfTruth;
+import uk.gov.hmcts.reform.civil.model.dq.Applicant1DQ;
+import uk.gov.hmcts.reform.civil.model.dq.Experts;
 import uk.gov.hmcts.reform.civil.model.referencedata.response.LocationRefData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
@@ -22,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
+import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 
 @SpringBootTest(classes = {
     MigrateCaseDataCallbackHandler.class,
@@ -87,6 +91,7 @@ public class MigrateCaseDataCallbackHandlerTest extends BaseCallbackHandlerTest 
                                                                   .getRespondent1DQRequestedCourt()
                                                                   .toBuilder()
                                                                   .responseCourtCode(null).build())
+                                                          .respondent1DQStatementOfTruth(new StatementOfTruth("name", "role"))
                                                           .build()).build();
         caseData = caseData.toBuilder()
             .respondent2DQ(caseData.getRespondent2DQ().toBuilder()
@@ -95,6 +100,10 @@ public class MigrateCaseDataCallbackHandlerTest extends BaseCallbackHandlerTest 
                                        .getRespondent2DQRequestedCourt()
                                        .toBuilder()
                                        .responseCourtCode(null).build())
+                               .respondent2DQExperts(Experts.builder()
+                                                                   .expertRequired(YES)
+                                                                   .build())
+                               .respondent2DQStatementOfTruth(new StatementOfTruth("name", "role"))
                                .build()).build();
 
         caseData = caseData.toBuilder().applicant1DQ(caseData.getApplicant1DQ().toBuilder()
@@ -103,6 +112,10 @@ public class MigrateCaseDataCallbackHandlerTest extends BaseCallbackHandlerTest 
                                                                  .getApplicant1DQRequestedCourt()
                                                                  .toBuilder()
                                                                  .responseCourtCode(null).build())
+                                                         .applicant1DQStatementOfTruth(new StatementOfTruth("name", "role"))
+                                                         .applicant1DQExperts(Experts.builder()
+                                                                                    .expertRequired(YES)
+                                                                                    .build())
                                                          .build()).build();
 
         caseData = caseData.toBuilder().applicant2DQ(caseData.getApplicant2DQ().toBuilder()
@@ -174,6 +187,10 @@ public class MigrateCaseDataCallbackHandlerTest extends BaseCallbackHandlerTest 
                                                                   .getRespondent1DQRequestedCourt()
                                                                   .toBuilder()
                                                                   .responseCourtCode(null).build())
+                                                          .respondent1DQStatementOfTruth(new StatementOfTruth("name", "role"))
+                                                          .respondent1DQExperts(Experts.builder()
+                                                                                     .expertRequired(YES)
+                                                                                     .build())
                                                           .build()).build();
         caseData = caseData.toBuilder()
             .respondent2DQ(caseData.getRespondent2DQ().toBuilder()
@@ -182,6 +199,7 @@ public class MigrateCaseDataCallbackHandlerTest extends BaseCallbackHandlerTest 
                                        .getRespondent2DQRequestedCourt()
                                        .toBuilder()
                                        .responseCourtCode(null).build())
+                               .respondent2DQStatementOfTruth(new StatementOfTruth("name", "role"))
                                .build()).build();
 
         caseData = caseData.toBuilder().applicant1DQ(caseData.getApplicant1DQ().toBuilder()
@@ -190,6 +208,7 @@ public class MigrateCaseDataCallbackHandlerTest extends BaseCallbackHandlerTest 
                                                                  .getApplicant1DQRequestedCourt()
                                                                  .toBuilder()
                                                                  .responseCourtCode(null).build())
+                                                         .applicant1DQStatementOfTruth(new StatementOfTruth("name", "role"))
                                                          .build()).build();
 
         caseData = caseData.toBuilder().applicant2DQ(caseData.getApplicant2DQ().toBuilder()

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/migration/MigrateCaseDataCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/migration/MigrateCaseDataCallbackHandlerTest.java
@@ -13,7 +13,6 @@ import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.StatementOfTruth;
-import uk.gov.hmcts.reform.civil.model.dq.Applicant1DQ;
 import uk.gov.hmcts.reform.civil.model.dq.Experts;
 import uk.gov.hmcts.reform.civil.model.referencedata.response.LocationRefData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -556,6 +556,11 @@ public class CaseDataBuilder {
         return this;
     }
 
+    public CaseDataBuilder respondent1DQ(Respondent1DQ respondent1DQ) {
+        this.respondent1DQ = respondent1DQ;
+        return this;
+    }
+
     public CaseDataBuilder respondent1DQWithoutSotAndExperts() {
         respondent1DQ = Respondent1DQ.builder()
             .respondent1DQFileDirectionsQuestionnaire(FileDirectionsQuestionnaire.builder()
@@ -578,11 +583,6 @@ public class CaseDataBuilder {
                                                      .vulnerabilityAdjustmentsRequired(NO).build())
             .respondent1DQDraftDirections(DocumentBuilder.builder().documentName("defendant1-directions.pdf").build())
             .build();
-        return this;
-    }
-
-    public CaseDataBuilder respondent1DQ(Respondent1DQ respondent1DQ) {
-        this.respondent1DQ = respondent1DQ;
         return this;
     }
 
@@ -740,6 +740,11 @@ public class CaseDataBuilder {
         return this;
     }
 
+    public CaseDataBuilder respondent2DQ(Respondent2DQ respondent2DQ) {
+        this.respondent2DQ = respondent2DQ;
+        return this;
+    }
+
     public CaseDataBuilder respondent2DQWithoutSotAndExperts() {
         respondent2DQ = Respondent2DQ.builder()
             .respondent2DQFileDirectionsQuestionnaire(FileDirectionsQuestionnaire.builder()
@@ -763,11 +768,6 @@ public class CaseDataBuilder {
             .respondent2DQLanguage(WelshLanguageRequirements.builder().build())
             .respondent2DQDraftDirections(DocumentBuilder.builder().documentName("defendant2-directions.pdf").build())
             .build();
-        return this;
-    }
-
-    public CaseDataBuilder respondent2DQ(Respondent2DQ respondent2DQ) {
-        this.respondent2DQ = respondent2DQ;
         return this;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -556,6 +556,31 @@ public class CaseDataBuilder {
         return this;
     }
 
+    public CaseDataBuilder respondent1DQWithoutSotAndExperts() {
+        respondent1DQ = Respondent1DQ.builder()
+            .respondent1DQFileDirectionsQuestionnaire(FileDirectionsQuestionnaire.builder()
+                                                          .explainedToClient(List.of("CONFIRM"))
+                                                          .oneMonthStayRequested(YES)
+                                                          .reactionProtocolCompliedWith(YES)
+                                                          .build())
+            .respondent1DQDisclosureOfElectronicDocuments(DisclosureOfElectronicDocuments.builder()
+                                                              .reachedAgreement(YES)
+                                                              .build())
+            .respondent1DQDisclosureOfNonElectronicDocuments(DisclosureOfNonElectronicDocuments.builder()
+                                                                 .directionsForDisclosureProposed(NO)
+                                                                 .build())
+            .respondent1DQWitnesses(Witnesses.builder().witnessesToAppear(NO).build())
+            .respondent1DQHearing(Hearing.builder().hearingLength(ONE_DAY).unavailableDatesRequired(NO).build())
+            .respondent1DQHearingSupport(HearingSupport.builder().requirements(List.of()).build())
+            .respondent1DQFurtherInformation(FurtherInformation.builder().futureApplications(NO).build())
+            .respondent1DQLanguage(WelshLanguageRequirements.builder().build())
+            .respondent1DQVulnerabilityQuestions(VulnerabilityQuestions.builder()
+                                                     .vulnerabilityAdjustmentsRequired(NO).build())
+            .respondent1DQDraftDirections(DocumentBuilder.builder().documentName("defendant1-directions.pdf").build())
+            .build();
+        return this;
+    }
+
     public CaseDataBuilder respondent1DQ(Respondent1DQ respondent1DQ) {
         this.respondent1DQ = respondent1DQ;
         return this;
@@ -575,6 +600,37 @@ public class CaseDataBuilder {
                                                                  .directionsForDisclosureProposed(NO)
                                                                  .build())
             .respondent1DQExperts(Experts.builder().expertRequired(NO).build())
+            .respondent1DQWitnesses(Witnesses.builder().witnessesToAppear(NO).build())
+            .respondent1DQHearing(Hearing.builder().hearingLength(ONE_DAY).unavailableDatesRequired(NO).build())
+            .respondent1DQRequestedCourt(RequestedCourt.builder()
+                                             .responseCourtCode("444")
+                                             .caseLocation(CaseLocation.builder()
+                                                               .baseLocation("dummy base").region("dummy region")
+                                                               .build()).build())
+            .respondent1DQHearingSupport(HearingSupport.builder().requirements(List.of()).build())
+            .respondent1DQFurtherInformation(FurtherInformation.builder().futureApplications(NO).build())
+            .respondent1DQLanguage(WelshLanguageRequirements.builder().build())
+            .respondent1DQVulnerabilityQuestions(VulnerabilityQuestions.builder()
+                                                     .vulnerabilityAdjustmentsRequired(NO).build())
+            .respondent1DQStatementOfTruth(StatementOfTruth.builder().name("John Doe").role("Solicitor").build())
+            .respondent1DQDraftDirections(DocumentBuilder.builder().documentName("defendant1-directions.pdf").build())
+            .build();
+        return this;
+    }
+
+    public CaseDataBuilder respondent1DQWithLocationAndWithoutExperts() {
+        respondent1DQ = Respondent1DQ.builder()
+            .respondent1DQFileDirectionsQuestionnaire(FileDirectionsQuestionnaire.builder()
+                                                          .explainedToClient(List.of("CONFIRM"))
+                                                          .oneMonthStayRequested(YES)
+                                                          .reactionProtocolCompliedWith(YES)
+                                                          .build())
+            .respondent1DQDisclosureOfElectronicDocuments(DisclosureOfElectronicDocuments.builder()
+                                                              .reachedAgreement(YES)
+                                                              .build())
+            .respondent1DQDisclosureOfNonElectronicDocuments(DisclosureOfNonElectronicDocuments.builder()
+                                                                 .directionsForDisclosureProposed(NO)
+                                                                 .build())
             .respondent1DQWitnesses(Witnesses.builder().witnessesToAppear(NO).build())
             .respondent1DQHearing(Hearing.builder().hearingLength(ONE_DAY).unavailableDatesRequired(NO).build())
             .respondent1DQRequestedCourt(RequestedCourt.builder()
@@ -625,6 +681,37 @@ public class CaseDataBuilder {
         return this;
     }
 
+    public CaseDataBuilder respondent2DQWithLocationAndWithoutExperts() {
+        respondent2DQ = Respondent2DQ.builder()
+            .respondent2DQFileDirectionsQuestionnaire(FileDirectionsQuestionnaire.builder()
+                                                          .explainedToClient(List.of("CONFIRM"))
+                                                          .oneMonthStayRequested(YES)
+                                                          .reactionProtocolCompliedWith(YES)
+                                                          .build())
+            .respondent2DQDisclosureOfElectronicDocuments(DisclosureOfElectronicDocuments.builder()
+                                                              .reachedAgreement(YES)
+                                                              .build())
+            .respondent2DQDisclosureOfNonElectronicDocuments(DisclosureOfNonElectronicDocuments.builder()
+                                                                 .directionsForDisclosureProposed(NO)
+                                                                 .build())
+            .respondent2DQWitnesses(Witnesses.builder().witnessesToAppear(NO).build())
+            .respondent2DQHearing(Hearing.builder().hearingLength(ONE_DAY).unavailableDatesRequired(NO).build())
+            .respondent2DQRequestedCourt(RequestedCourt.builder()
+                                             .responseCourtCode("444")
+                                             .caseLocation(CaseLocation.builder()
+                                                               .baseLocation("dummy base").region("dummy region")
+                                                               .build()).build())
+            .respondent2DQHearingSupport(HearingSupport.builder().requirements(List.of()).build())
+            .respondent2DQFurtherInformation(FurtherInformation.builder().futureApplications(NO).build())
+            .respondent2DQLanguage(WelshLanguageRequirements.builder().build())
+            .respondent2DQVulnerabilityQuestions(VulnerabilityQuestions.builder()
+                                                     .vulnerabilityAdjustmentsRequired(NO).build())
+            .respondent2DQStatementOfTruth(StatementOfTruth.builder().name("John Doe").role("Solicitor").build())
+            .respondent2DQDraftDirections(DocumentBuilder.builder().documentName("defendant1-directions.pdf").build())
+            .build();
+        return this;
+    }
+
     public CaseDataBuilder respondent2DQ() {
         respondent2DQ = Respondent2DQ.builder()
             .respondent2DQFileDirectionsQuestionnaire(FileDirectionsQuestionnaire.builder()
@@ -648,6 +735,32 @@ public class CaseDataBuilder {
                                                      .vulnerabilityAdjustmentsRequired(NO).build())
             .respondent2DQLanguage(WelshLanguageRequirements.builder().build())
             .respondent2DQStatementOfTruth(StatementOfTruth.builder().name("Jane Doe").role("Solicitor").build())
+            .respondent2DQDraftDirections(DocumentBuilder.builder().documentName("defendant2-directions.pdf").build())
+            .build();
+        return this;
+    }
+
+    public CaseDataBuilder respondent2DQWithoutSotAndExperts() {
+        respondent2DQ = Respondent2DQ.builder()
+            .respondent2DQFileDirectionsQuestionnaire(FileDirectionsQuestionnaire.builder()
+                                                          .explainedToClient(List.of("CONFIRM"))
+                                                          .oneMonthStayRequested(YES)
+                                                          .reactionProtocolCompliedWith(YES)
+                                                          .build())
+            .respondent2DQDisclosureOfElectronicDocuments(DisclosureOfElectronicDocuments.builder()
+                                                              .reachedAgreement(YES)
+                                                              .build())
+            .respondent2DQDisclosureOfNonElectronicDocuments(DisclosureOfNonElectronicDocuments.builder()
+                                                                 .directionsForDisclosureProposed(NO)
+                                                                 .build())
+            .respondent2DQWitnesses(Witnesses.builder().witnessesToAppear(NO).build())
+            .respondent2DQHearing(Hearing.builder().hearingLength(ONE_DAY).unavailableDatesRequired(NO).build())
+            .respondent2DQRequestedCourt(RequestedCourt.builder().build())
+            .respondent2DQHearingSupport(HearingSupport.builder().requirements(List.of()).build())
+            .respondent2DQFurtherInformation(FurtherInformation.builder().futureApplications(NO).build())
+            .respondent2DQVulnerabilityQuestions(VulnerabilityQuestions.builder()
+                                                     .vulnerabilityAdjustmentsRequired(NO).build())
+            .respondent2DQLanguage(WelshLanguageRequirements.builder().build())
             .respondent2DQDraftDirections(DocumentBuilder.builder().documentName("defendant2-directions.pdf").build())
             .build();
         return this;
@@ -704,6 +817,36 @@ public class CaseDataBuilder {
                                                                 .directionsForDisclosureProposed(NO)
                                                                 .build())
             .applicant1DQExperts(Experts.builder().expertRequired(NO).build())
+            .applicant1DQWitnesses(Witnesses.builder().witnessesToAppear(NO).build())
+            .applicant1DQHearing(Hearing.builder().hearingLength(ONE_DAY).unavailableDatesRequired(NO).build())
+            .applicant1DQRequestedCourt(RequestedCourt.builder()
+                                            .responseCourtCode("court4")
+                                            .caseLocation(CaseLocation.builder()
+                                                              .baseLocation("dummy base").region("dummy region")
+                                                              .build()).build())
+            .applicant1DQHearingSupport(HearingSupport.builder().requirements(List.of()).build())
+            .applicant1DQFurtherInformation(FurtherInformation.builder().futureApplications(NO).build())
+            .applicant1DQLanguage(WelshLanguageRequirements.builder().build())
+            .applicant1DQVulnerabilityQuestions(VulnerabilityQuestions.builder()
+                                                    .vulnerabilityAdjustmentsRequired(NO).build())
+            .applicant1DQStatementOfTruth(StatementOfTruth.builder().name("Bob Jones").role("Solicitor").build())
+            .build();
+        return this;
+    }
+
+    public CaseDataBuilder applicant1DQWithLocationWithoutExperts() {
+        applicant1DQ = Applicant1DQ.builder()
+            .applicant1DQFileDirectionsQuestionnaire(FileDirectionsQuestionnaire.builder()
+                                                         .explainedToClient(List.of("OTHER"))
+                                                         .oneMonthStayRequested(NO)
+                                                         .reactionProtocolCompliedWith(YES)
+                                                         .build())
+            .applicant1DQDisclosureOfElectronicDocuments(DisclosureOfElectronicDocuments.builder()
+                                                             .reachedAgreement(YES)
+                                                             .build())
+            .applicant1DQDisclosureOfNonElectronicDocuments(DisclosureOfNonElectronicDocuments.builder()
+                                                                .directionsForDisclosureProposed(NO)
+                                                                .build())
             .applicant1DQWitnesses(Witnesses.builder().witnessesToAppear(NO).build())
             .applicant1DQHearing(Hearing.builder().hearingLength(ONE_DAY).unavailableDatesRequired(NO).build())
             .applicant1DQRequestedCourt(RequestedCourt.builder()


### PR DESCRIPTION
Updating applicant DQ for unspec so that when applicant dq is present the court location gets set from applicant preferred court selected during claim creation journey 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
