### PR TITLE
CIV-6651 - DJ screen update for Trial and Disposal

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/StandardDirectionOrderDJ.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/StandardDirectionOrderDJ.java
@@ -324,11 +324,12 @@ public class StandardDirectionOrderDJ extends CallbackHandler {
         // existing cases
         if (featureToggleService.isHearingAndListingSDOEnabled()) {
             caseDataBuilder.disposalHearingOrderMadeWithoutHearingDJ(DisposalHearingOrderMadeWithoutHearingDJ
-                                                   .builder()
-                                                   .input(String.format("Each party has the right to apply to have this"
-                                                              + " order set aside or varied. Any such application must "
-                                                              + "be received by the Court "
-                                                              + "(together with the appropriate fee) by 4pm on %s.",
+                                                   .builder().input(String.format(
+                                                            "This order has been made without a hearing. "
+                                                           + "Each party has the right to apply to have this Order "
+                                                           + "set aside or varied. Any such application must "
+                                                           + "be received by the Court "
+                                                           + "(together with the appropriate fee) by 4pm on %s.",
                                                           deadlinesCalculator.plusWorkingDays(LocalDate.now(), 5)
                                                               .format(DateTimeFormatter
                                                                           .ofPattern("dd MMMM yyyy", Locale.ENGLISH))))
@@ -438,7 +439,8 @@ public class StandardDirectionOrderDJ extends CallbackHandler {
         if (featureToggleService.isHearingAndListingSDOEnabled()) {
             caseDataBuilder.trialOrderMadeWithoutHearingDJ(TrialOrderMadeWithoutHearingDJ.builder()
                                                .input(String.format(
-                                                       "Each party has the right to apply to have this Order "
+                                                       "This order has been made without a hearing. "
+                                                       + "Each party has the right to apply to have this Order "
                                                        + "set aside or varied. Any such application must be "
                                                        + "received by the Court "
                                                        + "(together with the appropriate fee) by 4pm on %s.",

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/StandardDirectionOrderDJTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/StandardDirectionOrderDJTest.java
@@ -488,8 +488,8 @@ public class StandardDirectionOrderDJTest extends BaseCallbackHandlerTest {
                 .isEqualTo(LocalDate.now().plusWeeks(4).toString());
 
             assertThat(response.getData()).extracting("disposalHearingOrderMadeWithoutHearingDJ").extracting("input")
-                .isEqualTo(String.format("Each party "
-                                             + "has the right to apply to have this order "
+                .isEqualTo(String.format("This order has been made without a hearing. Each party "
+                                             + "has the right to apply to have this Order "
                                              + "set aside or varied. Any such application must be "
                                              + "received by the Court "
                                              + "(together with the appropriate fee) by 4pm on %s.",
@@ -515,7 +515,7 @@ public class StandardDirectionOrderDJTest extends BaseCallbackHandlerTest {
                                + "summary and a chronology.");
 
             assertThat(response.getData()).extracting("trialOrderMadeWithoutHearingDJ").extracting("input")
-                .isEqualTo(String.format("Each party has the right to "
+                .isEqualTo(String.format("This order has been made without a hearing. Each party has the right to "
                                              + "apply to have this Order set aside or varied. Any such application "
                                              + "must be received by the Court (together with the appropriate fee) "
                                              + "by 4pm on %s.",


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-6651


### Change description ###
Changing text box contents in DJ trial and disposal screens to include 'This order has been made without a hearing.'
**Trial Screen**
![image](https://user-images.githubusercontent.com/95024266/213694460-3ea31da4-1c00-45ed-b669-41a860d49020.png)

**Disposal Screen**
![image](https://user-images.githubusercontent.com/95024266/213694529-3460c8a2-4491-4349-8583-f7833e87c387.png)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
