### PR TITLE
CIV-0000 update flow state allowing for STANDARD_DIRECTION_ORDER_DJ

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
@@ -275,6 +275,7 @@ public class FlowStateAllowedEventService {
                 DISMISS_CLAIM,
                 ADD_CASE_NOTE,
                 DEFAULT_JUDGEMENT,
+                STANDARD_DIRECTION_ORDER_DJ,
                 INFORM_AGREED_EXTENSION_DATE,
                 CHANGE_SOLICITOR_EMAIL,
                 INITIATE_GENERAL_APPLICATION,
@@ -302,6 +303,7 @@ public class FlowStateAllowedEventService {
                 CHANGE_SOLICITOR_EMAIL,
                 INITIATE_GENERAL_APPLICATION,
                 DEFAULT_JUDGEMENT,
+                STANDARD_DIRECTION_ORDER_DJ,
                 CREATE_SDO,
                 NotSuitable_SDO,
                 migrateCase
@@ -326,6 +328,7 @@ public class FlowStateAllowedEventService {
                 CHANGE_SOLICITOR_EMAIL,
                 INITIATE_GENERAL_APPLICATION,
                 DEFAULT_JUDGEMENT,
+                STANDARD_DIRECTION_ORDER_DJ,
                 CREATE_SDO,
                 NotSuitable_SDO,
                 migrateCase

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
@@ -323,6 +323,7 @@ class FlowStateAllowedEventServiceTest {
                         CREATE_SDO,
                         NotSuitable_SDO,
                         DEFAULT_JUDGEMENT,
+                        STANDARD_DIRECTION_ORDER_DJ,
                         CHANGE_SOLICITOR_EMAIL,
                         migrateCase
 
@@ -348,6 +349,7 @@ class FlowStateAllowedEventServiceTest {
                         CREATE_SDO,
                         NotSuitable_SDO,
                         DEFAULT_JUDGEMENT,
+                        STANDARD_DIRECTION_ORDER_DJ,
                         migrateCase
                     }
                 ),
@@ -371,6 +373,7 @@ class FlowStateAllowedEventServiceTest {
                         CREATE_SDO,
                         NotSuitable_SDO,
                         DEFAULT_JUDGEMENT,
+                        STANDARD_DIRECTION_ORDER_DJ,
                         migrateCase
                     }
                 ),


### PR DESCRIPTION
Update flow state for event STANDARD_DIRECTION_ORDER_DJ to allowed it in flowstates 

NOTIFICATION_ACKNOWLEDGED
NOTIFICATION_ACKNOWLEDGED_TIME_EXTENSION
CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION

previously, for claims going into flow states above,  the event STANDARD_DIRECTION_ORDER_DJ was not allowed, so case could not proceed

https://tools.hmcts.net/jira/browse/CIV-7564

```
[ ] Yes
[x ] No
```
