### PR TITLE
Fix small typo in javadoc

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/NocNotificationUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/NocNotificationUtils.java
@@ -173,7 +173,7 @@ public class NocNotificationUtils {
     /**
      * Builds the case name based on the applicant 1 and applicant 2 if there is one vs respondent 1 and respondent 2
      * if there is one.
-     * @param caseData data with the party names in to build the case name
+     * @param caseData data with the party names to build the case name
      * @return String of the party names concatenated
      */
     public static String getCaseName(CaseData caseData) {


### PR DESCRIPTION
This change fixes a small mistake in the javadoc of `NocNotificationUtils#getCaseName` where an extra word was inserted.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!
