### PR TITLE
CIV-0000 move away from using docker.io images

### DIFF
--- a/charts/civil-service/values.preview.template.yaml
+++ b/charts/civil-service/values.preview.template.yaml
@@ -49,6 +49,8 @@ java:
   postgresql:
     enabled: true
     image:
+      registry: hmctspublic.azurecr.io
+      repository: imported/bitnami/postgresql
       tag: '11.6.0'
     primary:
       persistence:


### PR DESCRIPTION
CIV-0000 move away from using docker.io images for anything and using hmcts public images.

details in this ticket
https://tools.hmcts.net/jira/browse/DTSPO-14561






**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
