### PR TITLE
Suppressing CVE-2022-3064 and CVE-2021-4235

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,6 +14,7 @@
   </suppress>
   <suppress until="2023-05-05">
     <notes>Temporarily suppressing as the latest snakeyaml 1.33 also has these vulnerabilities.</notes>
+    <packageUrl regex="true">^pkg:maven/org.yaml/snakeyaml@.*$</packageUrl>
     <cve>CVE-2022-3064</cve>
     <cve>CVE-2021-4235</cve>
   </suppress>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -12,4 +12,9 @@
   <suppress until="2023-05-05">
     <cve>CVE-2021-4277</cve>
   </suppress>
+  <suppress until="2023-05-05">
+    <notes>Temporarily suppressing as the latest snakeyaml 1.33 also has these vulnerabilities.</notes>
+    <cve>CVE-2022-3064</cve>
+    <cve>CVE-2021-4235</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### Change description ###
Temporarily suppressing CVE-2022-3064 and CVE-2021-4235 as latest snakeyaml 1.33 also has these vulnerabilities.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
