### PR TITLE
CIV-11704 Get Hearing Location from Ref Data

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/GenerateDirectionOrderCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/GenerateDirectionOrderCallbackHandler.java
@@ -18,12 +18,12 @@ import uk.gov.hmcts.reform.civil.enums.finalorders.CostEnums;
 import uk.gov.hmcts.reform.civil.enums.finalorders.FinalOrderToggle;
 import uk.gov.hmcts.reform.civil.enums.finalorders.HearingLengthFinalOrderList;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
-
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.HearingNotes;
 import uk.gov.hmcts.reform.civil.model.caseprogression.FreeFormOrderValues;
 import uk.gov.hmcts.reform.civil.model.common.DynamicList;
 import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
+import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.model.finalorders.AppealChoiceSecondDropdown;
 import uk.gov.hmcts.reform.civil.model.finalorders.AppealGrantedRefused;
 import uk.gov.hmcts.reform.civil.model.finalorders.AssistedOrderCostDetails;
@@ -35,10 +35,8 @@ import uk.gov.hmcts.reform.civil.model.finalorders.FinalOrderRepresentation;
 import uk.gov.hmcts.reform.civil.model.finalorders.OrderMade;
 import uk.gov.hmcts.reform.civil.model.finalorders.OrderMadeOnDetails;
 import uk.gov.hmcts.reform.civil.model.finalorders.OrderMadeOnDetailsOrderWithoutNotice;
-import uk.gov.hmcts.reform.civil.referencedata.LocationRefDataService;
 import uk.gov.hmcts.reform.civil.referencedata.model.LocationRefData;
-
-import uk.gov.hmcts.reform.civil.model.common.Element;
+import uk.gov.hmcts.reform.civil.service.LocationRefDataServiceHelper;
 import uk.gov.hmcts.reform.civil.service.docmosis.DocumentHearingLocationHelper;
 import uk.gov.hmcts.reform.civil.service.docmosis.caseprogression.JudgeFinalOrderGenerator;
 
@@ -50,10 +48,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
-import static java.util.Objects.nonNull;
-import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
 import static io.jsonwebtoken.lang.Collections.isEmpty;
 import static java.lang.String.format;
+import static java.util.Objects.nonNull;
+import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.MID;
@@ -99,7 +97,7 @@ public class GenerateDirectionOrderCallbackHandler extends CallbackHandler {
     public String defendantTwoPartyName;
     public String claimantTwoPartyName;
     public static final String APPEAL_NOTICE_DATE = "Appeal notice date";
-    private final LocationRefDataService locationRefDataService;
+    private final LocationRefDataServiceHelper locationRefDataServiceHelper;
     private final ObjectMapper objectMapper;
     private final JudgeFinalOrderGenerator judgeFinalOrderGenerator;
     private final DocumentHearingLocationHelper locationHelper;
@@ -159,7 +157,7 @@ public class GenerateDirectionOrderCallbackHandler extends CallbackHandler {
         if (ASSISTED_ORDER.equals(caseData.getFinalOrderSelection())) {
             String authToken = callbackParams.getParams().get(BEARER_TOKEN).toString();
 
-            List<LocationRefData> locations = (locationRefDataService
+            List<LocationRefData> locations = (locationRefDataServiceHelper
                 .getCourtLocationsForDefaultJudgments(authToken));
             caseDataBuilder = populateFields(caseDataBuilder, locations, caseData, authToken);
         } else {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/LocationRefDataServiceHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/LocationRefDataServiceHelper.java
@@ -1,0 +1,71 @@
+package uk.gov.hmcts.reform.civil.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.civil.referencedata.LRDConfiguration;
+import uk.gov.hmcts.reform.civil.referencedata.LocationRefDataService;
+import uk.gov.hmcts.reform.civil.referencedata.model.LocationRefData;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+@Slf4j
+@Service
+public class LocationRefDataServiceHelper extends LocationRefDataService {
+
+    private final RestTemplate restTemplate;
+    private final LRDConfiguration lrdConfiguration;
+    private final AuthTokenGenerator authTokenGenerator;
+
+    public LocationRefDataServiceHelper(RestTemplate restTemplate,
+                                        LRDConfiguration lrdConfiguration,
+                                        AuthTokenGenerator authTokenGenerator) {
+        super(restTemplate, lrdConfiguration, authTokenGenerator);
+        this.restTemplate = restTemplate;
+        this.lrdConfiguration = lrdConfiguration;
+        this.authTokenGenerator = authTokenGenerator;
+    }
+
+    @Override
+    public List<LocationRefData> getCourtLocationsForDefaultJudgments(String authToken) {
+        try {
+            ResponseEntity<List<LocationRefData>> responseEntity = restTemplate.exchange(
+                buildURIForDefaultJudgments(),
+                HttpMethod.GET,
+                getHeaders(authToken),
+                new ParameterizedTypeReference<>() {
+                }
+            );
+            return responseEntity.getBody();
+        } catch (Exception e) {
+            log.error("Location Reference Data Lookup Failed - " + e.getMessage(), e);
+        }
+        return new ArrayList<>();
+    }
+
+    private URI buildURIForDefaultJudgments() {
+        String queryURL = lrdConfiguration.getUrl() + lrdConfiguration.getEndpoint();
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(queryURL)
+            .queryParam("is_hearing_location", "Y")
+            .queryParam("court_type_id", "10")
+            .queryParam("location_type", "Court");
+        return builder.buildAndExpand(new HashMap<>()).toUri();
+    }
+
+    private HttpEntity<String> getHeaders(String authToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", authToken);
+        headers.add("ServiceAuthorization", authTokenGenerator.generate());
+        return new HttpEntity<>(headers);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/DocumentHearingLocationHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/DocumentHearingLocationHelper.java
@@ -21,7 +21,7 @@ public class DocumentHearingLocationHelper {
     private final LocationRefDataService locationRefDataService;
 
     public LocationRefData getHearingLocation(String valueFromForm, CaseData caseData, String authorisation) {
-        if (StringUtils.isNotBlank(valueFromForm)) { // false
+        if (StringUtils.isNotBlank(valueFromForm)) {
             Optional<LocationRefData> fromForm = locationRefDataService.getLocationMatchingLabel(
                 valueFromForm,
                 authorisation

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/DocumentHearingLocationHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/DocumentHearingLocationHelper.java
@@ -21,7 +21,7 @@ public class DocumentHearingLocationHelper {
     private final LocationRefDataService locationRefDataService;
 
     public LocationRefData getHearingLocation(String valueFromForm, CaseData caseData, String authorisation) {
-        if (StringUtils.isNotBlank(valueFromForm)) {
+        if (StringUtils.isNotBlank(valueFromForm)) { // false
             Optional<LocationRefData> fromForm = locationRefDataService.getLocationMatchingLabel(
                 valueFromForm,
                 authorisation

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/GenerateDirectionOrderCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/GenerateDirectionOrderCallbackHandlerTest.java
@@ -40,19 +40,18 @@ import uk.gov.hmcts.reform.civil.model.finalorders.FinalOrderFurtherHearing;
 import uk.gov.hmcts.reform.civil.model.finalorders.FinalOrderRecitalsRecorded;
 import uk.gov.hmcts.reform.civil.model.finalorders.FinalOrderRepresentation;
 import uk.gov.hmcts.reform.civil.model.finalorders.OrderMade;
-import uk.gov.hmcts.reform.civil.referencedata.LocationRefDataService;
 import uk.gov.hmcts.reform.civil.referencedata.model.LocationRefData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.PartyBuilder;
+import uk.gov.hmcts.reform.civil.service.LocationRefDataServiceHelper;
 import uk.gov.hmcts.reform.civil.service.docmosis.DocumentGeneratorService;
 import uk.gov.hmcts.reform.civil.service.docmosis.DocumentHearingLocationHelper;
 import uk.gov.hmcts.reform.civil.service.docmosis.caseprogression.JudgeFinalOrderGenerator;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import static java.lang.String.format;
@@ -70,7 +69,6 @@ import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.enums.finalorders.FinalOrdersClaimantRepresentationList.CLAIMANT_NOT_ATTENDING;
 import static uk.gov.hmcts.reform.civil.enums.finalorders.FinalOrdersDefendantRepresentationList.DEFENDANT_NOT_ATTENDING;
-
 import static uk.gov.hmcts.reform.civil.handler.callback.user.GenerateDirectionOrderCallbackHandler.BODY_1v1;
 import static uk.gov.hmcts.reform.civil.handler.callback.user.GenerateDirectionOrderCallbackHandler.BODY_1v2;
 import static uk.gov.hmcts.reform.civil.handler.callback.user.GenerateDirectionOrderCallbackHandler.BODY_2v1;
@@ -106,7 +104,7 @@ public class GenerateDirectionOrderCallbackHandlerTest extends BaseCallbackHandl
         + "by 4pm on";
 
     @MockBean
-    private LocationRefDataService locationRefDataService;
+    private LocationRefDataServiceHelper locationRefDataService;
     public static final CaseDocument finalOrder = CaseDocument.builder()
         .createdBy("Test")
         .documentName("document test name")


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-11704


### Change description ###

Overriday ref data method to customize the query parameter to remove Case management location to display Mid and South East Northumberland Law Courts (Bedlington), Berwick Magistrates Court and Moot hall in the location drop downs on SDO or general/final orders.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
