### PR TITLE
CIV-11621 - charge hearing fee 28 days before hearing

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/HearingFeeUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/HearingFeeUtils.java
@@ -22,7 +22,7 @@ public class HearingFeeUtils {
     public static LocalDate calculateHearingDueDate(LocalDate now, LocalDate hearingDate) {
         LocalDate calculatedHearingDueDate;
         if (now.isBefore(hearingDate.minusDays(36))) {
-            calculatedHearingDueDate = now.plusDays(28);
+            calculatedHearingDueDate = hearingDate.minusDays(28);
         } else {
             calculatedHearingDueDate = now.plusDays(7);
         }

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/HearingFeeUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/HearingFeeUtilsTest.java
@@ -35,7 +35,7 @@ class HearingFeeUtilsTest {
     @CsvSource({
         // current date,hearing date,expected
         "2022-10-27,2022-11-04,2022-11-03",   // based on bug report: on the boundary of exactly 7 days
-        "2022-10-01,2022-11-14,2022-10-29",   // hearing date more than 36 days away -> expect in 28 straight days time
+        "2022-10-01,2022-11-14,2022-10-17",   // hearing date more than 36 days away -> expect in 28 straight days time
         "2022-10-01,2022-10-14,2022-10-08",   // hearing date less than 36 days away -> expect in 7 straight days
         "2022-10-01,2022-10-10,2022-10-08"    // should never happen. If it does the deadline is the hearing day
     })


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-11621


### Change description ###
Currently hearing fee is charged 28 days after now, but it should be 28 days before hearing date.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
