### PR TITLE
CIV_7999 - CUI - FullDefence on both Defendant and Claimant makes the case goes offline

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceSpecCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceSpecCallbackHandler.java
@@ -55,7 +55,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -220,7 +219,7 @@ public class RespondToDefenceSpecCallbackHandler extends CallbackHandler
     private void setMediationConditionFlag(CaseData caseData, CaseData.CaseDataBuilder<?, ?> updatedCaseData) {
         DefendantResponseShowTag mediationFlag = respondentMediationService.setMediationRequired(caseData);
         if (mediationFlag != null) {
-            Set<DefendantResponseShowTag> showConditionFlags = new HashSet<>(caseData.getShowConditionFlags());
+            Set<DefendantResponseShowTag> showConditionFlags = caseData.getShowConditionFlags();
             showConditionFlags.add(mediationFlag);
             updatedCaseData.showConditionFlags(showConditionFlags);
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.civil.enums.CaseNoteType;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.ClaimType;
 import uk.gov.hmcts.reform.civil.enums.EmploymentTypeCheckboxFixedListLRspec;
+import uk.gov.hmcts.reform.civil.enums.MediationDecision;
 import uk.gov.hmcts.reform.civil.enums.MultiPartyResponseTypeFlags;
 import uk.gov.hmcts.reform.civil.enums.MultiPartyScenario;
 import uk.gov.hmcts.reform.civil.enums.PersonalInjuryType;
@@ -46,6 +47,8 @@ import uk.gov.hmcts.reform.civil.model.caseprogression.HearingOtherComments;
 import uk.gov.hmcts.reform.civil.model.caseprogression.RevisedHearingRequirements;
 import uk.gov.hmcts.reform.civil.model.caseprogression.UploadEvidenceExpert;
 import uk.gov.hmcts.reform.civil.model.caseprogression.UploadEvidenceWitness;
+import uk.gov.hmcts.reform.civil.model.citizenui.CaseDataLiP;
+import uk.gov.hmcts.reform.civil.model.citizenui.ClaimantMediationLip;
 import uk.gov.hmcts.reform.civil.model.common.DynamicList;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.model.common.MappableObject;
@@ -844,7 +847,7 @@ public class CaseData extends CaseDataParent implements MappableObject {
     }
 
     @JsonIgnore
-    public boolean isMediationAcceptedByDefendant() {
+    public boolean hasDefendantAgreedToFreeMediation() {
         return YES.equals(getResponseClaimMediationSpecRequired());
     }
 
@@ -859,5 +862,13 @@ public class CaseData extends CaseDataParent implements MappableObject {
         return multiPartyScenario.equals(TWO_V_ONE)
             && YES.equals(getDefendantSingleResponseToBothClaimants())
             && YES.equals(getApplicant1ProceedWithClaimSpec2v1());
+    }
+
+    @JsonIgnore
+    public boolean hasClaimantAgreedToFreeMediation() {
+        return Optional.ofNullable(getCaseDataLiP())
+            .map(CaseDataLiP::getApplicant1ClaimMediationSpecRequiredLip)
+            .map(ClaimantMediationLip::getHasAgreedFreeMediation)
+            .filter(MediationDecision.Yes::equals).isPresent();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/citizenui/RespondentMediationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/citizenui/RespondentMediationService.java
@@ -31,12 +31,12 @@ public class RespondentMediationService {
     private DefendantResponseShowTag getDefendantResponseShowTagFor1v1(CaseData caseData) {
         switch (caseData.getRespondent1ClaimResponseTypeForSpec()) {
             case FULL_DEFENCE:
-                if (caseData.isFullDefence() && caseData.isMediationAcceptedByDefendant()) {
+                if (caseData.isFullDefence() && caseData.hasDefendantAgreedToFreeMediation()) {
                     return DefendantResponseShowTag.CLAIMANT_MEDIATION_ONE_V_ONE;
                 }
                 break;
             case PART_ADMISSION:
-                if (caseData.isMediationAcceptedByDefendant()) {
+                if (caseData.hasDefendantAgreedToFreeMediation()) {
                     if (caseData.hasDefendantNotPaid()) {
                         return DefendantResponseShowTag.CLAIMANT_MEDIATION_ONE_V_ONE;
                     } else if (caseData.isSettlementDeclinedByClaimant()) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicate.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicate.java
@@ -881,6 +881,9 @@ public class FlowPredicate {
                 .filter(YesOrNo.NO::equals).isPresent()) {
                 return false;
             }
+            if (!caseData.hasClaimantAgreedToFreeMediation()) {
+                return false;
+            }
             return true;
         }
         return false;

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicateTest.java
@@ -5,12 +5,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.civil.enums.AllocatedTrack;
+import uk.gov.hmcts.reform.civil.enums.MediationDecision;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseType;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
 import uk.gov.hmcts.reform.civil.model.SmallClaimMedicalLRspec;
+import uk.gov.hmcts.reform.civil.model.citizenui.CaseDataLiP;
+import uk.gov.hmcts.reform.civil.model.citizenui.ClaimantMediationLip;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 
 import java.time.LocalDate;
@@ -2155,11 +2158,12 @@ class FlowPredicateTest {
                 .build();
 
             Map<YesOrNo[], Boolean> defClaim = Map.of(
-                new YesOrNo[]{null, null}, false,
-                new YesOrNo[]{NO, NO}, false,
-                new YesOrNo[]{NO, YES}, false,
-                new YesOrNo[]{YES, NO}, false,
-                new YesOrNo[]{YES, YES}, true
+                new YesOrNo[]{null, null, NO}, false,
+                new YesOrNo[]{NO, NO, NO}, false,
+                new YesOrNo[]{NO, YES, NO}, false,
+                new YesOrNo[]{YES, NO, NO}, false,
+                new YesOrNo[]{YES, NO, YES}, false,
+                new YesOrNo[]{YES, YES, YES}, true
             );
 
             defClaim.forEach((whoAgrees, expected) -> {
@@ -2168,6 +2172,10 @@ class FlowPredicateTest {
                     .applicant1ClaimMediationSpecRequired(SmallClaimMedicalLRspec.builder()
                                                               .hasAgreedFreeMediation(whoAgrees[1])
                                                               .build())
+                    .caseDataLiP(CaseDataLiP.builder()
+                                     .applicant1ClaimMediationSpecRequiredLip(ClaimantMediationLip.builder()
+                                     .hasAgreedFreeMediation(whoAgrees[2].equals(NO) ? MediationDecision.No : MediationDecision.Yes)
+                                     .build()).build())
                     .build();
                 Assertions.assertEquals(expected, FlowPredicate.allAgreedToMediation.test(cd));
             });
@@ -2183,11 +2191,12 @@ class FlowPredicateTest {
                 .build();
 
             Map<YesOrNo[], Boolean> defClaim = Map.of(
-                new YesOrNo[]{null, null}, false,
-                new YesOrNo[]{NO, NO}, false,
-                new YesOrNo[]{NO, YES}, false,
-                new YesOrNo[]{YES, NO}, false,
-                new YesOrNo[]{YES, YES}, true
+                new YesOrNo[]{null, null, NO}, false,
+                new YesOrNo[]{NO, NO, NO}, false,
+                new YesOrNo[]{NO, YES, NO}, false,
+                new YesOrNo[]{YES, NO, NO}, false,
+                new YesOrNo[]{YES, NO, YES}, false,
+                new YesOrNo[]{YES, YES, YES}, true
             );
 
             defClaim.forEach((whoAgrees, expected) -> {
@@ -2196,6 +2205,10 @@ class FlowPredicateTest {
                     .applicant1ClaimMediationSpecRequired(SmallClaimMedicalLRspec.builder()
                                                               .hasAgreedFreeMediation(whoAgrees[1])
                                                               .build())
+                    .caseDataLiP(CaseDataLiP.builder()
+                                     .applicant1ClaimMediationSpecRequiredLip(ClaimantMediationLip.builder()
+                                     .hasAgreedFreeMediation(whoAgrees[2].equals(NO) ? MediationDecision.No : MediationDecision.Yes)
+                                     .build()).build())
                     .build();
                 Assertions.assertEquals(expected, FlowPredicate.allAgreedToMediation.test(cd));
             });
@@ -2211,15 +2224,16 @@ class FlowPredicateTest {
                 .build();
 
             Map<YesOrNo[], Boolean> defClaim = Map.of(
-                new YesOrNo[]{null, null, null}, false,
-                new YesOrNo[]{NO, NO, NO}, false,
-                new YesOrNo[]{NO, NO, YES}, false,
-                new YesOrNo[]{NO, YES, NO}, false,
-                new YesOrNo[]{NO, YES, YES}, false,
-                new YesOrNo[]{YES, NO, NO}, false,
-                new YesOrNo[]{YES, NO, YES}, false,
-                new YesOrNo[]{YES, YES, NO}, false,
-                new YesOrNo[]{YES, YES, YES}, true
+                new YesOrNo[]{null, null, null, NO}, false,
+                new YesOrNo[]{NO, NO, NO, NO}, false,
+                new YesOrNo[]{NO, NO, YES, NO}, false,
+                new YesOrNo[]{NO, YES, NO, NO}, false,
+                new YesOrNo[]{NO, YES, YES, NO}, false,
+                new YesOrNo[]{YES, NO, NO, NO}, false,
+                new YesOrNo[]{YES, NO, YES, NO}, false,
+                new YesOrNo[]{YES, YES, NO, NO}, false,
+                new YesOrNo[]{YES, NO, NO, YES}, false,
+                new YesOrNo[]{YES, YES, YES, YES}, true
             );
 
             defClaim.forEach((whoAgrees, expected) -> {
@@ -2229,6 +2243,10 @@ class FlowPredicateTest {
                     .applicant1ClaimMediationSpecRequired(SmallClaimMedicalLRspec.builder()
                                                               .hasAgreedFreeMediation(whoAgrees[2])
                                                               .build())
+                    .caseDataLiP(CaseDataLiP.builder()
+                                     .applicant1ClaimMediationSpecRequiredLip(ClaimantMediationLip.builder()
+                                     .hasAgreedFreeMediation(whoAgrees[3].equals(NO) ? MediationDecision.No : MediationDecision.Yes)
+                                     .build()).build())
                     .build();
                 Assertions.assertEquals(expected, FlowPredicate.allAgreedToMediation.test(cd));
             });
@@ -2242,15 +2260,16 @@ class FlowPredicateTest {
                 .build();
 
             Map<YesOrNo[], Boolean> defClaim = Map.of(
-                new YesOrNo[]{null, null, null}, false,
-                new YesOrNo[]{NO, NO, NO}, false,
-                new YesOrNo[]{NO, NO, YES}, false,
-                new YesOrNo[]{NO, YES, NO}, false,
-                new YesOrNo[]{NO, YES, YES}, false,
-                new YesOrNo[]{YES, NO, NO}, false,
-                new YesOrNo[]{YES, NO, YES}, false,
-                new YesOrNo[]{YES, YES, NO}, false,
-                new YesOrNo[]{YES, YES, YES}, true
+                new YesOrNo[]{null, null, null, NO}, false,
+                new YesOrNo[]{NO, NO, NO, NO}, false,
+                new YesOrNo[]{NO, NO, YES, NO}, false,
+                new YesOrNo[]{NO, YES, NO, NO}, false,
+                new YesOrNo[]{NO, YES, YES, NO}, false,
+                new YesOrNo[]{YES, NO, NO, NO}, false,
+                new YesOrNo[]{YES, NO, YES, NO}, false,
+                new YesOrNo[]{YES, YES, NO, NO}, false,
+                new YesOrNo[]{YES, NO, NO, YES}, false,
+                new YesOrNo[]{YES, YES, YES, YES}, true
             );
 
             defClaim.forEach((whoAgrees, expected) -> {
@@ -2262,6 +2281,10 @@ class FlowPredicateTest {
                     .applicantMPClaimMediationSpecRequired(SmallClaimMedicalLRspec.builder()
                                                                .hasAgreedFreeMediation(whoAgrees[2])
                                                                .build())
+                    .caseDataLiP(CaseDataLiP.builder()
+                                     .applicant1ClaimMediationSpecRequiredLip(ClaimantMediationLip.builder()
+                                     .hasAgreedFreeMediation(whoAgrees[3].equals(NO) ? MediationDecision.No : MediationDecision.Yes)
+                                     .build()).build())
                     .build();
                 Assertions.assertEquals(expected, FlowPredicate.allAgreedToMediation.test(cd));
             });

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/StateFlowEngineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/StateFlowEngineTest.java
@@ -13,10 +13,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.enums.AllocatedTrack;
+import uk.gov.hmcts.reform.civil.enums.MediationDecision;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseType;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.model.citizenui.CaseDataLiP;
+import uk.gov.hmcts.reform.civil.model.citizenui.ClaimantMediationLip;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
@@ -4439,6 +4442,10 @@ class StateFlowEngineTest {
                 // defendant agrees to mediation
                 .responseClaimTrack(AllocatedTrack.SMALL_CLAIM.name())
                 .responseClaimMediationSpecRequired(YES)
+                .caseDataLiP(CaseDataLiP.builder()
+                                 .applicant1ClaimMediationSpecRequiredLip(ClaimantMediationLip.builder()
+                                 .hasAgreedFreeMediation(MediationDecision.Yes)
+                                 .build()).build())
                 .build();
 
             // When


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-7999

### Change description ###
**Defect** :  Defendant claim for Full defence and when claimant agree to procced with  the claim and submit his response then the case goes to offline instead  'JUDICIAL_REFERRAL' state. 

**Solution**: I have added a partial fix for Full Defence responseType. If 'Claimant has not agreeed for free mediation and submit the response then case move to '**JUDICIAL_REFERRAL**' state.'
Another fix would be 'If claimant has agreed for free mediation ' and submit the response then case should move to '**IN_MEDIATION**' 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
