### PR TITLE
CIV-6668 Create message correlation with tenant-id 

### DIFF
--- a/bin/import-bpmn-diagram.sh
+++ b/bin/import-bpmn-diagram.sh
@@ -14,6 +14,7 @@ do
     -H "Accept: application/json" \
     -H "ServiceAuthorization: Bearer ${serviceToken}" \
     -F "deployment-name=$(date +"%Y%m%d-%H%M%S")-$(basename ${file})" \
+    -F "tenant-id=civil" \
     -F "file=@${filepath}/$(basename ${file})")
 
 upload_http_code=$(echo "$uploadResponse" | tail -n1)

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/EventEmitterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/EventEmitterService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.civil.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.extension.rest.exception.RemoteProcessEngineException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.civil.event.DispatchBusinessProcessEvent;
@@ -15,6 +16,7 @@ import static java.lang.String.format;
 @Component
 public class EventEmitterService {
 
+    public static final String TENANT_ID = "civil";
     private final ApplicationEventPublisher applicationEventPublisher;
     private final RuntimeService runtimeService;
 
@@ -23,20 +25,40 @@ public class EventEmitterService {
         var businessProcess = caseData.getBusinessProcess();
         var camundaEvent = businessProcess.getCamundaEvent();
         log.info(format("Emitting %s camunda event for case: %d", camundaEvent, caseId));
+
+        boolean nullTenantAttempt = false;
         try {
             runtimeService.createMessageCorrelation(camundaEvent)
+                .tenantId(TENANT_ID)
                 .setVariable("caseId", caseId)
                 .correlateStartMessage();
-
             if (dispatchProcess) {
                 applicationEventPublisher.publishEvent(new DispatchBusinessProcessEvent(caseId, businessProcess));
             }
-
-            log.info("Camunda event emitted successfully");
-        } catch (Exception ex) {
-            log.error(format("Emitting %s camunda event failed for case: %d, message: %s",
-                             camundaEvent, caseId, ex.getMessage()
+            log.info("Camunda event emitted successfully with tenant");
+        } catch (RemoteProcessEngineException ex) {
+            nullTenantAttempt = true;
+        } catch (Exception e) {
+            log.error(format("Emitting %s camunda event failed for case: %d, tenant: %s, message: %s",
+                             camundaEvent, caseId, TENANT_ID, e.getMessage()
             ));
+        }
+
+        if (nullTenantAttempt) {
+            try {
+                runtimeService.createMessageCorrelation(camundaEvent)
+                    .setVariable("caseId", caseId)
+                    .withoutTenantId()
+                    .correlateStartMessage();
+                if (dispatchProcess) {
+                    applicationEventPublisher.publishEvent(new DispatchBusinessProcessEvent(caseId, businessProcess));
+                }
+                log.info("Camunda event emitted successfully without tenant");
+            } catch (Exception e) {
+                log.error(format("Emitting %s camunda event failed for case: %d, message: %s",
+                                 camundaEvent, caseId, e.getMessage()
+                ));
+            }
         }
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-6668

### Change description ###

Emit Camunda messages with tenant id, if definition doesn't exist attempt without tenant id

Added new tests for changes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
