### PR TITLE
CIV-11738 claimtrack updated in creato sdo

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -757,11 +757,6 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
             : callbackParams.getCaseData();
         CaseData.CaseDataBuilder<?, ?> updatedData = caseData.toBuilder();
 
-        System.out.println("track claim is   " + caseData.getClaimsTrack());
-        System.out.println("small track claim is " + SdoHelper.isSmallClaimsTrack(caseData));
-        System.out.println("fast track claim is " + SdoHelper.isFastTrack(caseData));
-
-
         List<String> errors = new ArrayList<>();
         if (nonNull(caseData.getSmallClaimsWitnessStatement())) {
             String inputValue1 = caseData.getSmallClaimsWitnessStatement().getInput2();
@@ -888,11 +883,7 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
         dataBuilder.smallClaimsMethodInPerson(deleteLocationList(
             caseData.getSmallClaimsMethodInPerson()));
 
-        System.out.println("track claim is   " + caseData.getClaimsTrack());
-
         setClaimsTrackBasedOnJudgeSelection(dataBuilder, caseData);
-
-        System.out.println("before about to submit");
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(dataBuilder.build().toMap(objectMapper))
@@ -902,25 +893,23 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
     // During SDO the claim track can change based on judges selection. In this case we want to update claims track
     // to this decision, or maintain it, if it was not changed.
     private void setClaimsTrackBasedOnJudgeSelection(CaseData.CaseDataBuilder<?, ?> dataBuilder, CaseData caseData) {
-        // unspec claims will use allocatedTrack to hold claims track value
-        System.out.println("case type is " + caseData.getCaseAccessCategory());
-        if (caseData.getCaseAccessCategory().equals(CaseCategory.UNSPEC_CLAIM)) {
-            if (SdoHelper.isSmallClaimsTrack(caseData)) {
-                System.out.println("not small");
-                dataBuilder.allocatedTrack(SMALL_CLAIM);
-            } else if (SdoHelper.isFastTrack(caseData)) {
-                System.out.println("not fast");
-                dataBuilder.allocatedTrack(FAST_CLAIM);
-            }
-            System.out.println("trackkkkk " + caseData.getAllocatedTrack());
-        }
-        // spec claims will use responseClaimTrack to hold claims track value
-        if (caseData.getCaseAccessCategory().equals(CaseCategory.SPEC_CLAIM)) {
-            if (SdoHelper.isSmallClaimsTrack(caseData)) {
-                dataBuilder.responseClaimTrack(SMALL_CLAIM.name());
-            } else if (SdoHelper.isFastTrack(caseData)) {
-                dataBuilder.responseClaimTrack(FAST_CLAIM.name());
-            }
+        CaseCategory caseAccessCategory = caseData.getCaseAccessCategory();
+        switch (caseAccessCategory) {
+            case UNSPEC_CLAIM:// unspec use allocatedTrack to hold claims track value
+                if (SdoHelper.isSmallClaimsTrack(caseData)) {
+                    dataBuilder.allocatedTrack(SMALL_CLAIM);
+                } else if (SdoHelper.isFastTrack(caseData)) {
+                    dataBuilder.allocatedTrack(FAST_CLAIM);
+                }
+                break;
+            case SPEC_CLAIM:// spec claims use responseClaimTrack to hold claims track value
+                if (SdoHelper.isSmallClaimsTrack(caseData)) {
+                    dataBuilder.responseClaimTrack(SMALL_CLAIM.name());
+                } else if (SdoHelper.isFastTrack(caseData)) {
+                    dataBuilder.responseClaimTrack(FAST_CLAIM.name());
+                }
+                break;
+            default: break;
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -99,6 +99,8 @@ import static uk.gov.hmcts.reform.civil.callback.CallbackType.MID;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CallbackVersion.V_1;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_SDO;
+import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.FAST_CLAIM;
+import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.SMALL_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.enums.sdo.OrderDetailsPagesSectionsToggle.SHOW;
 import static uk.gov.hmcts.reform.civil.enums.sdo.OrderType.DISPOSAL;
@@ -755,6 +757,11 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
             : callbackParams.getCaseData();
         CaseData.CaseDataBuilder<?, ?> updatedData = caseData.toBuilder();
 
+        System.out.println("track claim is   " + caseData.getClaimsTrack());
+        System.out.println("small track claim is " + SdoHelper.isSmallClaimsTrack(caseData));
+        System.out.println("fast track claim is " + SdoHelper.isFastTrack(caseData));
+
+
         List<String> errors = new ArrayList<>();
         if (nonNull(caseData.getSmallClaimsWitnessStatement())) {
             String inputValue1 = caseData.getSmallClaimsWitnessStatement().getInput2();
@@ -881,11 +888,40 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
         dataBuilder.smallClaimsMethodInPerson(deleteLocationList(
             caseData.getSmallClaimsMethodInPerson()));
 
+        System.out.println("track claim is   " + caseData.getClaimsTrack());
+
+        setClaimsTrackBasedOnJudgeSelection(dataBuilder, caseData);
+
         System.out.println("before about to submit");
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(dataBuilder.build().toMap(objectMapper))
             .build();
+    }
+
+    // During SDO the claim track can change based on judges selection. In this case we want to update claims track
+    // to this decision, or maintain it, if it was not changed.
+    private void setClaimsTrackBasedOnJudgeSelection(CaseData.CaseDataBuilder<?, ?> dataBuilder, CaseData caseData) {
+        // unspec claims will use allocatedTrack to hold claims track value
+        System.out.println("case type is " + caseData.getCaseAccessCategory());
+        if (caseData.getCaseAccessCategory().equals(CaseCategory.UNSPEC_CLAIM)) {
+            if (SdoHelper.isSmallClaimsTrack(caseData)) {
+                System.out.println("not small");
+                dataBuilder.allocatedTrack(SMALL_CLAIM);
+            } else if (SdoHelper.isFastTrack(caseData)) {
+                System.out.println("not fast");
+                dataBuilder.allocatedTrack(FAST_CLAIM);
+            }
+            System.out.println("trackkkkk " + caseData.getAllocatedTrack());
+        }
+        // spec claims will use responseClaimTrack to hold claims track value
+        if (caseData.getCaseAccessCategory().equals(CaseCategory.SPEC_CLAIM)) {
+            if (SdoHelper.isSmallClaimsTrack(caseData)) {
+                dataBuilder.responseClaimTrack(SMALL_CLAIM.name());
+            } else if (SdoHelper.isFastTrack(caseData)) {
+                dataBuilder.responseClaimTrack(FAST_CLAIM.name());
+            }
+        }
     }
 
     private DynamicList deleteLocationList(DynamicList list) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadHandlerBase.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadHandlerBase.java
@@ -54,7 +54,8 @@ import static uk.gov.hmcts.reform.civil.callback.CallbackType.MID;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.EVIDENCE_UPLOAD_APPLICANT;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.EVIDENCE_UPLOAD_RESPONDENT;
-import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.getAllocatedTrack;
+import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
+import static uk.gov.hmcts.reform.civil.enums.CaseCategory.UNSPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.CaseRole.RESPONDENTSOLICITORONE;
 import static uk.gov.hmcts.reform.civil.enums.CaseRole.RESPONDENTSOLICITORTWO;
 
@@ -219,10 +220,10 @@ abstract class EvidenceUploadHandlerBase extends CallbackHandler {
         }
         CaseData.CaseDataBuilder<?, ?> caseDataBuilder = caseData.toBuilder();
         //determine claim path, and assign to CCD object for show hide functionality
-        if (caseData.getClaimType() == null) {
-            caseDataBuilder.caseProgAllocatedTrack(getAllocatedTrack(caseData.getTotalClaimAmount(), null).name());
-        } else {
-            caseDataBuilder.caseProgAllocatedTrack(getAllocatedTrack(caseData.getClaimValue().toPounds(), caseData.getClaimType()).name());
+        if (caseData.getCaseAccessCategory().equals(UNSPEC_CLAIM)) {
+            caseDataBuilder.caseProgAllocatedTrack(caseData.getAllocatedTrack().name());
+        } else if (caseData.getCaseAccessCategory().equals(SPEC_CLAIM)){
+            caseDataBuilder.caseProgAllocatedTrack(caseData.getResponseClaimTrack());
         }
         caseDataBuilder.evidenceUploadOptions(DynamicList.fromList(dynamicListOptions));
         // was unable to null value properly in EvidenceUploadNotificationEventHandler after emails are sent,

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadHandlerBase.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadHandlerBase.java
@@ -219,10 +219,12 @@ abstract class EvidenceUploadHandlerBase extends CallbackHandler {
             }
         }
         CaseData.CaseDataBuilder<?, ?> caseDataBuilder = caseData.toBuilder();
-        //determine claim path, and assign to CCD object for show hide functionality
+        //Evidence upload will have different screen for Fast claims and Small claims.
+        // We use show hide in CCD to do this, using utility field caseProgAllocatedTrack to hold the value of the claim track
+        // for either spec claims (ResponseClaimTrack) or unspec claims (AllocatedTrack)
         if (caseData.getCaseAccessCategory().equals(UNSPEC_CLAIM)) {
             caseDataBuilder.caseProgAllocatedTrack(caseData.getAllocatedTrack().name());
-        } else if (caseData.getCaseAccessCategory().equals(SPEC_CLAIM)){
+        } else if (caseData.getCaseAccessCategory().equals(SPEC_CLAIM)) {
             caseDataBuilder.caseProgAllocatedTrack(caseData.getResponseClaimTrack());
         }
         caseDataBuilder.evidenceUploadOptions(DynamicList.fromList(dynamicListOptions));

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +24,7 @@ import uk.gov.hmcts.reform.civil.config.ClaimUrlsConfiguration;
 import uk.gov.hmcts.reform.civil.config.MockDatabaseConfiguration;
 import uk.gov.hmcts.reform.civil.crd.model.Category;
 import uk.gov.hmcts.reform.civil.crd.model.CategorySearchResult;
+import uk.gov.hmcts.reform.civil.enums.AllocatedTrack;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.enums.sdo.ClaimsTrack;
 import uk.gov.hmcts.reform.civil.enums.sdo.DisposalHearingMethod;
@@ -34,6 +37,8 @@ import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.helpers.DateFormatHelper;
 import uk.gov.hmcts.reform.civil.helpers.LocationHelper;
 import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
+import uk.gov.hmcts.reform.civil.model.finalorders.DatesFinalOrders;
+import uk.gov.hmcts.reform.civil.model.finalorders.OrderMade;
 import uk.gov.hmcts.reform.civil.service.CategoryService;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;
@@ -66,6 +71,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -81,6 +88,7 @@ import static uk.gov.hmcts.reform.civil.callback.CallbackType.MID;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_SDO;
 import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
+import static uk.gov.hmcts.reform.civil.enums.CaseCategory.UNSPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.handler.callback.user.CreateSDOCallbackHandler.CONFIRMATION_HEADER;
@@ -103,6 +111,11 @@ import static uk.gov.hmcts.reform.civil.handler.callback.user.CreateSDOCallbackH
 public class CreateSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
 
     public static final String REFERENCE_NUMBER = "000DC001";
+    private static final DynamicList options = DynamicList.builder()
+        .listItems(List.of(
+                       DynamicListElement.builder().code("00001").label("court 1 - 1 address - Y01 7RB").build(),
+                       DynamicListElement.builder().code("00002").label("court 2 - 2 address - Y02 7RB").build(),
+                       DynamicListElement.builder().code("00003").label("court 3 - 3 address - Y03 7RB").build())).build();
 
     @MockBean
     private Time time;
@@ -845,6 +858,172 @@ public class CreateSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
             );
             assertThat(dynamicList.getValue().getLabel()).isEqualTo("Site 3 - Adr 3 - CCC 333");
         }
+    }
+
+    @ParameterizedTest
+    @MethodSource("testDataUnspec")
+    void whenClaimUnspecAndJudgeSelects_changeTrackOrMaintainAllocatedTrack(CaseData caseData, AllocatedTrack expectedAllocatedTrack) {
+        // When judge selects a different track to which the claim is currently on, update allocatedTrack to match selection
+        // or maintain allocatedTrack if selection already corresponds with selection made.
+        when(featureToggleService.isEarlyAdoptersEnabled()).thenReturn(true);
+        CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
+        AboutToStartOrSubmitCallbackResponse response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+        assertThat(response.getData()).containsEntry("allocatedTrack", expectedAllocatedTrack.name());
+    }
+
+    static Stream<Arguments> testDataUnspec() {
+        DynamicListElement selectedCourt = DynamicListElement.builder()
+            .code("00002").label("court 2 - 2 address - Y02 7RB").build();
+        return Stream.of(
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(UNSPEC_CLAIM)
+                    .allocatedTrack(AllocatedTrack.SMALL_CLAIM)
+                    .fastTrackMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(NO)
+                    .claimsTrack(ClaimsTrack.fastTrack)
+                    .build(),
+                AllocatedTrack.FAST_CLAIM
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(UNSPEC_CLAIM)
+                    .allocatedTrack(AllocatedTrack.SMALL_CLAIM)
+                    .fastTrackMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(YES)
+                    .drawDirectionsOrderSmallClaims(NO)
+                    .orderType(OrderType.DECIDE_DAMAGES)
+                    .build(),
+                AllocatedTrack.FAST_CLAIM
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(UNSPEC_CLAIM)
+                    .allocatedTrack(AllocatedTrack.FAST_CLAIM)
+                    .disposalHearingMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(YES)
+                    .drawDirectionsOrderSmallClaims(NO)
+                    .orderType(OrderType.DISPOSAL)
+                    .build(),
+                AllocatedTrack.FAST_CLAIM
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(UNSPEC_CLAIM)
+                    .allocatedTrack(AllocatedTrack.FAST_CLAIM)
+                    .smallClaimsMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(NO)
+                    .claimsTrack(ClaimsTrack.smallClaimsTrack)
+                    .build(),
+                AllocatedTrack.SMALL_CLAIM
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(UNSPEC_CLAIM)
+                    .allocatedTrack(AllocatedTrack.FAST_CLAIM)
+                    .smallClaimsMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(YES)
+                    .drawDirectionsOrderSmallClaims(YES)
+                    .orderType(OrderType.DECIDE_DAMAGES)
+                    .build(),
+                AllocatedTrack.SMALL_CLAIM
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(UNSPEC_CLAIM)
+                    .allocatedTrack(AllocatedTrack.SMALL_CLAIM)
+                    .disposalHearingMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(YES)
+                    .drawDirectionsOrderSmallClaims(NO)
+                    .orderType(OrderType.DISPOSAL)
+                    .build(),
+                AllocatedTrack.SMALL_CLAIM
+            )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("testDataSpec")
+    void whenClaimSpecAndJudgeSelects_changeTrackOrMaintainClaimResponseTrack(CaseData caseData, String expectedClaimResponseTrack) {
+        // When judge selects a different track to which the claim is currently on, update ClaimResponseTrack to match selection
+        // or maintain ClaimResponseTrack if selection already corresponds with selection made.
+        when(featureToggleService.isEarlyAdoptersEnabled()).thenReturn(true);
+        CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
+        AboutToStartOrSubmitCallbackResponse response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+        assertThat(response.getData()).containsEntry("responseClaimTrack", expectedClaimResponseTrack);
+    }
+
+    static Stream<Arguments> testDataSpec() {
+        DynamicListElement selectedCourt = DynamicListElement.builder()
+            .code("00002").label("court 2 - 2 address - Y02 7RB").build();
+        return Stream.of(
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(SPEC_CLAIM)
+                    .responseClaimTrack("SMALL_CLAIM")
+                    .fastTrackMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(NO)
+                    .claimsTrack(ClaimsTrack.fastTrack)
+                    .build(),
+                "FAST_CLAIM"
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(SPEC_CLAIM)
+                    .responseClaimTrack("SMALL_CLAIM")
+                    .fastTrackMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(YES)
+                    .drawDirectionsOrderSmallClaims(NO)
+                    .orderType(OrderType.DECIDE_DAMAGES)
+                    .build(),
+                "FAST_CLAIM"
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(SPEC_CLAIM)
+                    .responseClaimTrack("FAST_CLAIM")
+                    .disposalHearingMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(YES)
+                    .drawDirectionsOrderSmallClaims(NO)
+                    .orderType(OrderType.DISPOSAL)
+                    .build(),
+                "FAST_CLAIM"
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(SPEC_CLAIM)
+                    .responseClaimTrack("FAST_CLAIM")
+                    .smallClaimsMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(NO)
+                    .claimsTrack(ClaimsTrack.smallClaimsTrack)
+                    .build(),
+                "SMALL_CLAIM"
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(SPEC_CLAIM)
+                    .responseClaimTrack("FAST_CLAIM")
+                    .smallClaimsMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(YES)
+                    .drawDirectionsOrderSmallClaims(YES)
+                    .orderType(OrderType.DECIDE_DAMAGES)
+                    .build(),
+                "SMALL_CLAIM"
+            ),
+            Arguments.of(
+                CaseDataBuilder.builder().atStateClaimDraft().build().toBuilder()
+                    .caseAccessCategory(SPEC_CLAIM)
+                    .responseClaimTrack("SMALL_CLAIM")
+                    .disposalHearingMethodInPerson(options.toBuilder().value(selectedCourt).build())
+                    .drawDirectionsOrderRequired(YES)
+                    .drawDirectionsOrderSmallClaims(NO)
+                    .orderType(OrderType.DISPOSAL)
+                    .build(),
+                "SMALL_CLAIM"
+            )
+        );
     }
 
     @Nested

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
@@ -37,8 +37,6 @@ import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.helpers.DateFormatHelper;
 import uk.gov.hmcts.reform.civil.helpers.LocationHelper;
 import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
-import uk.gov.hmcts.reform.civil.model.finalorders.DatesFinalOrders;
-import uk.gov.hmcts.reform.civil.model.finalorders.OrderMade;
 import uk.gov.hmcts.reform.civil.service.CategoryService;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.model.CaseData;

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadApplicantHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadApplicantHandlerTest.java
@@ -27,12 +27,10 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.SubmittedCallbackResponse;
 import uk.gov.hmcts.reform.civil.callback.CallbackHandler;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
-import uk.gov.hmcts.reform.civil.enums.ClaimType;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.Bundle;
 import uk.gov.hmcts.reform.civil.model.CaseData;
-import uk.gov.hmcts.reform.civil.model.ClaimValue;
 import uk.gov.hmcts.reform.civil.model.IdValue;
 import uk.gov.hmcts.reform.civil.model.caseprogression.UploadEvidenceDocumentType;
 import uk.gov.hmcts.reform.civil.model.caseprogression.UploadEvidenceExpert;
@@ -61,6 +59,8 @@ import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.MID;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.SUBMITTED;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.EVIDENCE_UPLOAD_APPLICANT;
+import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.SMALL_CLAIM;
+import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.CaseRole.RESPONDENTSOLICITORONE;
 import static uk.gov.hmcts.reform.civil.enums.CaseRole.RESPONDENTSOLICITORTWO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
@@ -134,10 +134,8 @@ class EvidenceUploadApplicantHandlerTest extends BaseCallbackHandlerTest {
         // Given
         CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotified().build().toBuilder()
             .notificationText(null)
-            .claimType(ClaimType.CLINICAL_NEGLIGENCE)
-            .claimValue(ClaimValue.builder()
-                            .statementOfValueInPennies(BigDecimal.valueOf(5000))
-                            .build())
+            .allocatedTrack(SMALL_CLAIM)
+            .responseClaimTrack(null)
             .build();
         given(userService.getUserInfo(anyString())).willReturn(UserInfo.builder().uid("uid").build());
         given(coreCaseUserService.userHasCaseRole(any(), any(), any())).willReturn(false);
@@ -154,9 +152,10 @@ class EvidenceUploadApplicantHandlerTest extends BaseCallbackHandlerTest {
     void givenAboutToStart_assignCaseProgAllocatedTrackSpec() {
         // Given
         CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotified().build().toBuilder()
+            .caseAccessCategory(SPEC_CLAIM)
             .notificationText(null)
-            .claimType(null)
-            .totalClaimAmount(BigDecimal.valueOf(12500))
+            .allocatedTrack(null)
+            .responseClaimTrack("FAST_CLAIM")
             .build();
         given(userService.getUserInfo(anyString())).willReturn(UserInfo.builder().uid("uid").build());
         given(coreCaseUserService.userHasCaseRole(any(), any(), any())).willReturn(false);


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-11738

updated CREATE_SDO to update fields (unspec) allocatedTrack or (spec) responseClaimTrack to the track selected by the judge 



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
