### PR TITLE
CIV-8005 Sonarqube exclusions removed 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,7 +319,7 @@ sonarqube {
     property "sonar.projectName", "CIVIL :: service"
     property "sonar.projectKey", "civil-service"
     property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
-    property "sonar.coverage.exclusions", "**/model/**, **/config/**/*Configuration.java, **/testingsupport/**, **/*ExternalTaskListener.java, **/stereotypes/**, **/*Exception.java, **/PostcodeValidator.java, **/BundleRequestExecutor.java, **/InformAgreedExtensionDateCallbackHandler.java, **/EventHistoryMapper*.java, **/*Spec*.java, **/model/hearingvalues/**, **/enums/hearing/**, **/fees/client/**"
+    property "sonar.coverage.exclusions", "**/model/**, **/config/**/*Configuration.java, **/testingsupport/**, **/*ExternalTaskListener.java, **/stereotypes/**, **/*Exception.java, **/EventHistoryMapper*.java, **/*Spec*.java, **/model/hearingvalues/**, **/enums/hearing/**, **/fees/client/**"
     property "sonar.cpd.exclusions", "**/*DocumentManagementService.java, **/*Spec*.java"
     property "sonar.host.url", "https://sonar.reform.hmcts.net/"
   }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-8005


### Change description ###
Sonarqube exclusions removed for PostcodeValidator,BundleRequestExecutor,InformAgreedExtensionDateCallbackHandler


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
