### PR TITLE
CIV-10946 - Fixed issues with Judge's Add Case Note Handler

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddCaseNoteCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddCaseNoteCallbackHandler.java
@@ -56,7 +56,7 @@ public class AddCaseNoteCallbackHandler extends CallbackHandler {
             caseData.getCaseNote()
         );
 
-        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToList(caseNote, caseData.getCaseNotes());
+        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(caseNote, caseData.getCaseNotes());
 
         CaseData updatedCaseData = caseData.toBuilder()
             .caseNotes(caseNotes)

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadJudgeHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadJudgeHandler.java
@@ -12,14 +12,17 @@ import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.enums.CaseNoteType;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.CaseNote;
+import uk.gov.hmcts.reform.civil.model.common.Element;
+import uk.gov.hmcts.reform.civil.service.CaseNoteService;
 
-import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
 import static java.lang.String.format;
+import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
@@ -31,14 +34,17 @@ public class EvidenceUploadJudgeHandler extends CallbackHandler {
 
     private static final List<CaseEvent> EVENTS = Collections.singletonList(EVIDENCE_UPLOAD_JUDGE);
     private final ObjectMapper objectMapper;
+
+    public static final String EVIDENCE_UPLOAD_HEADER_THREE = "# Case note added \n # %s";
     public static final String EVIDENCE_UPLOAD_HEADER_TWO = "# Document uploaded \n # %s";
     public static final String EVIDENCE_UPLOAD_HEADER_ONE = "# Document uploaded and note added \n # %s";
     public static final String EVIDENCE_UPLOAD_BODY_ONE = "## You have uploaded: \n %s";
+    private final CaseNoteService caseNoteService;
 
     @Override
     protected Map<String, Callback> callbacks() {
         return new ImmutableMap.Builder<String, Callback>()
-            .put(callbackKey(ABOUT_TO_START), this::emptyCallbackResponse)
+            .put(callbackKey(ABOUT_TO_START), this::removeCaseNoteType)
             .put(callbackKey(ABOUT_TO_SUBMIT), this::populateSubmittedDateTime)
             .put(callbackKey(SUBMITTED), this::buildConfirmation)
             .build();
@@ -49,12 +55,33 @@ public class EvidenceUploadJudgeHandler extends CallbackHandler {
         return EVENTS;
     }
 
+    private AboutToStartOrSubmitCallbackResponse removeCaseNoteType(CallbackParams callbackParams) {
+        var caseData = callbackParams.getCaseData();
+        CaseData.CaseDataBuilder<?, ?> caseDataBuilder = caseData.toBuilder();
+
+        caseDataBuilder.caseNoteType(null).build();
+
+        return AboutToStartOrSubmitCallbackResponse.builder()
+            .data(caseDataBuilder.build().toMap(objectMapper))
+            .build();
+    }
+
     private AboutToStartOrSubmitCallbackResponse populateSubmittedDateTime(CallbackParams callbackParams) {
         var caseData = callbackParams.getCaseData();
         CaseData.CaseDataBuilder<?, ?> caseDataBuilder = caseData.toBuilder();
 
-        if (caseData.getCaseNoteTypeNoteTA() != null) {
-            caseDataBuilder.noteAdditionDateTime(LocalDateTime.now());
+        if (caseData.getCaseNoteType().equals(CaseNoteType.NOTE_ONLY)) {
+            CaseNote caseNoteTA = caseNoteService.buildCaseNote(
+                callbackParams.getParams().get(BEARER_TOKEN).toString(),
+                caseData.getCaseNoteTA()
+            );
+
+            List<Element<CaseNote>> caseNotesTa = caseNoteService.addNoteToListEnd(caseNoteTA, caseData.getCaseNotesTA());
+
+            caseDataBuilder
+                .caseNotesTA(caseNotesTa)
+                .caseNoteTA(null)
+                .build();
         }
 
         return AboutToStartOrSubmitCallbackResponse.builder()
@@ -72,13 +99,17 @@ public class EvidenceUploadJudgeHandler extends CallbackHandler {
     }
 
     private String getHeader(CaseData caseData) {
-        if (null != caseData.getCaseNoteType() && caseData.getCaseNoteType().equals(CaseNoteType.DOCUMENT_ONLY)) {
-            return format(EVIDENCE_UPLOAD_HEADER_TWO, caseData.getLegacyCaseReference());
+
+        switch (caseData.getCaseNoteType()) {
+            case NOTE_ONLY:
+                return format(EVIDENCE_UPLOAD_HEADER_THREE, caseData.getLegacyCaseReference());
+            case DOCUMENT_ONLY:
+                return format(EVIDENCE_UPLOAD_HEADER_TWO, caseData.getLegacyCaseReference());
+            case DOCUMENT_AND_NOTE:
+                return format(EVIDENCE_UPLOAD_HEADER_ONE, caseData.getLegacyCaseReference());
+            default:
+                return null;
         }
-        if (caseData.getCaseNoteType().equals(CaseNoteType.DOCUMENT_AND_NOTE)) {
-            return format(EVIDENCE_UPLOAD_HEADER_ONE, caseData.getLegacyCaseReference());
-        }
-        return null;
     }
 
     private String getBody(CaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -570,7 +570,8 @@ public class CaseData extends CaseDataParent implements MappableObject {
     private final List<Element<DocumentWithName>> documentAndName;
     private final List<Element<DocumentAndNote>> documentAndNote;
     private final CaseNoteType caseNoteType;
-    private final String caseNoteTypeNoteTA;
+    private final String caseNoteTA;
+    private final List<Element<CaseNote>> caseNotesTA;
     private final LocalDateTime noteAdditionDateTime;
     private final String caseTypeFlag;
     private final String witnessStatementFlag;
@@ -1038,7 +1039,7 @@ public class CaseData extends CaseDataParent implements MappableObject {
     public String getApplicant1Email() {
         return getApplicant1().getPartyEmail() != null ? getApplicant1().getPartyEmail() : getClaimantUserDetails().getEmail();
     }
-    
+
     @JsonIgnore
     public String getHelpWithFeesReferenceNumber() {
         return Optional.ofNullable(getCaseDataLiP())

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/CaseNoteService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/CaseNoteService.java
@@ -7,7 +7,6 @@ import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.idam.client.IdamClient;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
@@ -19,20 +18,28 @@ import static uk.gov.hmcts.reform.civil.utils.ElementUtils.element;
 public class CaseNoteService {
 
     private final IdamClient idamClient;
+    private final Time time;
 
     public CaseNote buildCaseNote(String authorisation, String note) {
         UserDetails userDetails = idamClient.getUserDetails(authorisation);
 
         return CaseNote.builder()
             .createdBy(userDetails.getFullName())
-            .createdOn(LocalDateTime.now())
+            .createdOn(time.now())
             .note(note)
             .build();
     }
 
-    public List<Element<CaseNote>> addNoteToList(CaseNote caseNote, List<Element<CaseNote>> caseNotes) {
+    public List<Element<CaseNote>> addNoteToListStart(CaseNote caseNote, List<Element<CaseNote>> caseNotes) {
         List<Element<CaseNote>> updatedCaseNotes = ofNullable(caseNotes).orElse(newArrayList());
         updatedCaseNotes.add(0, element(caseNote));
+
+        return updatedCaseNotes;
+    }
+
+    public List<Element<CaseNote>> addNoteToListEnd(CaseNote caseNote, List<Element<CaseNote>> caseNotes) {
+        List<Element<CaseNote>> updatedCaseNotes = ofNullable(caseNotes).orElse(newArrayList());
+        updatedCaseNotes.add(element(caseNote));
 
         return updatedCaseNotes;
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddCaseNoteCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/AddCaseNoteCallbackHandlerTest.java
@@ -90,12 +90,12 @@ class AddCaseNoteCallbackHandlerTest extends BaseCallbackHandlerTest {
 
             when(caseNoteService.buildCaseNote(params.getParams().get(BEARER_TOKEN).toString(), "Example case note"))
                 .thenReturn(expectedCaseNote);
-            when(caseNoteService.addNoteToList(expectedCaseNote, caseData.getCaseNotes())).thenReturn(updatedCaseNotes);
+            when(caseNoteService.addNoteToListStart(expectedCaseNote, caseData.getCaseNotes())).thenReturn(updatedCaseNotes);
 
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
 
             verify(caseNoteService).buildCaseNote(params.getParams().get(BEARER_TOKEN).toString(), "Example case note");
-            verify(caseNoteService).addNoteToList(expectedCaseNote, caseData.getCaseNotes());
+            verify(caseNoteService).addNoteToListStart(expectedCaseNote, caseData.getCaseNotes());
 
             assertThat(response.getData())
                 .doesNotHaveToString("caseNote");

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadJudgeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadJudgeHandlerTest.java
@@ -25,7 +25,6 @@ import uk.gov.hmcts.reform.civil.model.documents.DocumentWithName;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.CaseNoteService;
 import uk.gov.hmcts.reform.civil.service.Time;
-import uk.gov.hmcts.reform.civil.utils.ElementUtils;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -97,8 +96,7 @@ public class EvidenceUploadJudgeHandlerTest extends BaseCallbackHandlerTest {
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
 
             assertThat(response.getData()).extracting("caseNotesTA")
-                .isEqualTo(objectMapper.convertValue(updatedCaseNotes, new TypeReference<>() {
-            }));
+                .isEqualTo(objectMapper.convertValue(updatedCaseNotes, new TypeReference<>() {}));
 
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadJudgeHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadJudgeHandlerTest.java
@@ -1,11 +1,14 @@
 package uk.gov.hmcts.reform.civil.handler.callback.user;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.reform.ccd.client.model.AboutToStartOrSubmitCallbackResponse;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
@@ -14,28 +17,44 @@ import uk.gov.hmcts.reform.civil.callback.CallbackType;
 import uk.gov.hmcts.reform.civil.enums.CaseNoteType;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.CaseNote;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.documentmanagement.model.Document;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentAndNote;
 import uk.gov.hmcts.reform.civil.model.documents.DocumentWithName;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
+import uk.gov.hmcts.reform.civil.service.CaseNoteService;
+import uk.gov.hmcts.reform.civil.service.Time;
+import uk.gov.hmcts.reform.civil.utils.ElementUtils;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
+import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {
     EvidenceUploadJudgeHandler.class,
-    JacksonAutoConfiguration.class
+    JacksonAutoConfiguration.class,
+    CaseNoteService.class
 })
 public class EvidenceUploadJudgeHandlerTest extends BaseCallbackHandlerTest {
 
     @Autowired
     private EvidenceUploadJudgeHandler handler;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private CaseNoteService caseNoteService;
+
+    @MockBean
+    private Time time;
 
     public static final String REFERENCE_NUMBER = "000DC001";
 
@@ -44,11 +63,15 @@ public class EvidenceUploadJudgeHandlerTest extends BaseCallbackHandlerTest {
 
         @Test
         void aboutToStartCallback_placeholder() {
-            CaseData caseData = CaseDataBuilder.builder().build();
+            CaseData caseData = CaseDataBuilder.builder().atStateNotificationAcknowledged().build().toBuilder()
+                .caseNoteType(CaseNoteType.NOTE_ONLY)
+                .build();
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_START);
 
-            AboutToStartOrSubmitCallbackResponse response = (AboutToStartOrSubmitCallbackResponse) handler
+            var response = (AboutToStartOrSubmitCallbackResponse) handler
                 .handle(params);
+
+            assertThat(response.getData()).extracting("caseNoteType").isNull();
 
         }
     }
@@ -59,26 +82,37 @@ public class EvidenceUploadJudgeHandlerTest extends BaseCallbackHandlerTest {
         @Test
         void shouldPopulateNoteDateTime_whenNoteIsAddedToCase() {
             CaseData caseData = CaseDataBuilder.builder().atStateNotificationAcknowledged().build().toBuilder()
-                .caseNoteTypeNoteTA("test note")
+                .caseNoteType(CaseNoteType.NOTE_ONLY)
+                .caseNoteTA("test note")
                 .build();
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
+            CaseNote expectedCaseNote = createCaseNote(time.now(), "John Doe", "test note");
+            List<Element<CaseNote>> updatedCaseNotes = wrapElements(expectedCaseNote);
+
+            when(caseNoteService.buildCaseNote(params.getParams().get(BEARER_TOKEN).toString(), "test note"))
+                .thenReturn(expectedCaseNote);
+            when(caseNoteService.addNoteToListEnd(expectedCaseNote, caseData.getCaseNotes())).thenReturn(updatedCaseNotes);
+
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
 
-            assertThat(response.getData().get("noteAdditionDateTime")).isNotNull();
+            assertThat(response.getData()).extracting("caseNotesTA")
+                .isEqualTo(objectMapper.convertValue(updatedCaseNotes, new TypeReference<>() {
+            }));
 
         }
 
         @Test
         void shouldNotPopulateNoteDateTime_whenNoteIsAddedToCase() {
             CaseData caseData = CaseDataBuilder.builder().atStateNotificationAcknowledged().build().toBuilder()
-                .caseNoteTypeNoteTA(null)
+                .caseNoteType(CaseNoteType.DOCUMENT_ONLY)
+                .caseNoteTA(null)
                 .build();
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
             var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
 
-            assertThat(response.getData().get("noteAdditionDateTime")).isNull();
+            assertThat(response.getData()).extracting("caseNotesTA").isNull();
 
         }
     }
@@ -142,6 +176,30 @@ public class EvidenceUploadJudgeHandlerTest extends BaseCallbackHandlerTest {
                                                                           .confirmationBody(String.format(body))
                                                                           .build());
         }
+
+        @Test
+        void submittedCallback_noteOnly() {
+            String header = "# Case note added \n # " + REFERENCE_NUMBER;
+
+            CaseData caseData = CaseDataBuilder.builder().atStateNotificationAcknowledged().build().toBuilder()
+                .caseNoteType(CaseNoteType.NOTE_ONLY)
+                .build();
+            CallbackParams params = callbackParamsOf(caseData, CallbackType.SUBMITTED);
+
+            SubmittedCallbackResponse response = (SubmittedCallbackResponse) handler.handle(params);
+
+            assertThat(response).usingRecursiveComparison().isEqualTo(SubmittedCallbackResponse.builder()
+                                                                          .confirmationHeader(header)
+                                                                          .build());
+        }
+    }
+
+    private CaseNote createCaseNote(LocalDateTime timeStamp, String createdBy, String note) {
+        return CaseNote.builder()
+            .createdOn(timeStamp)
+            .createdBy(createdBy)
+            .note(note)
+            .build();
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/CaseNoteServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/CaseNoteServiceTest.java
@@ -64,7 +64,7 @@ class CaseNoteServiceTest {
     @Test
     void shouldAddNoteToList_WhenNullList() {
         CaseNote caseNote = caseNoteForToday("new note");
-        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToList(caseNote, null);
+        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(caseNote, null);
 
         assertThat(unwrapElements(caseNotes)).contains(caseNote);
     }
@@ -72,7 +72,7 @@ class CaseNoteServiceTest {
     @Test
     void shouldAddNoteToList_WhenEmptyList() {
         CaseNote caseNote = caseNoteForToday("new note");
-        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToList(caseNote, new ArrayList<>());
+        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(caseNote, new ArrayList<>());
 
         assertThat(unwrapElements(caseNotes)).contains(caseNote);
     }
@@ -83,7 +83,7 @@ class CaseNoteServiceTest {
         CaseNote newNote = caseNoteWithDate(today);
         CaseNote oldNote = caseNoteWithDate(today.minusDays(5));
 
-        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToList(newNote, wrapElements(oldNote));
+        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(newNote, wrapElements(oldNote));
 
         assertThat(unwrapElements(caseNotes)).isEqualTo(List.of(newNote, oldNote));
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/CaseNoteServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/CaseNoteServiceTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.unwrapElements;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
 
@@ -41,11 +42,17 @@ class CaseNoteServiceTest {
     @MockBean
     private IdamClient idamClient;
 
+    @MockBean
+    private Time time;
+    private LocalDateTime timeNow = LocalDateTime.of(2023, 10, 9, 1, 1, 1);
+
     @Nested
     class BuildCaseNote {
         @BeforeEach
         void setUp() {
+
             given(idamClient.getUserDetails(BEARER_TOKEN)).willReturn(USER_DETAILS);
+            when(time.now()).thenReturn(timeNow);
         }
 
         @Test
@@ -55,44 +62,46 @@ class CaseNoteServiceTest {
 
             assertThat(caseNote.getNote()).isEqualTo(caseNoteForToday(note).getNote());
             assertThat(caseNote.getCreatedBy()).isEqualTo(caseNoteForToday(note).getCreatedBy());
-            assertThat(caseNote.getCreatedOn()).isCloseTo(caseNoteForToday(note).getCreatedOn(),
-                                                          within(1, ChronoUnit.SECONDS));
+            assertThat(caseNote.getCreatedOn()).isCloseTo(
+                caseNoteForToday(note).getCreatedOn(),
+                within(1, ChronoUnit.SECONDS)
+            );
             verify(idamClient).getUserDetails(BEARER_TOKEN);
         }
-    }
 
-    @Test
-    void shouldAddNoteToList_WhenNullList() {
-        CaseNote caseNote = caseNoteForToday("new note");
-        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(caseNote, null);
+        @Test
+        void shouldAddNoteToList_WhenNullList() {
+            CaseNote caseNote = caseNoteForToday("new note");
+            List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(caseNote, null);
 
-        assertThat(unwrapElements(caseNotes)).contains(caseNote);
-    }
+            assertThat(unwrapElements(caseNotes)).contains(caseNote);
+        }
 
-    @Test
-    void shouldAddNoteToList_WhenEmptyList() {
-        CaseNote caseNote = caseNoteForToday("new note");
-        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(caseNote, new ArrayList<>());
+        @Test
+        void shouldAddNoteToList_WhenEmptyList() {
+            CaseNote caseNote = caseNoteForToday("new note");
+            List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(caseNote, new ArrayList<>());
 
-        assertThat(unwrapElements(caseNotes)).contains(caseNote);
-    }
+            assertThat(unwrapElements(caseNotes)).contains(caseNote);
+        }
 
-    @Test
-    void shouldAddNoteToListWithNewestAtTop_WhenExistingNotes() {
-        LocalDateTime today = LocalDateTime.now();
-        CaseNote newNote = caseNoteWithDate(today);
-        CaseNote oldNote = caseNoteWithDate(today.minusDays(5));
+        @Test
+        void shouldAddNoteToListWithNewestAtTop_WhenExistingNotes() {
+            LocalDateTime today = time.now();
+            CaseNote newNote = caseNoteWithDate(today);
+            CaseNote oldNote = caseNoteWithDate(today.minusDays(5));
 
-        List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(newNote, wrapElements(oldNote));
+            List<Element<CaseNote>> caseNotes = caseNoteService.addNoteToListStart(newNote, wrapElements(oldNote));
 
-        assertThat(unwrapElements(caseNotes)).isEqualTo(List.of(newNote, oldNote));
+            assertThat(unwrapElements(caseNotes)).isEqualTo(List.of(newNote, oldNote));
+        }
     }
 
     private CaseNote caseNoteForToday(String note) {
         return CaseNote.builder()
             .note(note)
             .createdBy(USER_DETAILS.getFullName())
-            .createdOn(LocalDateTime.now())
+            .createdOn(time.now())
             .build();
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-10946

### Change description ###
Added the ability to do multiple casenotes, changed LocalDateTime.now() to time.now() to force use of British timezone, and removed prepopulation of fields. 
![image](https://github.com/hmcts/civil-service/assets/107135537/c1dd32f4-394d-4779-aabb-e660aa7a0444)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
