### PR TITLE
CIV-7682 Fix git convention enforcement for merge

### DIFF
--- a/.git-config/hooks/commit-msg
+++ b/.git-config/hooks/commit-msg
@@ -4,6 +4,7 @@ REGEX_ISSUE_ID='^CIV-[0-9]+ .*'
 REGEX_GENERIC_TASK='^CIV-TASK .*'
 REGEX_RENOVATE='^Update .*'
 REGEX_RENOVATE_BRANCH='renovate\/.*'
+REGEX_MERGE=`Merge branch .*`
 
 COMMIT_MESSAGE=$(head -n 1 "$1")
 
@@ -26,6 +27,12 @@ if [[ $COMMIT_MESSAGE =~ $REGEX_RENOVATE ]]; then
     exit 0
   fi
 fi
+
+if [[ $COMMIT_MESSAGE =~ $REGEX_MERGE ]]; then
+  # This is a merge done locally. All good.
+  exit 0
+fi
+
 
 # We don't recognize this commit message format, so it's invalid to us. We report an error to the user and exit.
 echo "The provided commit message is invalid. Commit messages must start with CIV-nnnn or CIV-TASK"

--- a/README.md
+++ b/README.md
@@ -149,6 +149,26 @@ To publish your contracts:
 ```
 git config --local core.hooksPath .git-config/hooks
 ```
+Once the above is done, you will be required to follow specific conventions for your commit messages and branch names.
+
+If you violate a convention, the git error message will report clearly the convention you should follow and provide
+additional information where necessary.
+
+*Optional:*
+* Install this plugin in Chrome: https://github.com/refined-github/refined-github
+
+  It will automatically set the title for new PRs according to the first commit message, so you won't have to change it manually.
+
+  Note that it will also alter other behaviours in GitHub. Hopefully these will also be improvements to you.
+
+*In case of problems*
+
+1. Get in touch with your Technical Lead so that they can get you unblocked
+2. If the rare eventuality that the above is not possible, you can disable enforcement of conventions using the following command
+
+   `git config --local --unset core.hooksPath`
+
+   Still, you shouldn't be doing it so make sure you get in touch with a Technical Lead soon afterwards.
 
 ## License
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-7682


### Change description ###
The enforcement of git conventions was getting in the way of local merges. This should fix it.
Also some small improvements to the documentation.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
