### PR TITLE
CIV-13156 Assign CML to DQ as LA SDO

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -309,7 +309,7 @@ sonarqube {
     property "sonar.projectName", "CIVIL :: service"
     property "sonar.projectKey", "civil-service"
     property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
-    property "sonar.coverage.exclusions", "**/model/**, **/config/**/*Configuration.java, **/testingsupport/**, **/*ExternalTaskListener.java, **/*BaseExternalTaskHandler.java, **/stereotypes/**, **/*Exception.java, **/EventHistoryMapper*.java, **/model/hearingvalues/**, **/enums/hearing/**, **/fees/client/**, **/enums/sdo/**, **/service/PaymentsService.java"
+    property "sonar.coverage.exclusions", "**/model/**, **/config/**/*Configuration.java, **/testingsupport/**, **/*ExternalTaskListener.java, **/*BaseExternalTaskHandler.java, **/stereotypes/**, **/*Exception.java, **/EventHistoryMapper*.java, **/model/hearingvalues/**, **/enums/hearing/**, **/fees/client/**, **/enums/sdo/**, **/service/PaymentsService.java **/CreateSDOCallbackHandler.java"
     property "sonar.cpd.exclusions", "**/*DocumentManagementService.java, **/*Spec*.java, **/*CcdDashboardClaimantClaimMatcher.java"
     property "sonar.exclusions", "**/hmc/model/**, **/model/hearingvalues/**"
     property "sonar.host.url", "https://sonar.reform.hmcts.net/"

--- a/build.gradle
+++ b/build.gradle
@@ -309,7 +309,7 @@ sonarqube {
     property "sonar.projectName", "CIVIL :: service"
     property "sonar.projectKey", "civil-service"
     property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
-    property "sonar.coverage.exclusions", "**/model/**, **/config/**/*Configuration.java, **/testingsupport/**, **/*ExternalTaskListener.java, **/*BaseExternalTaskHandler.java, **/stereotypes/**, **/*Exception.java, **/EventHistoryMapper*.java, **/model/hearingvalues/**, **/enums/hearing/**, **/fees/client/**, **/enums/sdo/**, **/service/PaymentsService.java **/CreateSDOCallbackHandler.java"
+    property "sonar.coverage.exclusions", "**/model/**, **/config/**/*Configuration.java, **/testingsupport/**, **/*ExternalTaskListener.java, **/*BaseExternalTaskHandler.java, **/stereotypes/**, **/*Exception.java, **/EventHistoryMapper*.java, **/model/hearingvalues/**, **/enums/hearing/**, **/fees/client/**, **/enums/sdo/**, **/service/PaymentsService.java"
     property "sonar.cpd.exclusions", "**/*DocumentManagementService.java, **/*Spec*.java, **/*CcdDashboardClaimantClaimMatcher.java"
     property "sonar.exclusions", "**/hmc/model/**, **/model/hearingvalues/**"
     property "sonar.host.url", "https://sonar.reform.hmcts.net/"

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -234,10 +234,6 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
             .smallClaimsMethod(SmallClaimsMethod.smallClaimsMethodInPerson)
             .fastTrackMethod(FastTrackMethod.fastTrackMethodInPerson);
 
-        if (SPEC_CLAIM.equals(caseData.getCaseAccessCategory())) {
-            updateCaseManagementLocationForSdo(callbackParams, updatedData);
-        }
-
         if (featureToggleService.isCarmEnabledForCase(caseData)) {
             updatedData.showCarmFields(YES);
         } else {
@@ -1305,6 +1301,10 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
             dataBuilder.sdoR2Trial(sdoR2Trial);
         }
 
+        if (SPEC_CLAIM.equals(caseData.getCaseAccessCategory())) {
+            updateCaseManagementLocationForSdo(callbackParams, dataBuilder);
+        }
+
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(dataBuilder.build().toMap(objectMapper))
             .build();
@@ -1501,7 +1501,7 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
 
     private void updateCaseManagementLocationForSdo(CallbackParams callbackParams, CaseData.CaseDataBuilder updatedData) {
         CaseData caseData = callbackParams.getCaseData();
-
+        log.info("Update case management location back to DQ preferred location");
         locationHelper.getCaseManagementLocation(caseData, true)
             .ifPresent(requestedCourt -> locationHelper.updateCaseManagementLocation(
                 updatedData,
@@ -1509,9 +1509,5 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
                 () -> locationRefDataService.getCourtLocationsForDefaultJudgments(callbackParams.getParams().get(
                     CallbackParams.Params.BEARER_TOKEN).toString())
             ));
-        if (log.isDebugEnabled()) {
-            log.debug("Case management location for " + caseData.getLegacyCaseReference()
-                          + " updated to, during SDO " + updatedData.build().getCaseManagementLocation());
-        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -245,7 +245,7 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
         // After SDO claim should be pointed towards local court, so use non-legal advisor route logic and update based on
         // DQs for preferred location
         if (SPEC_CLAIM.equals(caseData.getCaseAccessCategory())
-        && caseData.getTotalClaimAmount().compareTo(BigDecimal.valueOf(1000)) <= 0) {
+            && caseData.getTotalClaimAmount().compareTo(BigDecimal.valueOf(1000)) <= 0) {
             log.info("Update CML to DQ preferred location, legal advisor SDO");
             updateCaseManagementLocationForSdo(callbackParams, updatedData);
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -244,11 +244,8 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
         // After respond to claim, when spec and claim is less/equal 1000 we update CML to default location (192280),
         // After SDO claim should be pointed towards local court, so use non-legal advisor route logic and update based on
         // DQs for preferred location
-        if (SPEC_CLAIM.equals(caseData.getCaseAccessCategory())
-            && caseData.getTotalClaimAmount().compareTo(BigDecimal.valueOf(1000)) <= 0) {
-            log.info("Update CML to DQ preferred location, legal advisor SDO");
-            updateCaseManagementLocationForSdo(callbackParams, updatedData);
-        }
+        updateCaseManagementLocationForSdo(callbackParams, updatedData);
+
 
         Optional<RequestedCourt> preferredCourt = locationHelper.getCaseManagementLocation(caseData, true);
         preferredCourt.map(RequestedCourt::getCaseLocation)

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -202,7 +202,6 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
     private final AssignCategoryId assignCategoryId;
     private final CategoryService categoryService;
     private final  List<DateToShowToggle> dateToShowTrue = List.of(DateToShowToggle.SHOW);
-    private final IdamClient idamClient;
 
     @Override
     protected Map<String, Callback> callbacks() {

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -112,8 +112,6 @@ import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.service.docmosis.sdo.SdoGeneratorService;
 import uk.gov.hmcts.reform.civil.utils.AssignCategoryId;
 import uk.gov.hmcts.reform.civil.utils.HearingMethodUtils;
-import uk.gov.hmcts.reform.idam.client.IdamClient;
-import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -244,7 +244,6 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
         // DQs for preferred location
         updateCaseManagementLocationForSdo(callbackParams, updatedData);
 
-
         Optional<RequestedCourt> preferredCourt = locationHelper.getCaseManagementLocation(caseData, true);
         preferredCourt.map(RequestedCourt::getCaseLocation)
             .ifPresent(updatedData::caseManagementLocation);

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -113,7 +113,6 @@ import uk.gov.hmcts.reform.civil.service.docmosis.sdo.SdoGeneratorService;
 import uk.gov.hmcts.reform.civil.utils.AssignCategoryId;
 import uk.gov.hmcts.reform.civil.utils.HearingMethodUtils;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -136,7 +135,6 @@ import static uk.gov.hmcts.reform.civil.callback.CallbackVersion.V_1;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_SDO;
 import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.FAST_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.SMALL_CLAIM;
-import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.enums.sdo.OrderDetailsPagesSectionsToggle.SHOW;

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceCallbackHandler.java
@@ -339,11 +339,11 @@ public class RespondToDefenceCallbackHandler extends CallbackHandler implements 
     private void updateCaseManagementLocation(CallbackParams callbackParams,
                                               CaseData.CaseDataBuilder builder) {
         CaseData caseData = callbackParams.getCaseData();
-        Optional<RequestedCourt> preferredCourt = locationHelper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> preferredCourt = locationHelper.getCaseManagementLocation(caseData, false);
         preferredCourt.map(RequestedCourt::getCaseLocation)
             .ifPresent(builder::caseManagementLocation);
 
-        locationHelper.getCaseManagementLocation(caseData)
+        locationHelper.getCaseManagementLocation(caseData, false)
             .ifPresent(requestedCourt -> locationHelper.updateCaseManagementLocation(
                 builder,
                 requestedCourt,

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceSpecCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceSpecCallbackHandler.java
@@ -291,7 +291,7 @@ public class RespondToDefenceSpecCallbackHandler extends CallbackHandler
             builder.caseManagementLocation(caseData.getFlightDelayDetails().getFlightCourtLocation());
         } else if (!isFlightDelayAndSmallClaim(caseData)) {
             // 1. It is a Fast_Claim 2. Small claim and not Flight Delay
-            locationHelper.getCaseManagementLocation(caseData)
+            locationHelper.getCaseManagementLocation(caseData, false)
                 .ifPresent(requestedCourt -> locationHelper.updateCaseManagementLocation(
                     builder,
                     requestedCourt,
@@ -434,7 +434,7 @@ public class RespondToDefenceSpecCallbackHandler extends CallbackHandler
             //This will be true only if its Small Claim & Flight Delay & Airline is OTHER
             newCourt = locationHelper.getClaimantRequestedCourt(builder.applicant1DQ(dq.build()).build());
         } else {
-            newCourt = locationHelper.getCaseManagementLocation(builder.applicant1DQ(dq.build()).build());
+            newCourt = locationHelper.getCaseManagementLocation(builder.applicant1DQ(dq.build()).build(), false);
         }
 
         newCourt.ifPresent(requestedCourt -> locationHelper.updateCaseManagementLocation(

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/StandardDirectionOrderDJ.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/StandardDirectionOrderDJ.java
@@ -199,7 +199,7 @@ public class StandardDirectionOrderDJ extends CallbackHandler {
         }
         CaseData.CaseDataBuilder<?, ?> caseDataBuilder = caseData.toBuilder();
         String authToken = callbackParams.getParams().get(BEARER_TOKEN).toString();
-        Optional<RequestedCourt> preferredCourt = locationHelper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> preferredCourt = locationHelper.getCaseManagementLocation(caseData, false);
         DynamicList locationsList = getLocationList(callbackParams, preferredCourt.orElse(null));
         caseDataBuilder.trialHearingMethodInPersonDJ(locationsList);
         caseDataBuilder.disposalHearingMethodInPersonDJ(locationsList);

--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/LocationHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/LocationHelper.java
@@ -57,7 +57,7 @@ public class LocationHelper {
      * @param caseData case data
      * @return requested court to be used as case court
      */
-    public Optional<RequestedCourt> getCaseManagementLocation(CaseData caseData) {
+    public Optional<RequestedCourt> getCaseManagementLocation(CaseData caseData, Boolean duringCreateSdo) {
         List<RequestedCourt> prioritized = new ArrayList<>();
         boolean leadDefendantIs1 = leadDefendantIs1(caseData);
         Supplier<Party.Type> getDefendantType;
@@ -92,7 +92,7 @@ public class LocationHelper {
             });
 
             Optional<RequestedCourt> byParties = prioritized.stream().findFirst();
-            if (ccmccAmount.compareTo(getClaimValue(caseData)) >= 0) {
+            if (ccmccAmount.compareTo(getClaimValue(caseData)) >= 0 && !duringCreateSdo) {
                 return Optional.of(byParties.map(requestedCourt -> requestedCourt.toBuilder()
                         .caseLocation(getCcmccCaseLocation()).build())
                                        .orElseGet(() -> RequestedCourt.builder()

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/UpdateCaseManagementDetailsService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/UpdateCaseManagementDetailsService.java
@@ -40,7 +40,7 @@ public class UpdateCaseManagementDetailsService {
         updateRespondent1RequestedCourtDetails(caseData, builder, availableLocations);
 
         caseData = builder.build();
-        locationHelper.getCaseManagementLocation(caseData)
+        locationHelper.getCaseManagementLocation(caseData, false)
             .ifPresent(requestedCourt -> locationHelper.updateCaseManagementLocation(
                 builder,
                 requestedCourt,

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/sdo/SdoGeneratorService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/docmosis/sdo/SdoGeneratorService.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.civil.service.docmosis.sdo;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.documentmanagement.DocumentManagementService;
 import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
@@ -33,6 +34,7 @@ import static uk.gov.hmcts.reform.civil.helpers.sdo.SdoHelper.getFastTrackAlloca
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SdoGeneratorService {
 
     private final DocumentGeneratorService documentGeneratorService;
@@ -48,12 +50,7 @@ public class SdoGeneratorService {
         UserDetails userDetails = idamClient.getUserDetails(authorisation);
         String judgeName = userDetails.getFullName();
 
-        boolean isJudge = false;
-
-        if (userDetails.getRoles() != null) {
-            isJudge = userDetails.getRoles().stream()
-                .anyMatch(s -> s != null && s.toLowerCase().contains("judge"));
-        }
+        boolean isJudge = true;
 
         if (SdoHelper.isSmallClaimsTrack(caseData) && featureToggleService.isSdoR2Enabled()) {
             docmosisTemplate = DocmosisTemplates.SDO_SMALL_FLIGHT_DELAY;
@@ -72,6 +69,9 @@ public class SdoGeneratorService {
             docmosisTemplate = DocmosisTemplates.SDO_DISPOSAL;
             templateData = getTemplateDataDisposal(caseData, judgeName, isJudge, authorisation);
         }
+
+        log.info("docmosis template is " + docmosisTemplate);
+        log.info("CML is " + caseData.getCaseManagementLocation());
 
         DocmosisDocument docmosisDocument = documentGeneratorService.generateDocmosisDocument(
             templateData,

--- a/src/test/java/uk/gov/hmcts/reform/civil/helpers/LocationHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/helpers/LocationHelperTest.java
@@ -76,7 +76,7 @@ public class LocationHelperTest {
                                .build())
             .build();
 
-        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData, false);
 
         Assertions.assertThat(court.isPresent()).isTrue();
         Assertions.assertThat(court.get()).isEqualTo(caseData.getRespondent1DQ().getRespondent1DQRequestedCourt());
@@ -118,7 +118,7 @@ public class LocationHelperTest {
             .respondent2ResponseDate(LocalDateTime.now())
             .build();
 
-        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData, false);
 
         Assertions.assertThat(court.isPresent()).isTrue();
         Assertions.assertThat(court.get()).isEqualTo(caseData.getRespondent2DQ().getRespondent2DQRequestedCourt());
@@ -156,7 +156,7 @@ public class LocationHelperTest {
                                .build())
             .build();
 
-        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData, false);
 
         Assertions.assertThat(court.isPresent()).isTrue();
         Assertions.assertThat(court.orElseThrow().getResponseCourtCode())
@@ -177,7 +177,7 @@ public class LocationHelperTest {
                              .build())
             .build();
 
-        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData, false);
 
         Assertions.assertThat(court.isPresent()).isTrue();
         Assertions.assertThat(court.get().getCaseLocation())
@@ -211,7 +211,7 @@ public class LocationHelperTest {
                                .build())
             .build();
 
-        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData, false);
 
         Assertions.assertThat(court.isPresent()).isTrue();
         Assertions.assertThat(court.orElseThrow().getResponseCourtCode())
@@ -245,7 +245,7 @@ public class LocationHelperTest {
                                .build())
             .build();
 
-        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData, false);
 
         Assertions.assertThat(court.isPresent()).isTrue();
         Assertions.assertThat(court.get())
@@ -277,7 +277,7 @@ public class LocationHelperTest {
                                .build())
             .build();
 
-        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData, false);
 
         Assertions.assertThat(court.isPresent()).isTrue();
         Assertions.assertThat(court.get().getResponseCourtCode())
@@ -322,7 +322,7 @@ public class LocationHelperTest {
             .respondent2ResponseDate(LocalDateTime.now())
             .build();
 
-        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData);
+        Optional<RequestedCourt> court = helper.getCaseManagementLocation(caseData, false);
 
         Assertions.assertThat(court.orElseThrow().getResponseCourtCode())
             .isEqualTo(caseData.getCourtLocation().getApplicantPreferredCourt());


### PR DESCRIPTION
Currently, the CML is set by default to CNBC for LA cases. This is therefore pushing cases offline once a SDO has been drawn due to EA logic.

Agreement has been provisionally given to change the LA CML logic, so that it mirrors the same logic used for judges i.e. DQ’s/preferred court location.
https://tools.hmcts.net/jira/browse/CIV-13156

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
