### PR TITLE
CIV-7682 Fix git conventions

### DIFF
--- a/.git-config/hooks/commit-msg
+++ b/.git-config/hooks/commit-msg
@@ -4,7 +4,8 @@ REGEX_ISSUE_ID='^CIV-[0-9]+ .*'
 REGEX_GENERIC_TASK='^CIV-TASK .*'
 REGEX_RENOVATE='^Update .*'
 REGEX_RENOVATE_BRANCH='renovate\/.*'
-REGEX_MERGE=`Merge branch .*`
+REGEX_MERGE='Merge branch .*'
+REGEX_REVERT='Revert .*'
 
 COMMIT_MESSAGE=$(head -n 1 "$1")
 
@@ -30,6 +31,11 @@ fi
 
 if [[ $COMMIT_MESSAGE =~ $REGEX_MERGE ]]; then
   # This is a merge done locally. All good.
+  exit 0
+fi
+
+if [[ $COMMIT_MESSAGE =~ $REGEX_REVERT ]]; then
+  # This is a revert. All good.
   exit 0
 fi
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-7682


### Change description ###
- Fixed a wrong instruction
- Added support for revert message



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
