### PR TITLE
CIV-0000 Adding recipients list for send letter service

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -8,7 +8,7 @@ import uk.gov.hmcts.contino.GithubAPI
 def type = "java"
 def product = "civil"
 def component = "service"
-def ccdBranch = "CIV-9230"
+def ccdBranch = "master"
 def camundaBranch = "master"
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -8,7 +8,7 @@ import uk.gov.hmcts.contino.GithubAPI
 def type = "java"
 def product = "civil"
 def component = "service"
-def ccdBranch = "master"
+def ccdBranch = "CIV-9230"
 def camundaBranch = "master"
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 

--- a/build.gradle
+++ b/build.gradle
@@ -369,7 +369,7 @@ configurations.all {
 }
 
 dependencies {
-  implementation 'com.github.hmcts:civil-commons:1.0.17'
+  implementation 'com.github.hmcts:civil-commons:1.0.20'
 
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/ClaimContinuingOnlineRespondentPartyForSpecNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/ClaimContinuingOnlineRespondentPartyForSpecNotificationHandler.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.civil.service.Time;
 import uk.gov.hmcts.reform.civil.service.docmosis.pip.PiPLetterGenerator;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -99,8 +100,9 @@ public class ClaimContinuingOnlineRespondentPartyForSpecNotificationHandler exte
     private void generatePIPLetter(CallbackParams callbackParams) {
         CaseData caseData = callbackParams.getCaseData();
         byte[] letter = pipLetterGenerator.downloadLetter(caseData);
+        List<String> recipients = Arrays.asList(caseData.getRespondent1().getPartyName());
         bulkPrintService.printLetter(letter, caseData.getLegacyCaseReference(),
-                                     caseData.getLegacyCaseReference(), FIRST_CONTACT_PACK_LETTER_TYPE);
+                                     caseData.getLegacyCaseReference(), FIRST_CONTACT_PACK_LETTER_TYPE, recipients);
     }
 
     private void generatePIPEmail(CaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/SendSDOBulkPrintService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/SendSDOBulkPrintService.java
@@ -9,6 +9,8 @@ import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentDownloadService;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import static uk.gov.hmcts.reform.civil.handler.tasks.BaseExternalTaskHandler.log;
@@ -35,7 +37,9 @@ public class SendSDOBulkPrintService {
                     log.error("Failed getting letter content for SDO ");
                     throw new DocumentDownloadException(caseDocument.get().getValue().getDocumentName(), e);
                 }
-                bulkPrintService.printLetter(letterContent, caseData.getLegacyCaseReference(), caseData.getLegacyCaseReference(), SDO_ORDER_PACK_LETTER_TYPE);
+                List<String> recipients = Arrays.asList(caseData.getRespondent1().getPartyName());
+                bulkPrintService.printLetter(letterContent, caseData.getLegacyCaseReference(),
+                                             caseData.getLegacyCaseReference(), SDO_ORDER_PACK_LETTER_TYPE, recipients);
             }
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -209,6 +209,7 @@ notifications:
   claimantSolicitorAgreedExtensionDateForSpec: "5b6d65ea-a3b5-4e40-94e0-69dc7100c982"
   respondentSolicitorAgreedExtensionDateForSpec: "fbf3ed5e-3726-4009-8561-f856fb5dbda0"
   claimantSolicitorDefendantResponseForSpec: "635e7509-9fb6-4c80-9f0b-0476f96aad5c"
+  claimantSolicitorDefendantResponse1v2DSForSpec: "635e7509-9fb6-4c80-9f0b-0476f96aad5c"
   claimantSolicitorImmediatelyDefendantResponseForSpec: "263d7737-933d-4d0b-9f08-23847613f6a4"
   respondentSolicitorDefendantResponseForSpec: "9527f77e-b346-4527-b93c-c2affd39fa51"
   respondentDefendantResponseForSpec: "94c71894-9590-4995-aae0-edea94fc4594"

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/ClaimContinuingOnlineRespondentPartyForSpecNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/ClaimContinuingOnlineRespondentPartyForSpecNotificationHandlerTest.java
@@ -150,7 +150,7 @@ public class ClaimContinuingOnlineRespondentPartyForSpecNotificationHandlerTest 
                     caseData.getLegacyCaseReference(),
                     caseData.getLegacyCaseReference(),
                     "first-contact-pack",
-                    Arrays.asList("recipients")
+                    Arrays.asList(caseData.getRespondent1().getPartyName())
                 );
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/ClaimContinuingOnlineRespondentPartyForSpecNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/ClaimContinuingOnlineRespondentPartyForSpecNotificationHandlerTest.java
@@ -30,6 +30,7 @@ import uk.gov.hmcts.reform.civil.prd.model.Organisation;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
 
@@ -148,7 +149,8 @@ public class ClaimContinuingOnlineRespondentPartyForSpecNotificationHandlerTest 
                     LETTER_CONTENT,
                     caseData.getLegacyCaseReference(),
                     caseData.getLegacyCaseReference(),
-                    "first-contact-pack"
+                    "first-contact-pack",
+                    Arrays.asList("recipients")
                 );
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/SendSDOBulkPrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/SendSDOBulkPrintServiceTest.java
@@ -56,7 +56,7 @@ class SendSDOBulkPrintServiceTest {
                 caseData.getLegacyCaseReference(),
                 caseData.getLegacyCaseReference(),
                 SDO_ORDER_PACK_LETTER_TYPE,
-                Arrays.asList("recipients")
+                Arrays.asList(caseData.getRespondent1().getPartyName())
             );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/SendSDOBulkPrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/SendSDOBulkPrintServiceTest.java
@@ -13,6 +13,8 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentDownloadService;
 
+import java.util.Arrays;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -47,14 +49,14 @@ class SendSDOBulkPrintServiceTest {
 
         // when
         sendSDOBulkPrintService.sendSDOToDefendantLIP(caseData);
-
         // then
         verify(bulkPrintService)
             .printLetter(
                 LETTER_CONTENT,
                 caseData.getLegacyCaseReference(),
                 caseData.getLegacyCaseReference(),
-                SDO_ORDER_PACK_LETTER_TYPE
+                SDO_ORDER_PACK_LETTER_TYPE,
+                Arrays.asList("recipients")
             );
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/SendSDOBulkPrintServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/SendSDOBulkPrintServiceTest.java
@@ -10,7 +10,9 @@ import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
 import uk.gov.hmcts.reform.civil.documentmanagement.model.Document;
 import uk.gov.hmcts.reform.civil.documentmanagement.model.DownloadedDocumentResponse;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.Party;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
+import uk.gov.hmcts.reform.civil.sampledata.PartyBuilder;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentDownloadService;
 
 import java.util.Arrays;
@@ -43,8 +45,11 @@ class SendSDOBulkPrintServiceTest {
     @Test
     void shouldDownloadDocumentAndPrintLetterSuccessfully() {
         // given
+        Party respondent1 = PartyBuilder.builder().soleTrader().build();
         CaseData caseData = CaseDataBuilder.builder()
-            .systemGeneratedCaseDocuments(wrapElements(CaseDocument.builder().documentType(SDO_ORDER).documentLink(DOCUMENT_LINK).build())).build();
+            .systemGeneratedCaseDocuments(wrapElements(CaseDocument.builder().documentType(SDO_ORDER).documentLink(DOCUMENT_LINK).build()))
+            .respondent1(respondent1)
+            .build();
         given(documentDownloadService.downloadDocument(any())).willReturn(new DownloadedDocumentResponse(new ByteArrayResource(LETTER_CONTENT), "test", "test"));
 
         // when


### PR DESCRIPTION
Adding recipients in send letter service
{ 
... (the same)
"additional_data": {
        ... (previous additional data fields)
        "recipients": ["person one", "person two" (as an example)] (new field)
    }
}

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
