### PR TITLE
CIV-7927 Map keys in interpreter language

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/hearingsmappings/CaseFlagsToHearingValueMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/hearingsmappings/CaseFlagsToHearingValueMapper.java
@@ -44,10 +44,32 @@ public class CaseFlagsToHearingValueMapper {
     }
 
     public static String getInterpreterLanguage(List<FlagDetail> flagDetails) {
-        var flags = filter(flagDetails, CaseFlagPredicates.isActive(), CaseFlagPredicates.isHearingRelevant(),
-                           CaseFlagPredicates.hasLanguageInterpreterFlag()
+        String spokenLanguageInterpreter = getSpokenLanguageInterpreter(flagDetails);
+        String signLanguageInterpreter = getSignLanguageInterpreter(flagDetails);
+
+        return spokenLanguageInterpreter != null ? spokenLanguageInterpreter : signLanguageInterpreter;
+    }
+
+    private static String getSpokenLanguageInterpreter(List<FlagDetail> flagDetails) {
+        var flags = filter(
+            flagDetails,
+            CaseFlagPredicates.isActive(),
+            CaseFlagPredicates.isHearingRelevant(),
+            CaseFlagPredicates.hasLanguageInterpreterFlag()
         );
-        return flags.stream().count() > 0 ? flags.get(0).getSubTypeValue() : null;
+
+        return flags.stream().count() > 0 ? flags.get(0).getSubTypeKey() : null;
+    }
+
+    private static String getSignLanguageInterpreter(List<FlagDetail> flagDetails) {
+        var flags = filter(
+            flagDetails,
+            CaseFlagPredicates.isActive(),
+            CaseFlagPredicates.isHearingRelevant(),
+            CaseFlagPredicates.hasSignLanguageInterpreterFlag()
+        );
+
+        return flags.stream().count() > 0 ? flags.get(0).getSubTypeKey() : null;
     }
 
     public static String getCustodyStatus(List<FlagDetail> flagDetails) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseFlagPredicates.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/CaseFlagPredicates.java
@@ -40,6 +40,10 @@ public class CaseFlagPredicates {
         return flagDetail -> LANGUAGE_INTERPRETER_FLAGS.contains(flagDetail.getFlagCode());
     }
 
+    public static Predicate<FlagDetail> hasSignLanguageInterpreterFlag() {
+        return flagDetail -> SIGN_LANGUAGE_INTERPRETER_FLAGS.contains(flagDetail.getFlagCode());
+    }
+
     public static Predicate<FlagDetail> hasCaseInterpreterRequiredFlag() {
         return flagDetail -> SIGN_LANGUAGE_INTERPRETER_FLAGS.contains(flagDetail.getFlagCode())
             || LANGUAGE_INTERPRETER_FLAGS.contains(flagDetail.getFlagCode());

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/CaseFlagsToHearingValueMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/CaseFlagsToHearingValueMapperTest.java
@@ -120,6 +120,13 @@ public class CaseFlagsToHearingValueMapperTest {
         }
 
         @Test
+        public void shouldReturnNullWhenNoFlags() {
+            List<FlagDetail> flagDetails = List.of();
+
+            assertEquals(null, getInterpreterLanguage(flagDetails));
+        }
+
+        @Test
         public void shouldReturnSignLanguageKeyWhenNoSpokenLanguageKey() {
             FlagDetail flagDetail1 = FlagDetail.builder()
                 .status("Active")
@@ -171,7 +178,15 @@ public class CaseFlagsToHearingValueMapperTest {
                 .subTypeValue("WELSH")
                 .build();
 
-            List<FlagDetail> flagDetails = List.of(flagDetail1, flagDetail2, flagDetail3);
+            FlagDetail flagDetail4 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .subTypeKey("sign-sse")
+                .subTypeValue("Speech Supported English (SSE)")
+                .flagCode("RA0042")
+                .build();
+
+            List<FlagDetail> flagDetails = List.of(flagDetail1, flagDetail2, flagDetail3, flagDetail4);
 
             assertEquals("fra", getInterpreterLanguage(flagDetails));
         }

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/CaseFlagsToHearingValueMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/CaseFlagsToHearingValueMapperTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.utils;
 
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
@@ -68,24 +69,142 @@ public class CaseFlagsToHearingValueMapperTest {
         assertEquals(true, getAdditionalSecurity(flagDetails));
     }
 
-    @Test
-    public void testHasLanguageInterpreterFlag() {
-        FlagDetail flagDetail1 = FlagDetail.builder()
-            .status("Active")
-            .hearingRelevant(YES)
-            .flagCode("PF0015")
-            .subTypeValue("english")
-            .build();
+    @Nested
+    class GetLanguageInterpreter {
+        @Test
+        public void shouldReturnLanguageInterpreterFlag() {
+            FlagDetail flagDetail1 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .subTypeKey("fra")
+                .subTypeValue("French")
+                .build();
 
-        FlagDetail flagDetail2 = FlagDetail.builder()
-            .status("INACTIVE")
-            .hearingRelevant(YES)
-            .flagCode("PF0015")
-            .build();
+            FlagDetail flagDetail2 = FlagDetail.builder()
+                .status("INACTIVE")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .build();
 
-        List<FlagDetail> flagDetails = List.of(flagDetail1, flagDetail2);
+            List<FlagDetail> flagDetails = List.of(flagDetail1, flagDetail2);
 
-        assertEquals("english", getInterpreterLanguage(flagDetails));
+            assertEquals("fra", getInterpreterLanguage(flagDetails));
+        }
+
+        @Test
+        public void shouldReturnNullWhenNoSubValueKey() {
+            FlagDetail flagDetail1 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .subTypeValue("random")
+                .build();
+
+            FlagDetail flagDetail2 = FlagDetail.builder()
+                .status("INACTIVE")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .build();
+
+            FlagDetail flagDetail3 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .subTypeValue("American Sign Language")
+                .flagCode("RA0042")
+                .build();
+
+            List<FlagDetail> flagDetails = List.of(flagDetail1, flagDetail2, flagDetail3);
+
+            assertEquals(null, getInterpreterLanguage(flagDetails));
+        }
+
+        @Test
+        public void shouldReturnSignLanguageKeyWhenNoSpokenLanguageKey() {
+            FlagDetail flagDetail1 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .subTypeValue("random")
+                .build();
+
+            FlagDetail flagDetail2 = FlagDetail.builder()
+                .status("INACTIVE")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .build();
+
+            FlagDetail flagDetail3 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .subTypeKey("sign-sse")
+                .subTypeValue("Speech Supported English (SSE)")
+                .flagCode("RA0042")
+                .build();
+
+            List<FlagDetail> flagDetails = List.of(flagDetail1, flagDetail2, flagDetail3);
+
+            assertEquals("sign-sse", getInterpreterLanguage(flagDetails));
+        }
+
+        @Test
+        public void shouldReturnFirstSpokenLanguageInterpreterFlag() {
+            FlagDetail flagDetail1 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .subTypeKey("fra")
+                .subTypeValue("French")
+                .build();
+
+            FlagDetail flagDetail2 = FlagDetail.builder()
+                .status("INACTIVE")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .build();
+
+            FlagDetail flagDetail3 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .subTypeKey("wel")
+                .subTypeValue("WELSH")
+                .build();
+
+            List<FlagDetail> flagDetails = List.of(flagDetail1, flagDetail2, flagDetail3);
+
+            assertEquals("fra", getInterpreterLanguage(flagDetails));
+        }
+
+        @Test
+        public void shouldReturnFirstSignLanguageInterpreterFlag() {
+            FlagDetail flagDetail1 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .subTypeKey("sign-sse")
+                .subTypeValue("Speech Supported English (SSE)")
+                .flagCode("RA0042")
+                .build();
+
+            FlagDetail flagDetail2 = FlagDetail.builder()
+                .status("INACTIVE")
+                .hearingRelevant(YES)
+                .flagCode("PF0015")
+                .build();
+
+            FlagDetail flagDetail3 = FlagDetail.builder()
+                .status("Active")
+                .hearingRelevant(YES)
+                .subTypeKey("sign")
+                .subTypeValue("Some other sign")
+                .flagCode("RA0042")
+                .build();
+
+            List<FlagDetail> flagDetails = List.of(flagDetail1, flagDetail2, flagDetail3);
+
+            assertEquals("sign-sse", getInterpreterLanguage(flagDetails));
+        }
+
     }
 
     @Test


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-7927


### Change description ###
- Update getInterpreterLanguage to return first first spoken language interpreter subTypeKey (or first sign language subTypeKey when no spoken language is available)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
