### PR TITLE
CIV-0000 - Suppressing CVE-2022-45688

### DIFF
--- a/charts/civil-service/values.preview.template.yaml
+++ b/charts/civil-service/values.preview.template.yaml
@@ -42,7 +42,7 @@ java:
     POLLING_EVENT_EMITTER_ENABLED: false
     CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-aat.service.core-compute-aat.internal
     DOCUMENT_MANAGEMENT_SECURED: true
-    STITCHING_API_ENABLED: false
+    STITCHING_API_ENABLED: true
   postgresql:
     enabled: true
     image:

--- a/charts/civil-service/values.preview.template.yaml
+++ b/charts/civil-service/values.preview.template.yaml
@@ -42,7 +42,7 @@ java:
     POLLING_EVENT_EMITTER_ENABLED: false
     CASE_DOCUMENT_AM_URL: http://ccd-case-document-am-api-aat.service.core-compute-aat.internal
     DOCUMENT_MANAGEMENT_SECURED: true
-    STITCHING_API_ENABLED: true
+    STITCHING_API_ENABLED: false
   postgresql:
     enabled: true
     image:

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,6 +24,12 @@
     <cve>CVE-2022-45143</cve>
     <cve>CVE-2021-4235</cve>
     <cve>CVE-2022-3064</cve>
+  </suppress>
+
+  <suppress until="2023-05-05">
+    <notes>Temporary Suppression
+      CVE-2022-45688 refer CIV-7427
+    </notes>
     <cve>CVE-2022-45688</cve>
   </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -24,5 +24,6 @@
     <cve>CVE-2022-45143</cve>
     <cve>CVE-2021-4235</cve>
     <cve>CVE-2022-3064</cve>
+    <cve>CVE-2022-45688</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
Suppressing CVE-2022-45688 as this dependency is not being used anywhere
[ ] Yes
[x ] No
```
