### PR TITLE
CIV-0000 Fixed population of docs after a bundle is created

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadHandlerBase.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadHandlerBase.java
@@ -1227,9 +1227,18 @@ abstract class EvidenceUploadHandlerBase extends CallbackHandler {
                 // If a document already exists in the collection, it cannot be re-added.
                 boolean containsValue = additionalBundleDocs.stream()
                     .map(Element::getValue)
-                    .map(UploadEvidenceDocumentType::getDocumentUpload)
+                    .map(upload -> upload != null ? upload.getDocumentUpload() : null)
+                    .filter(docUpload -> docUpload != null)
                     .map(Document::getDocumentUrl)
                     .anyMatch(docUrl -> docUrl.equals(documentToAdd.getDocumentUrl()));
+                // When a bundle is created, applicantDocsUploadedAfterBundle and respondentDocsUploadedAfterBundle
+                // are assigned as empty lists, in actuality they contain a single element (default builder) we remove
+                // this as it is not required.
+                additionalBundleDocs.removeIf(element -> {
+                    UploadEvidenceDocumentType upload = element.getValue();
+                    return upload == null || upload.getDocumentUpload() == null
+                        || upload.getDocumentUpload().getDocumentUrl() == null;
+                });
                 if (!containsValue) {
                     var newDocument = UploadEvidenceDocumentType.builder()
                         .typeOfDocument(documentTypeDisplayName)

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadApplicantHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/EvidenceUploadApplicantHandlerTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.civil.handler.callback.user;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -599,6 +600,32 @@ class EvidenceUploadApplicantHandlerTest extends BaseCallbackHandlerTest {
         ReflectionUtils.invokeMethod(ReflectionUtils.getRequiredMethod(target.getClass(),
                                                                        method, argument.getClass()), target, argument);
         return target;
+    }
+
+    @Test
+    void shouldAddApplicantEvidenceDocWhenBundleCreatedDateIsBeforeEvidenceUploaded_onNewCreatedBundle() {
+        List<Element<UploadEvidenceDocumentType>> applicantDocsUploadedAfterBundle = new ArrayList<>();
+        UploadEvidenceDocumentType document = new UploadEvidenceDocumentType();
+        document.setCreatedDatetime(LocalDateTime.now(ZoneId.of("Europe/London")));
+        applicantDocsUploadedAfterBundle.add(ElementUtils.element(document));
+        // Given caseBundles with bundle created date is before witness and expert doc created date
+        CaseData caseData = CaseDataBuilder.builder().atStateNotificationAcknowledged().build().toBuilder()
+            // populate applicantDocsUploadedAfterBundle with a default built element after a new bundle, it only
+            // contains createdDatetime and no document, so will be removed from final list
+            .applicantDocsUploadedAfterBundle(applicantDocsUploadedAfterBundle)
+            // added after trial bundle, so will  be added
+            .documentWitnessStatement(getWitnessDocs(LocalDateTime.of(2022, 05, 10, 12, 13, 12), "url22"))
+            .documentExpertReport(getExpertDocs(LocalDateTime.of(2022, 06, 10, 12, 13, 12), "url44"))
+            .caseBundles(prepareCaseBundles(LocalDateTime.of(2022, 04, 10, 12, 12, 12))).build();
+        CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
+        given(userService.getUserInfo(anyString())).willReturn(UserInfo.builder().uid("uid").build());
+        given(coreCaseUserService.userHasCaseRole(any(), any(), eq(RESPONDENTSOLICITORONE))).willReturn(false);
+        given(coreCaseUserService.userHasCaseRole(any(), any(), eq(RESPONDENTSOLICITORTWO))).willReturn(false);
+        // When handle is called
+        var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+        CaseData updatedData = mapper.convertValue(response.getData(), CaseData.class);
+        // Then applicant docs uploaded after bundle should return size 2, 2 new docs and 1 being removed.
+        assertThat(updatedData.getApplicantDocsUploadedAfterBundle()).hasSize(2);
     }
 
     @Test


### PR DESCRIPTION
Fixed null pointer when a new bundle has been created and we stream lists to check for duplicate docs during evidence upload. 

respondentDocsUploadedAfterBundle and applicantDocsUploadedAfterBundle are populated with default builder createddatetime, but not an actual document. 

Added null guard and remove empty element (element with only createddatetime)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
