### PR TITLE
CIV-0000 CLAIM_DISMISSED_HEARING_FEE_DUE_DEADLINE to spec cases

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/flowstate/FlowStateAllowedEventService.java
@@ -1627,6 +1627,13 @@ public class FlowStateAllowedEventService {
             List.of(
                 REQUEST_JUDGEMENT_ADMISSION_SPEC
             )
+        ),
+        entry(
+            CLAIM_DISMISSED_HEARING_FEE_DUE_DEADLINE.fullName(),
+            List.of(
+                CASE_PROCEEDS_IN_CASEMAN,
+                ADD_CASE_NOTE
+            )
         )
     );
 


### PR DESCRIPTION
Case cannot have case note added as flowstate is in CLAIM_DISMISSED_HEARING_FEE_DUE_DEADLINE 
And spec case do not currently allow ADD_CASE_NOTE in this scenario, updated to align with unspec


https://tools.hmcts.net/jira/browse/CIV-13232

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
