### PR TITLE
CIV-0000 updates based on CIV-7564, adding TAKE_CASE_OFFLINE to same …

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
@@ -281,7 +281,8 @@ public class FlowStateAllowedEventService {
                 INITIATE_GENERAL_APPLICATION,
                 CREATE_SDO,
                 NotSuitable_SDO,
-                migrateCase
+                migrateCase,
+                TAKE_CASE_OFFLINE
             )
         ),
 
@@ -306,7 +307,8 @@ public class FlowStateAllowedEventService {
                 STANDARD_DIRECTION_ORDER_DJ,
                 CREATE_SDO,
                 NotSuitable_SDO,
-                migrateCase
+                migrateCase,
+                TAKE_CASE_OFFLINE
             )
         ),
 
@@ -331,7 +333,8 @@ public class FlowStateAllowedEventService {
                 STANDARD_DIRECTION_ORDER_DJ,
                 CREATE_SDO,
                 NotSuitable_SDO,
-                migrateCase
+                migrateCase,
+                TAKE_CASE_OFFLINE
             )
         ),
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventServiceTest.java
@@ -325,8 +325,8 @@ class FlowStateAllowedEventServiceTest {
                         DEFAULT_JUDGEMENT,
                         STANDARD_DIRECTION_ORDER_DJ,
                         CHANGE_SOLICITOR_EMAIL,
-                        migrateCase
-
+                        migrateCase,
+                        TAKE_CASE_OFFLINE
                     }
                 ),
                 of(
@@ -350,7 +350,8 @@ class FlowStateAllowedEventServiceTest {
                         NotSuitable_SDO,
                         DEFAULT_JUDGEMENT,
                         STANDARD_DIRECTION_ORDER_DJ,
-                        migrateCase
+                        migrateCase,
+                        TAKE_CASE_OFFLINE
                     }
                 ),
                 of(
@@ -374,7 +375,8 @@ class FlowStateAllowedEventServiceTest {
                         NotSuitable_SDO,
                         DEFAULT_JUDGEMENT,
                         STANDARD_DIRECTION_ORDER_DJ,
-                        migrateCase
+                        migrateCase,
+                        TAKE_CASE_OFFLINE
                     }
                 ),
                 of(


### PR DESCRIPTION
Update flow state for event TAKE_CASE_OFFLINE to allowed it in flowstates

NOTIFICATION_ACKNOWLEDGED
NOTIFICATION_ACKNOWLEDGED_TIME_EXTENSION
CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION

https://tools.hmcts.net/jira/browse/CIV-7564 added STANDARD_DIRECTION_ORDER_DJ  to be allowed in above, this adds on to now allow TAKE_CASE_OFFLINE 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
