### PR TITLE
CIV-TASK Support revert branch naming convention and CIV-TASK

### DIFF
--- a/.git-config/hooks/pre-commit
+++ b/.git-config/hooks/pre-commit
@@ -2,6 +2,7 @@
 LOCAL_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 
 RENOVATE_PREFIX="^renovate/"
+GITHUB_REVERT_PREFIX="^revert-[0-9]{1,5}.*"
 
 VALID_PREFIXES="^(feat|spike|fix|test|refactor)\/(.*)"
 VALID_TICKET_1='CIV-[0-9]{1,5}$'
@@ -16,15 +17,20 @@ if [[ $LOCAL_BRANCH =~ $RENOVATE_PREFIX ]]; then
   exit 0
 fi
 
+if [[ $LOCAL_BRANCH =~ $GITHUB_REVERT_PREFIX ]]; then
+  # This is a revert branch created from GitHub. We don't check anything else.
+  exit 0
+fi
+
+
 if [[ ! $LOCAL_BRANCH =~ $VALID_PREFIXES ]]; then
   # No valid prefix, we need to fail the script
-  echo "The provided branch prefix is missing or invalid. All branches must start with one of:"
+  echo "The provided branch prefix is missing or invalid. All branches not created automatically must start with one of:"
   echo "  feat/"
   echo "  spike/"
   echo "  fix/"
   echo "  test/"
   echo "  refactor/"
-  echo "  renovate/"
   echo ""
   echo "Please rename your branch. To rename your branch you can use the following command:"
   echo "  git branch -m <newname>"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,6 @@ jobs:
     steps:
     - uses: deepakputhraya/action-pr-title@master
       with:
-        regex: '^(CIV-[0-9]{3,4} [a-zA-Z0-9._\- ]+)|(\[Snyk\].+)$' # Regex the title should match.
+        regex: '^(CIV-[0-9]{3,4} [a-zA-Z0-9._\- ]+)|(CIV-TASK [a-zA-Z0-9._\- ]+)|(\[Snyk\].+)$' # Regex the title should match.
         allowed_prefixes: 'CIV-,[Snyk]' # title should start with the given prefix
         prefix_case_sensitive: true # title prefix are case insensitive:


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
- Supports "revert-" naming convention for branches, as those branches are created by github automatically
- Supports CIV-TASK in the PR title as it's allowed in commits. Will enable us to stop using CIV-0000 to get around that.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
