### PR TITLE
Revert "CIV-7098 upgrade to Java 17"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG APP_INSIGHTS_AGENT_VERSION=2.5.1
 
 # Application image
 
-FROM hmctspublic.azurecr.io/base/java:17-distroless
+FROM hmctspublic.azurecr.io/base/java:openjdk-11-distroless-1.2
 
 # Change to non-root privilege
 USER hmcts

--- a/build.gradle
+++ b/build.gradle
@@ -10,17 +10,16 @@ plugins {
   id 'au.com.dius.pact' version '4.2.14'
   id "io.freefair.lombok" version "5.3.3.3"
   id "org.flywaydb.flyway" version "9.0.1"
+  id 'net.ltgt.apt' version '0.21'
 }
 
 group = 'uk.gov.hmcts.reform'
 version = '0.0.1'
 
 allprojects {
-  java {
-    toolchain {
-      languageVersion = JavaLanguageVersion.of(17)
-    }
-  }
+
+  sourceCompatibility = '11'
+  targetCompatibility = '11'
 
   apply plugin: 'java'
   apply plugin: 'jacoco'
@@ -29,6 +28,7 @@ allprojects {
   apply plugin: 'org.springframework.boot'
   apply plugin: 'org.owasp.dependencycheck'
   apply plugin: 'com.github.ben-manes.versions'
+  apply plugin: 'net.ltgt.apt'
 
   checkstyle {
     maxWarnings = 0
@@ -37,8 +37,8 @@ allprojects {
   }
 
   jacoco {
-    toolVersion = '0.8.8' // jacocoMavenPluginVersion
-    reportsDirectory = file("$buildDir/reports/jacoco")
+    toolVersion = '0.8.5' // jacocoMavenPluginVersion
+    reportsDir = file("$buildDir/reports/jacoco")
   }
 
 // before committing a change, make sure task still works
@@ -96,12 +96,6 @@ allprojects {
 
       dependency group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.2'
       dependency group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.4'
-
-      // To prevent other libraries using conflicting versions
-      dependency group: 'org.slf4j', name: 'slf4j-api', version: '2.0.5'
-      dependency group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.5'
-      dependency group: 'org.slf4j', name: 'jul-to-slf4j', version: '2.0.5'
-      dependency group: 'org.slf4j', name: 'slf4j-nop', version: '2.0.5'
 
       // solves CVE-2022-25857
       dependencySet(
@@ -217,7 +211,7 @@ task pullTestAsset(type: Exec, description: 'Installs Yarn dependencies.') {
 }
 
 task fortifyScan(type: JavaExec, description: 'Run fortify scan.')  {
-  getMainClass().set("uk.gov.hmcts.fortifyclient.FortifyClientMainApp")
+  main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
 }
@@ -435,6 +429,7 @@ dependencies {
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.19.0'
   implementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
 
+
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '9.0.69'
   implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.4'
 
@@ -468,19 +463,20 @@ dependencies {
 
   testImplementation group: 'io.rest-assured', name: 'rest-assured'
 
-  testImplementation group: 'org.springframework.statemachine', name: 'spring-statemachine-test', version: versions.springStatemachine
+  testCompile group: 'org.springframework.statemachine', name: 'spring-statemachine-test', version: versions.springStatemachine
+  testImplementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.6.4'
   testImplementation 'com.github.hmcts:fortify-client:1.2.2:all'
   //pact contract testing
-  contractTestImplementation group: 'au.com.dius', name: 'pact-jvm-consumer-junit5_2.12', version: versions.pact
-  contractTestImplementation group: 'au.com.dius', name: 'pact-jvm-consumer-java8_2.12', version: versions.pact
-  contractTestImplementation group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
+  contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-junit5_2.12', version: versions.pact
+  contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-java8_2.12', version: versions.pact
+  contractTestCompile group: 'org.hamcrest', name: 'java-hamcrest', version: '2.0.0.0'
 
-  contractTestImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
-  contractTestImplementation("org.junit.jupiter:junit-jupiter-engine:5.7.0")
+  contractTestCompile("org.junit.jupiter:junit-jupiter-api:5.7.0")
+  contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.7.0")
   contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.3.2')
 
-  contractTestImplementation sourceSets.main.runtimeClasspath
-  contractTestImplementation sourceSets.test.runtimeClasspath
+  contractTestCompile sourceSets.main.runtimeClasspath
+  contractTestCompile sourceSets.test.runtimeClasspath
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 #
-# Copyright © 2015-2021 the original authors.
+# Copyright Â© 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,10 +32,10 @@
 #       Busybox and similar reduced shells will NOT work, because this script
 #       requires all of these POSIX shell features:
 #         * functions;
-#         * expansions «$var», «${var}», «${var:-default}», «${var+SET}»,
-#           «${var#prefix}», «${var%suffix}», and «$( cmd )»;
-#         * compound commands having a testable exit status, especially «case»;
-#         * various built-in commands including «command», «set», and «ulimit».
+#         * expansions Â«$varÂ», Â«${var}Â», Â«${var:-default}Â», Â«${var+SET}Â»,
+#           Â«${var#prefix}Â», Â«${var%suffix}Â», and Â«$( cmd )Â»;
+#         * compound commands having a testable exit status, especially Â«caseÂ»;
+#         * various built-in commands including Â«commandÂ», Â«setÂ», and Â«ulimitÂ».
 #
 #   Important for patching:
 #

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/CaseEventTaskHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/tasks/CaseEventTaskHandlerTest.java
@@ -212,12 +212,7 @@ class CaseEventTaskHandlerTest {
         @Test
         void shouldNotCallHandleFailureMethod_whenExceptionOnCompleteCall() {
             String errorMessage = "there was an error";
-            CaseData caseData = new CaseDataBuilder().atStateClaimDraft()
-                .businessProcess(BusinessProcess.builder().status(BusinessProcessStatus.READY).build())
-                .build();
-            CaseDetails caseDetails = CaseDetailsBuilder.builder().data(caseData).build();
-            when(coreCaseDataService.startUpdate(any(), any()))
-                .thenReturn(StartEventResponse.builder().caseDetails(caseDetails).build());
+
             doThrow(new NotFoundException(errorMessage, new RestException(errorMessage, new Exception())))
                 .when(externalTaskService).complete(mockTask);
 
@@ -796,7 +791,7 @@ class CaseEventTaskHandlerTest {
                     caseDataBuilder.atStateClaimDetailsNotified_1v2_andNotifyOnlyOneSolicitor()
                         .addRespondent2(YES)
                         .respondent2Represented(YES)
-                        .respondent2OrgRegistered(YES);
+                        .respondent2OrgRegistered(YES);;
                     break;
                 case TAKEN_OFFLINE_BY_STAFF:
                     caseDataBuilder.atStateTakenOfflineByStaff()


### PR DESCRIPTION
Reverts hmcts/civil-service#2223

Reverting as this is causing issues with AppInsights that are not reported during the build but are clogging the logs.

Demo appears to have the same issue so we'll rework it in Demo before trying another deployment.