### PR TITLE
CIV-8306 Test Dispute Resolution Hearing Small Track SDO

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -8,7 +8,7 @@ import uk.gov.hmcts.contino.GithubAPI
 def type = "java"
 def product = "civil"
 def component = "service"
-def ccdBranch = "master"
+def ccdBranch = "feat/CIV-8306"
 def camundaBranch = "master"
 def yarnBuilder = new uk.gov.hmcts.contino.YarnBuilder(this)
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/enums/sdo/SmallTrack.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/enums/sdo/SmallTrack.java
@@ -1,11 +1,7 @@
 package uk.gov.hmcts.reform.civil.enums.sdo;
 
 public enum SmallTrack {
-    smallClaimBuildingDispute,
     smallClaimCreditHire,
-    smallClaimHousingDisrepair,
     smallClaimRoadTrafficAccident,
-    smallClaimDisputeResolutionHearing,
-    smallClaimPPI,
-    smallClaimFlightDelay
+    smallClaimDisputeResolutionHearing
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/enums/sdo/SmallTrack.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/enums/sdo/SmallTrack.java
@@ -1,6 +1,11 @@
 package uk.gov.hmcts.reform.civil.enums.sdo;
 
 public enum SmallTrack {
+    smallClaimBuildingDispute,
     smallClaimCreditHire,
-    smallClaimRoadTrafficAccident
+    smallClaimHousingDisrepair,
+    smallClaimRoadTrafficAccident,
+    smallClaimDisputeResolutionHearing,
+    smallClaimPPI,
+    smallClaimFlightDelay
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/sdo/SdoHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/sdo/SdoHelper.java
@@ -84,20 +84,12 @@ public class SdoHelper {
 
     public static SmallTrack getSmallClaimsAdditionalDirectionEnum(String additionalDirection) {
         switch (additionalDirection) {
-            case "smallClaimBuildingDispute":
-                return SmallTrack.smallClaimBuildingDispute;
             case "smallClaimCreditHire":
                 return SmallTrack.smallClaimCreditHire;
-            case "smallClaimHousingDisrepair":
-                return SmallTrack.smallClaimHousingDisrepair;
             case "smallClaimRoadTrafficAccident":
                 return SmallTrack.smallClaimRoadTrafficAccident;
             case "smallClaimDisputeResolutionHearing":
                 return SmallTrack.smallClaimDisputeResolutionHearing;
-            case "smallClaimPPI":
-                return SmallTrack.smallClaimPPI;
-            case "smallClaimFlightDelay":
-                return SmallTrack.smallClaimFlightDelay;
             default:
                 return null;
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/sdo/SdoHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/sdo/SdoHelper.java
@@ -84,10 +84,20 @@ public class SdoHelper {
 
     public static SmallTrack getSmallClaimsAdditionalDirectionEnum(String additionalDirection) {
         switch (additionalDirection) {
+            case "smallClaimBuildingDispute":
+                return SmallTrack.smallClaimBuildingDispute;
             case "smallClaimCreditHire":
                 return SmallTrack.smallClaimCreditHire;
+            case "smallClaimHousingDisrepair":
+                return SmallTrack.smallClaimHousingDisrepair;
             case "smallClaimRoadTrafficAccident":
                 return SmallTrack.smallClaimRoadTrafficAccident;
+            case "smallClaimDisputeResolutionHearing":
+                return SmallTrack.smallClaimDisputeResolutionHearing;
+            case "smallClaimPPI":
+                return SmallTrack.smallClaimPPI;
+            case "smallClaimFlightDelay":
+                return SmallTrack.smallClaimFlightDelay;
             default:
                 return null;
         }

--- a/src/test/java/uk/gov/hmcts/reform/civil/helpers/sdo/SdoHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/helpers/sdo/SdoHelperTest.java
@@ -130,6 +130,8 @@ public class SdoHelperTest {
                 .isEqualTo(SmallTrack.smallClaimCreditHire);
             assertThat(SdoHelper.getSmallClaimsAdditionalDirectionEnum("smallClaimRoadTrafficAccident"))
                 .isEqualTo(SmallTrack.smallClaimRoadTrafficAccident);
+            assertThat(SdoHelper.getSmallClaimsAdditionalDirectionEnum("smallClaimDisputeResolutionHearing"))
+                .isEqualTo(SmallTrack.smallClaimDisputeResolutionHearing);
         }
 
         @Test
@@ -169,6 +171,22 @@ public class SdoHelperTest {
                 .build();
 
             assertThat(SdoHelper.hasSmallAdditionalDirections(caseData, "smallClaimRoadTrafficAccident"))
+                .isTrue();
+        }
+
+        @Test
+        void shouldReturnTrue_ifHasDisputeResolutionHearing() {
+            List<SmallTrack> directions = List.of(SmallTrack.smallClaimDisputeResolutionHearing);
+            CaseData caseData = CaseDataBuilder.builder()
+                .atStateClaimDraft()
+                .build()
+                .toBuilder()
+                .drawDirectionsOrderRequired(NO)
+                .claimsTrack(ClaimsTrack.smallClaimsTrack)
+                .smallClaims(directions)
+                .build();
+
+            assertThat(SdoHelper.hasSmallAdditionalDirections(caseData, "smallClaimDisputeResolutionHearing"))
                 .isTrue();
         }
 


### PR DESCRIPTION
### JIRA link ###
[Judge's Screen: Order Details - Dispute Resolution Hearing Section (Small Track SDO) ](https://tools.hmcts.net/jira/browse/CIV-8306)


### Change description ###

When a judge is making a Small Claims Track SDO, upon selecting Dispute resolution hearing from the option list, when the judge go to the Order Details screen, the section should be available for the Judge to make the order for Dispute Resolution Hearing.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
