### PR TITLE
CIV-8460 Code fix for SNI-3708 : Judge receiving a callback error SDO

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicate.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowPredicate.java
@@ -834,6 +834,7 @@ public class FlowPredicate {
         caseData.getRespondent1PinToPostLRspec() != null;
 
     public static final Predicate<CaseData> allAgreedToMediation = caseData -> {
+
         boolean result = false;
         if (SPEC_CLAIM.equals(caseData.getCaseAccessCategory())
             && AllocatedTrack.SMALL_CLAIM.name().equals(caseData.getResponseClaimTrack())


### PR DESCRIPTION
I have 3 cases in My Tasks which I have deemed unsuitable for SDO. However, clicking on “Not suitable for SDO” results in the following error message:

Callback to service has been unsuccessful for event Not suitable for SDO url http://civil-service-prod.service.core-compute-prod.internal/cases/callbacks/about-to-start caseTypeId CIVIL caseEvent Id NotSuitable_SDO callbackType AboutToStar

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-8460


### Change description ###
Code fix for SNI-3708 : Judge receiving a callback error SDO



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
