### PR TITLE
CIV-9614 Rollup unavailability dates from DJ

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/DefaultJudgementHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/DefaultJudgementHandler.java
@@ -20,6 +20,7 @@ import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.referencedata.model.LocationRefData;
 import uk.gov.hmcts.reform.civil.referencedata.LocationRefDataService;
+import uk.gov.hmcts.reform.civil.utils.UnavailabilityDatesUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -244,6 +245,7 @@ public class DefaultJudgementHandler extends CallbackHandler {
             caseDataBuilder
                 .hearingSupportRequirementsDJ(hearingSupportRequirementsDJ);
         }
+        UnavailabilityDatesUtils.rollUpUnavailabilityDatesForApplicantDJ(caseDataBuilder);
         caseDataBuilder.businessProcess(BusinessProcess.ready(DEFAULT_JUDGEMENT));
 
         return AboutToStartOrSubmitCallbackResponse.builder()

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -51,6 +51,8 @@ import uk.gov.hmcts.reform.civil.model.CorrectEmail;
 import uk.gov.hmcts.reform.civil.model.CourtLocation;
 import uk.gov.hmcts.reform.civil.model.DefendantPinToPostLRspec;
 import uk.gov.hmcts.reform.civil.model.Fee;
+import uk.gov.hmcts.reform.civil.model.HearingDates;
+import uk.gov.hmcts.reform.civil.model.HearingSupportRequirementsDJ;
 import uk.gov.hmcts.reform.civil.model.IdValue;
 import uk.gov.hmcts.reform.civil.model.IdamUserDetails;
 import uk.gov.hmcts.reform.civil.model.LengthOfUnemploymentComplexTypeLRspec;
@@ -451,6 +453,8 @@ public class CaseDataBuilder {
     private RespondentResponsePartAdmissionPaymentTimeLRspec defenceAdmitPartPaymentTimeRouteRequired;
     private ResponseOneVOneShowTag showResponseOneVOneFlag;
 
+    private HearingSupportRequirementsDJ hearingSupportRequirementsDJ;
+
     public CaseDataBuilder sameRateInterestSelection(SameRateInterestSelection sameRateInterestSelection) {
         this.sameRateInterestSelection = sameRateInterestSelection;
         return this;
@@ -780,6 +784,23 @@ public class CaseDataBuilder {
         return this;
     }
 
+    public CaseDataBuilder respondent2DQWithUnavailableDates() {
+        UnavailableDate unavailableDateRange = UnavailableDate.builder()
+            .fromDate(LocalDate.of(2023, 8, 20))
+            .toDate(LocalDate.of(2023, 8, 22))
+            .unavailableDateType(UnavailableDateType.DATE_RANGE)
+            .build();
+        UnavailableDate unavailableDate = UnavailableDate.builder()
+            .date(LocalDate.of(2023, 8, 20))
+            .unavailableDateType(UnavailableDateType.SINGLE_DATE)
+            .build();
+        this.respondent2DQ = Respondent2DQ.builder()
+            .respondent2DQHearing(Hearing.builder().hearingLength(MORE_THAN_DAY).unavailableDatesRequired(YES)
+                                      .unavailableDates(wrapElements(List.of(unavailableDate, unavailableDateRange))).build())
+            .build();
+        return this;
+    }
+
     public CaseDataBuilder applicant1DQWithUnavailableDateRange() {
         UnavailableDate unavailableDate = UnavailableDate.builder()
             .fromDate(LocalDate.now().plusDays(1))
@@ -801,6 +822,23 @@ public class CaseDataBuilder {
         this.applicant1DQ = Applicant1DQ.builder()
             .applicant1DQHearing(Hearing.builder().hearingLength(ONE_DAY).unavailableDatesRequired(YES)
                                       .unavailableDates(wrapElements(List.of(unavailableDate))).build())
+            .build();
+        return this;
+    }
+
+    public CaseDataBuilder applicant2DQWithUnavailableDates() {
+        UnavailableDate unavailableDateRange = UnavailableDate.builder()
+            .fromDate(LocalDate.of(2023, 8, 20))
+            .toDate(LocalDate.of(2023, 8, 22))
+            .unavailableDateType(UnavailableDateType.DATE_RANGE)
+            .build();
+        UnavailableDate unavailableDate = UnavailableDate.builder()
+            .date(LocalDate.of(2023, 8, 20))
+            .unavailableDateType(UnavailableDateType.SINGLE_DATE)
+            .build();
+        this.applicant2DQ = Applicant2DQ.builder()
+            .applicant2DQHearing(Hearing.builder().hearingLength(MORE_THAN_DAY).unavailableDatesRequired(YES)
+                                      .unavailableDates(wrapElements(List.of(unavailableDate, unavailableDateRange))).build())
             .build();
         return this;
     }
@@ -2281,6 +2319,24 @@ public class CaseDataBuilder {
         trialHearingJudgesRecitalDJ = TrialHearingJudgesRecital
             .builder()
             .judgeNameTitle("test name")
+            .build();
+        return this;
+    }
+
+    public CaseDataBuilder atStateClaimantRequestsDJWithUnavailableDates() {
+        HearingDates singleDate = HearingDates.builder()
+            .hearingUnavailableFrom(LocalDate.of(2023, 8, 20))
+            .hearingUnavailableUntil(LocalDate.of(2023, 8, 20))
+            .build();
+
+        HearingDates dateRange = HearingDates.builder()
+            .hearingUnavailableFrom(LocalDate.of(2023, 8, 20))
+            .hearingUnavailableUntil(LocalDate.of(2023, 8, 22))
+            .build();
+
+        hearingSupportRequirementsDJ = HearingSupportRequirementsDJ.builder()
+            .hearingUnavailableDates(YES)
+            .hearingDates(wrapElements(List.of(singleDate, dateRange)))
             .build();
         return this;
     }
@@ -5970,6 +6026,7 @@ public class CaseDataBuilder {
             .defenceAdmitPartPaymentTimeRouteRequired(defenceAdmitPartPaymentTimeRouteRequired)
             .specDefenceFullAdmitted2Required(specDefenceFullAdmitted2Required)
             .showResponseOneVOneFlag(showResponseOneVOneFlag)
+            .hearingSupportRequirementsDJ(hearingSupportRequirementsDJ)
             .build();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/UnavailabilityDatesUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/UnavailabilityDatesUtilsTest.java
@@ -4,13 +4,20 @@ import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.civil.enums.dq.UnavailableDateType;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.UnavailableDate;
+import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
+import static uk.gov.hmcts.reform.civil.enums.dq.UnavailableDateType.DATE_RANGE;
+import static uk.gov.hmcts.reform.civil.enums.dq.UnavailableDateType.SINGLE_DATE;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.unwrapElements;
+import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
 
 public class UnavailabilityDatesUtilsTest {
 
@@ -24,7 +31,7 @@ public class UnavailabilityDatesUtilsTest {
         UnavailabilityDatesUtils.rollUpUnavailabilityDatesForRespondent(builder);
         UnavailableDate expected = UnavailableDate.builder()
             .date(LocalDate.now().plusDays(1))
-            .unavailableDateType(UnavailableDateType.SINGLE_DATE)
+            .unavailableDateType(SINGLE_DATE)
             .build();
         UnavailableDate result = unwrapElements(builder.build().getRespondent1().getUnavailableDates()).get(0);
         assertEquals(expected.getDate(), result.getDate());
@@ -52,10 +59,58 @@ public class UnavailabilityDatesUtilsTest {
         UnavailableDate expected = UnavailableDate.builder()
             .fromDate(LocalDate.now().plusDays(1))
             .toDate(LocalDate.now().plusDays(2))
-            .unavailableDateType(UnavailableDateType.SINGLE_DATE)
+            .unavailableDateType(SINGLE_DATE)
             .build();
         UnavailableDate result = unwrapElements(builder.build().getRespondent1().getUnavailableDates()).get(0);
         assertEquals(result.getFromDate(), expected.getFromDate());
+    }
+
+    @Test
+    public void shouldReturnDatesForBothRespondents1v2SameSolSingleResponse() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .atStateClaimDetailsNotified()
+            .respondentResponseIsSame(YES)
+            .multiPartyClaimOneDefendantSolicitor()
+            .respondent1DQWithUnavailableDateRange()
+            .build();
+        CaseData.CaseDataBuilder<?, ?> builder = caseData.toBuilder();
+        UnavailabilityDatesUtils.rollUpUnavailabilityDatesForRespondent(builder);
+        List<UnavailableDate> expected = List.of(UnavailableDate.builder()
+            .fromDate(LocalDate.now().plusDays(1))
+            .toDate(LocalDate.now().plusDays(2))
+            .unavailableDateType(DATE_RANGE)
+            .build());
+
+        List<UnavailableDate> expectedRespondent1Dates = unwrapElements(builder.build().getRespondent1().getUnavailableDates());
+        List<UnavailableDate> expectedRespondent2Dates = unwrapElements(builder.build().getRespondent2().getUnavailableDates());
+        assertThat(expectedRespondent1Dates).isEqualTo(expected);
+        assertThat(expectedRespondent2Dates).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReturnDatesForBothRespondents1v2SameSolDivergentResponse() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .atStateClaimDetailsNotified()
+            .multiPartyClaimOneDefendantSolicitor()
+            .respondent2DQWithUnavailableDates()
+            .build();
+        CaseData.CaseDataBuilder<?, ?> builder = caseData.toBuilder();
+        UnavailabilityDatesUtils.rollUpUnavailabilityDatesForRespondent(builder);
+
+        List<Element<UnavailableDate>> expected = wrapElements(
+            UnavailableDate.builder()
+                .date(LocalDate.of(2023, 8, 20))
+                .unavailableDateType(SINGLE_DATE)
+                .build(),
+            UnavailableDate.builder()
+                .fromDate(LocalDate.of(2023, 8, 20))
+                .toDate(LocalDate.of(2023, 8, 22))
+                .unavailableDateType(DATE_RANGE)
+                .build()
+        );
+
+        assertThat(builder.build().getRespondent1().getUnavailableDates()).isNull();
+        assertThat(builder.build().getRespondent2().getUnavailableDates()).isEqualTo(expected);
     }
 
     @Test
@@ -85,11 +140,110 @@ public class UnavailabilityDatesUtilsTest {
         UnavailabilityDatesUtils.rollUpUnavailabilityDatesForApplicant(builder);
         UnavailableDate expected = UnavailableDate.builder()
             .date(LocalDate.now().plusDays(1))
-            .unavailableDateType(UnavailableDateType.SINGLE_DATE)
+            .unavailableDateType(SINGLE_DATE)
             .build();
         UnavailableDate result = unwrapElements(builder.build().getApplicant1().getUnavailableDates()).get(0);
         assertEquals(expected.getDate(), result.getDate());
         assertEquals(expected.getUnavailableDateType(), result.getUnavailableDateType());
     }
 
+    @Test
+    public void shouldReturnDatesForBothApplicants2v1() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .multiPartyClaimTwoApplicants()
+            .atStateBothApplicantsRespondToDefenceAndProceed_2v1()
+            .applicant1DQWithUnavailableDateRange()
+            .build();
+        CaseData.CaseDataBuilder<?, ?> builder = caseData.toBuilder();
+        UnavailabilityDatesUtils.rollUpUnavailabilityDatesForApplicant(builder);
+        List<Element<UnavailableDate>> expected = wrapElements(UnavailableDate.builder()
+            .fromDate(LocalDate.now().plusDays(1))
+            .toDate(LocalDate.now().plusDays(2))
+            .unavailableDateType(DATE_RANGE)
+            .build());
+        List<Element<UnavailableDate>> expectedApplicant1 = builder.build().getApplicant1().getUnavailableDates();
+        List<Element<UnavailableDate>> expectedApplicant2 = builder.build().getApplicant2().getUnavailableDates();
+
+        assertThat(expectedApplicant1).isEqualTo(expected);
+        assertThat(expectedApplicant2).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReturnDatesForApplicant2DivergentResponse2v1() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .multiPartyClaimTwoApplicants()
+            .atState2v1Applicant1NotProceedApplicant2Proceeds()
+            .applicant2DQWithUnavailableDates()
+            .build();
+        CaseData.CaseDataBuilder<?, ?> builder = caseData.toBuilder();
+        UnavailabilityDatesUtils.rollUpUnavailabilityDatesForApplicant(builder);
+        List<UnavailableDate> expected = List.of(
+            UnavailableDate.builder()
+                .date(LocalDate.of(2023, 8, 20))
+                .unavailableDateType(UnavailableDateType.SINGLE_DATE)
+                .build(),
+            UnavailableDate.builder()
+                .fromDate(LocalDate.of(2023, 8, 20))
+                .toDate(LocalDate.of(2023, 8, 22))
+                .unavailableDateType(UnavailableDateType.DATE_RANGE)
+                .build());
+
+        List<UnavailableDate> expectedApplicant1 = unwrapElements(builder.build().getApplicant1().getUnavailableDates());
+        List<UnavailableDate> expectedApplicant2 = unwrapElements(builder.build().getApplicant2().getUnavailableDates());
+        assertThat(expectedApplicant1).isEqualTo(emptyList());
+        assertThat(expectedApplicant2).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldUnavailabilityDateWhenProvidedForApplicantDJ() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .atStateClaimDetailsNotified()
+            .atStateClaimantRequestsDJWithUnavailableDates()
+            .build();
+
+        CaseData.CaseDataBuilder<?, ?> builder = caseData.toBuilder();
+        UnavailabilityDatesUtils.rollUpUnavailabilityDatesForApplicantDJ(builder);
+
+        UnavailableDate expectedSingleDate = UnavailableDate.builder()
+            .unavailableDateType(SINGLE_DATE)
+            .date(LocalDate.of(2023, 8, 20))
+            .build();
+
+        UnavailableDate expectedDateRange = UnavailableDate.builder()
+            .unavailableDateType(DATE_RANGE)
+            .fromDate(LocalDate.of(2023, 8, 20))
+            .toDate(LocalDate.of(2023, 8, 22))
+            .build();
+
+        List<Element<UnavailableDate>> expected = wrapElements(List.of(expectedSingleDate, expectedDateRange));
+
+        assertThat(builder.build().getApplicant1().getUnavailableDates()).isEqualTo(expected);
+    }
+
+    @Test
+    public void shouldReturnUnavailabilityDateWhenProvidedForApplicantDJ2v1() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .atStateClaimDetailsNotified()
+            .multiPartyClaimTwoApplicants()
+            .atStateClaimantRequestsDJWithUnavailableDates()
+            .build();
+
+        CaseData.CaseDataBuilder<?, ?> builder = caseData.toBuilder();
+        UnavailabilityDatesUtils.rollUpUnavailabilityDatesForApplicantDJ(builder);
+
+        UnavailableDate expectedSingleDate = UnavailableDate.builder()
+            .unavailableDateType(SINGLE_DATE)
+            .date(LocalDate.of(2023, 8, 20))
+            .build();
+
+        UnavailableDate expectedDateRange = UnavailableDate.builder()
+            .unavailableDateType(DATE_RANGE)
+            .fromDate(LocalDate.of(2023, 8, 20))
+            .toDate(LocalDate.of(2023, 8, 22))
+            .build();
+
+        List<Element<UnavailableDate>> expected = wrapElements(List.of(expectedSingleDate, expectedDateRange));
+
+        assertThat(builder.build().getApplicant1().getUnavailableDates()).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CIV-9614

### Change description ###

- rollup unavailability dates added in DJ
- fix bugs with 1v2ss and 2v1 response journeys

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
