### PR TITLE
DTSCCI-000 re-add kotlin deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,13 @@ allprojects {
       dependencySet(group: 'com.google.guava', version: '33.1.0-jre') {
         entry 'guava'
       }
+
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-common', version: '1.8.20'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk7', version: '1.8.20'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.8.20'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.8.20'
+      dependency group: 'org.jetbrains.kotlin', name: 'kotlin-reflect', version: '1.8.20'
+
       // CVE-2021-29425
       dependency group: 'commons-io', name: 'commons-io', version: '2.16.1'
       dependency group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.12.0'
@@ -431,6 +438,7 @@ dependencies {
   implementation group: 'org.elasticsearch', name: 'elasticsearch', version: '7.17.20'
   implementation group: 'com.networknt', name: 'json-schema-validator', version: '1.4.0'
 
+  implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: versions.jackson
   implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.17.0'
 
   implementation group: 'org.camunda.bpm', name: 'camunda-external-task-client', version: '7.17.0'


### PR DESCRIPTION
These dependencies were removed because I thought they weren't necessary but removing them introduced intermittent exceptions:

```
2024-04-15T17:33:12.236 ERROR [http-nio-4000-exec-9] o.a.c.c.C.[.[localhost].[/].[dispatcherServlet]java.lang.ClassNotFoundException: com.fasterxml.jackson.module.kotlin.ExtensionsKt
	at org.camunda.bpm.extension.rest.config.CamundaFeignExceptionDecoder.decodeException(FeignErrorDecoderConfiguration.kt:84)
	at org.camunda.bpm.extension.rest.config.FeignErrorDecoderConfiguration$errorDecoder$1.decode(FeignErrorDecoderConfiguration.kt:61)
	at feign.AsyncResponseHandler.handleResponse(AsyncResponseHandler.java:98)
	at feign.SynchronousMethodHandler.executeAndDecode(SynchronousMethodHandler.java:141)
```

It's possible that the dependency set entries are not required and it's just the jackson module, but further investigation is required. 