### PR TITLE
Fix for states from SDO flow

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
@@ -483,7 +483,10 @@ public class FlowStateAllowedEventService {
                 REFER_TO_JUDGE,
                 migrateCase,
                 TAKE_CASE_OFFLINE,
-                GENERATE_DIRECTIONS_ORDER
+                GENERATE_DIRECTIONS_ORDER,
+                EVIDENCE_UPLOAD_APPLICANT,
+                EVIDENCE_UPLOAD_RESPONDENT,
+                EVIDENCE_UPLOAD_JUDGE
             )
         ),
 
@@ -925,7 +928,10 @@ public class FlowStateAllowedEventService {
                 REFER_TO_JUDGE,
                 migrateCase,
                 TAKE_CASE_OFFLINE,
-                GENERATE_DIRECTIONS_ORDER
+                GENERATE_DIRECTIONS_ORDER,
+                EVIDENCE_UPLOAD_APPLICANT,
+                EVIDENCE_UPLOAD_RESPONDENT,
+                EVIDENCE_UPLOAD_JUDGE
             )
         ),
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
@@ -519,7 +519,10 @@ class FlowStateAllowedEventServiceTest {
                         REFER_TO_JUDGE,
                         migrateCase,
                         TAKE_CASE_OFFLINE,
-                        GENERATE_DIRECTIONS_ORDER
+                        GENERATE_DIRECTIONS_ORDER,
+                        EVIDENCE_UPLOAD_APPLICANT,
+                        EVIDENCE_UPLOAD_RESPONDENT,
+                        EVIDENCE_UPLOAD_JUDGE
                     }
                 ),
                 of(


### PR DESCRIPTION
Update states to allow case prog events if SDO journey i.e. case goes into FULL_DEFENCE_PROCEED;


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
