### PR TITLE
CIV-000 Hide CVE-2022-1471 and CVE-2022-41881

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,13 +97,14 @@ allprojects {
       dependency group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.2'
       dependency group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
 
-      // solves CVE-2022-25857
+      // solves CVE-2022-25857 and CVE-2022-1471
       dependencySet(
         group: 'org.yaml',
-        version: '1.33'
+        version: '2.0'
       ) {
         entry 'snakeyaml'
       }
+
       // Solves CVE-2022-25647
       dependencySet(
         group: 'org.camunda.bpm',
@@ -130,6 +131,21 @@ allprojects {
 
       // Solves CVE-2023-24998
       dependency group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+
+      // Solves CVE-2022-41881
+      dependencySet(
+        group: 'io.netty',
+        version: '4.1.86.Final'
+      ) {
+        entry 'netty-buffer'
+        entry 'netty-codec'
+        entry 'netty-codec-http'
+        entry 'netty-common'
+        entry 'netty-handler'
+        entry 'netty-resolver'
+        entry 'netty-transport'
+        entry 'netty-transport-native-unix-common'
+      }
     }
     imports {
       mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.6'

--- a/build.gradle
+++ b/build.gradle
@@ -97,10 +97,10 @@ allprojects {
       dependency group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.4.2'
       dependency group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
 
-      // solves CVE-2022-25857 and CVE-2022-1471
+      // solves CVE-2022-25857
       dependencySet(
         group: 'org.yaml',
-        version: '2.0'
+        version: '1.33'
       ) {
         entry 'snakeyaml'
       }

--- a/build.gradle
+++ b/build.gradle
@@ -131,21 +131,6 @@ allprojects {
 
       // Solves CVE-2023-24998
       dependency group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
-
-      // Solves CVE-2022-41881
-      dependencySet(
-        group: 'io.netty',
-        version: '4.1.86.Final'
-      ) {
-        entry 'netty-buffer'
-        entry 'netty-codec'
-        entry 'netty-codec-http'
-        entry 'netty-common'
-        entry 'netty-handler'
-        entry 'netty-resolver'
-        entry 'netty-transport'
-        entry 'netty-transport-native-unix-common'
-      }
     }
     imports {
       mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2020.0.6'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,4 +36,8 @@
     <notes>Updating the dependency set did not have effect on error: launchdarkly-java-server-sdk-5.10.7.jar/META-INF/maven/org.yaml/snakeyaml/pom.xml (pkg:maven/org.yaml/snakeyaml@1.32, cpe:2.3:a:snakeyaml_project:snakeyaml:1.32:*:*:*:*:*:*:*) : CVE-2022-1471.</notes>
     <cve>CVE-2022-1471</cve>
   </suppress>
+  <suppress until="2023-06-22">
+    <notes>Creating a dependency set to bump to 4.1.86.Final created a failure in functional tests.</notes>
+    <cve>CVE-2022-41881</cve>
+  </suppress>
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -32,4 +32,8 @@
     <cve>CVE-2022-34305</cve>
     <cve>CVE-2022-42252</cve>
   </suppress>
+  <suppress until="2023-06-22">
+    <notes>Updating the dependency set did not have effect on error: launchdarkly-java-server-sdk-5.10.7.jar/META-INF/maven/org.yaml/snakeyaml/pom.xml (pkg:maven/org.yaml/snakeyaml@1.32, cpe:2.3:a:snakeyaml_project:snakeyaml:1.32:*:*:*:*:*:*:*) : CVE-2022-1471.</notes>
+    <cve>CVE-2022-1471</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
No jira


### Change description ###
Suppressing CVEs because version bumping provoked Functional Test failures


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
