### PR TITLE
CIV-11422 Make MCI event available for caseworkers in awaiting defendant acknowledgement state

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/ManageContactInformationCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/ManageContactInformationCallbackHandler.java
@@ -46,6 +46,7 @@ import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.MANAGE_CONTACT_INFORMATION;
 import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.CaseState.AWAITING_APPLICANT_INTENTION;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.AWAITING_RESPONDENT_ACKNOWLEDGEMENT;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.ONE_V_TWO_TWO_LEGAL_REP;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.getMultiPartyScenario;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
@@ -129,7 +130,7 @@ public class ManageContactInformationCallbackHandler extends CallbackHandler {
         UserInfo userInfo = userService.getUserInfo(authToken);
         boolean isAdmin = isAdmin(authToken);
 
-        List<String> errors = isAwaitingClaimantIntention(caseData)
+        List<String> errors = isBeforeAwaitingApplicantIntention(caseData)
             && !isAdmin ? List.of(INVALID_CASE_STATE_ERROR) : null;
 
         if (errors != null) {
@@ -495,8 +496,8 @@ public class ManageContactInformationCallbackHandler extends CallbackHandler {
             .build();
     }
 
-    private boolean isAwaitingClaimantIntention(CaseData caseData) {
-        return caseData.getCcdState().equals(AWAITING_APPLICANT_INTENTION);
+    private boolean isBeforeAwaitingApplicantIntention(CaseData caseData) {
+        return caseData.getCcdState().equals(AWAITING_APPLICANT_INTENTION) || caseData.getCcdState().equals(AWAITING_RESPONDENT_ACKNOWLEDGEMENT);
     }
 
     private boolean isAdmin(String userAuthToken) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ManageContactInformationCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ManageContactInformationCallbackHandlerTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -147,10 +148,11 @@ class ManageContactInformationCallbackHandlerTest extends BaseCallbackHandlerTes
             assertNull(response.getErrors());
         }
 
-        @Test
-        void shouldReturnErrors_WhenAboutToStartIsInvokedByNonAdminUserWhileCaseInAwaitingApplicantIntentionState() {
+        @ParameterizedTest
+        @EnumSource(value = CaseState.class, names = {"AWAITING_RESPONDENT_ACKNOWLEDGEMENT", "AWAITING_APPLICANT_INTENTION"})
+        void shouldReturnErrors_WhenAboutToStartIsInvokedByNonAdminUserWhileCaseInAwaitingRespondentAcknowledgementState(CaseState states) {
             when(userService.getUserInfo(anyString())).thenReturn(LEGAL_REP_USER);
-            CaseData caseData = CaseData.builder().ccdState(CaseState.AWAITING_APPLICANT_INTENTION)
+            CaseData caseData = CaseData.builder().ccdState(states)
                 .ccdCaseReference(123L)
                 .build();
             CallbackParams params = callbackParamsOf(caseData, CallbackType.ABOUT_TO_START);


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-11422


### Change description ###

- Make manage contact information event available for caseworkers in awaiting defendant acknowledgement state
- add a error to stop LRs accessing the event in AWAITING_RESPONDENT_ACKNOWLEDGEMENT


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
