### PR TITLE
CIV-0000 Fix Hearing Notice Generator Locations

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtils.java
@@ -266,7 +266,7 @@ public class HmcDataUtils {
     @Nullable
     public static LocationRefData getLocationRefData(String hearingId, String venueId,
                                                      String bearerToken, LocationRefDataService locationRefDataService) {
-        List<LocationRefData> locations = locationRefDataService.getCourtLocationsForDefaultJudgments(bearerToken);
+        List<LocationRefData> locations = locationRefDataService.getHearingCourtLocations(bearerToken);
         var matchedLocations =  locations.stream().filter(loc -> loc.getEpimmsId().equals(venueId)).toList();
         if (matchedLocations.size() > 0) {
             return matchedLocations.get(0);

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateHearingNoticeHmcHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateHearingNoticeHmcHandlerTest.java
@@ -119,7 +119,7 @@ public class GenerateHearingNoticeHmcHandlerTest extends BaseCallbackHandlerTest
 
         List<LocationRefData> locations = List.of(LocationRefData.builder()
                                                       .epimmsId(EPIMS).build());
-        when(locationRefDataService.getCourtLocationsForDefaultJudgments(anyString()))
+        when(locationRefDataService.getHearingCourtLocations(anyString()))
             .thenReturn(locations);
         when(camundaService.getProcessVariables(PROCESS_INSTANCE_ID)).thenReturn(inputVariables);
         when(hearingsService.getHearingResponse(anyString(), anyString())).thenReturn(hearing);
@@ -187,7 +187,7 @@ public class GenerateHearingNoticeHmcHandlerTest extends BaseCallbackHandlerTest
 
         List<LocationRefData> locations = List.of(LocationRefData.builder()
                                                       .epimmsId(EPIMS).build());
-        when(locationRefDataService.getCourtLocationsForDefaultJudgments(anyString()))
+        when(locationRefDataService.getHearingCourtLocations(anyString()))
             .thenReturn(locations);
         when(camundaService.getProcessVariables(PROCESS_INSTANCE_ID)).thenReturn(inputVariables);
         when(hearingsService.getHearingResponse(anyString(), anyString())).thenReturn(hearing);

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearing/HearingNoticeHmcGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/docmosis/hearing/HearingNoticeHmcGeneratorTest.java
@@ -98,7 +98,7 @@ class HearingNoticeHmcGeneratorTest {
             .thenReturn(CASE_DOCUMENT);
 
         when(locationRefDataService
-                 .getCourtLocationsForDefaultJudgments(BEARER_TOKEN)).thenReturn(List.of(LocationRefData.builder()
+                 .getHearingCourtLocations(BEARER_TOKEN)).thenReturn(List.of(LocationRefData.builder()
                                                                                              .epimmsId(EPIMS)
                                                                                              .siteName("SiteName")
                                                                                              .courtAddress(

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
@@ -1172,7 +1172,7 @@ class HmcDataUtilsTest {
         @Test
         void shouldReturnLocation_whenInvoked() {
             List<LocationRefData> locations = List.of(LocationRefData.builder().epimmsId("venue").build());
-            when(locationRefDataService.getCourtLocationsForDefaultJudgments("authToken"))
+            when(locationRefDataService.getHearingCourtLocations("authToken"))
                 .thenReturn(locations);
             LocationRefData locationRefData = HmcDataUtils.getLocationRefData(
                 "HER123",
@@ -1186,7 +1186,7 @@ class HmcDataUtilsTest {
 
         @Test
         void shouldThrowException_whenLocationIsNull() {
-            when(locationRefDataService.getCourtLocationsForDefaultJudgments("abc"))
+            when(locationRefDataService.getHearingCourtLocations("abc"))
                 .thenReturn(null);
             assertThrows(
                 IllegalArgumentException.class,


### PR DESCRIPTION
There is currently an issue when a hearing is listed for a supported hearing location such as Derby Magistrates causing causing the hearing notice generator to error out when triggered via the hearing notice scheduler.
The hearing notice generator calls location refdata to retrieve hearing locations, to be able to retrieve the hearing venue name. It is currently setup to retrieve locations where they are both hearing locations and case management locations rather than just hearing locations.
This fix ensures we are filtering by just hearing locations.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
