### PR TITLE
CIV-13275 Physical Hearing bundle section (Cosmetic change)

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/constants/SdoR2UiConstantFastTrack.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/constants/SdoR2UiConstantFastTrack.java
@@ -76,8 +76,7 @@ public final class SdoR2UiConstantFastTrack {
         " be double spaced using a font size of 12.";
     public static final String PECUNIARY_LOSS = "If there is a claim for future pecuniary loss and the parties have " +
         "not already set out their case on periodical payments, they must do so in the respective schedule and counter-schedule.";
-    public static final String PHYSICAL_TRIAL_BUNDLE = "The Claimant shall deliver to the court a physical copy of" +
-        " the court generated bundle no later than 10 days before the trial.";
+    public static final String PHYSICAL_TRIAL_BUNDLE = "The Claimant's solicitor shall bring to the court, on the day of the hearing, a paper copy of the hearing bundle.";
 
     public static final String WELSH_LANG_DESCRIPTION =
         """

--- a/src/main/java/uk/gov/hmcts/reform/civil/constants/SdoR2UiConstantSmallClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/constants/SdoR2UiConstantSmallClaim.java
@@ -56,7 +56,7 @@ public final class SdoR2UiConstantSmallClaim {
     public static final String RESTRICT_NUMBER_PAGES_TEXT1 = "Each witness statement should be no more than";
     public static final String RESTRICT_NUMBER_PAGES_TEXT2 = "pages of A4 (including exhibits). Statements should" +
         " be double spaced using a font size of 12.";
-    public static final String BUNDLE_TEXT = "The Claimant shall deliver to the court a physical copy of the court generated bundle no later than 10 days before the trial.";
+    public static final String BUNDLE_TEXT = "The Claimant's solicitor shall bring to the court, on the day of the hearing, a paper copy of the hearing bundle.";
     public static final String IMP_NOTES_TEXT = "This order has been made without hearing. Each party has the right to apply to have this Order set aside or varied." +
         " Any such application must be received by the Court" +
         " (together with the appropriate fee) by 4pm on";

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandler.java
@@ -980,7 +980,7 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
                                                 .trialOnOptions(HearingOnRadioOptions.OPEN_DATE)
                                                 .methodOfHearing(hearingMethodList)
                                                 .lengthList(SmallClaimsSdoR2TimeEstimate.THIRTY_MINUTES)
-                                                .physicalBundleOptions(SmallClaimsSdoR2PhysicalTrialBundleOptions.NO)
+                                                .physicalBundleOptions(SmallClaimsSdoR2PhysicalTrialBundleOptions.PARTY)
                                                 .sdoR2SmallClaimsHearingFirstOpenDateAfter(SdoR2SmallClaimsHearingFirstOpenDateAfter.builder()
                                                                                   .listFrom(LocalDate.now().plusDays(56)).build())
                                                 .sdoR2SmallClaimsHearingWindow(SdoR2SmallClaimsHearingWindow.builder().dateTo(LocalDate.now().plusDays(70))
@@ -1061,7 +1061,7 @@ public class CreateSDOCallbackHandler extends CallbackHandler {
                                    .trialOnOptions(TrialOnRadioOptions.OPEN_DATE)
                                    .lengthList(FastTrackHearingTimeEstimate.FIVE_HOURS)
                                    .methodOfHearing(hearingMethodList)
-                                   .physicalBundleOptions(PhysicalTrialBundleOptions.NONE)
+                                   .physicalBundleOptions(PhysicalTrialBundleOptions.PARTY)
                                    .sdoR2TrialFirstOpenDateAfter(
                                        SdoR2TrialFirstOpenDateAfter.builder()
                                                                      .listFrom(LocalDate.now().plusDays(434)).build())

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
@@ -2574,7 +2574,7 @@ public class CreateSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
                 .collect(Collectors.toList());
             assertThat(hearingMethodValuesDRHActual).containsOnly(HearingMethod.IN_PERSON.getLabel());
             assertThat(data.getSdoR2SmallClaimsHearing().getLengthList()).isEqualTo(SmallClaimsSdoR2TimeEstimate.THIRTY_MINUTES);
-            assertThat(data.getSdoR2SmallClaimsHearing().getPhysicalBundleOptions()).isEqualTo(SmallClaimsSdoR2PhysicalTrialBundleOptions.NO);
+            assertThat(data.getSdoR2SmallClaimsHearing().getPhysicalBundleOptions()).isEqualTo(SmallClaimsSdoR2PhysicalTrialBundleOptions.PARTY);
             assertThat(data.getSdoR2SmallClaimsHearing().getSdoR2SmallClaimsHearingFirstOpenDateAfter().getListFrom()).isEqualTo(LocalDate.now().plusDays(56));
             assertThat(data.getSdoR2SmallClaimsHearing().getSdoR2SmallClaimsHearingWindow().getListFrom()).isEqualTo(LocalDate.now().plusDays(56));
             assertThat(data.getSdoR2SmallClaimsHearing().getSdoR2SmallClaimsHearingWindow().getDateTo()).isEqualTo(LocalDate.now().plusDays(70));

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/CreateSDOCallbackHandlerTest.java
@@ -557,7 +557,7 @@ public class CreateSDOCallbackHandlerTest extends BaseCallbackHandlerTest {
                 .extracting("methodOfHearing").extracting("value").extracting("label").asString().isEqualTo(
                     HearingMethod.IN_PERSON.getLabel());
             assertThat(response.getData()).extracting("sdoR2Trial")
-                .extracting("physicalBundleOptions").asString().isEqualTo(PhysicalTrialBundleOptions.NONE.toString());
+                .extracting("physicalBundleOptions").asString().isEqualTo(PhysicalTrialBundleOptions.PARTY.toString());
             assertThat(response.getData()).extracting("sdoR2Trial")
                 .extracting("sdoR2TrialFirstOpenDateAfter").extracting("listFrom").asString().isEqualTo(LocalDate.now().plusDays(434).toString());
             assertThat(response.getData()).extracting("sdoR2Trial")


### PR DESCRIPTION
### JIRA link (if applicable) ###

[CIV-13275 Physical Hearing bundle section (Cosmetic change)](https://tools.hmcts.net/jira/browse/CIV-13725)

### Change description ###

Judge's Order Details screen (DRH/NIHL)

Cosmetic change needed on all Judge's Order details screen where the "Physical hearing/trial bundle" section appears.
the default selected option should be "Party" replace the text field content with "The Claimant's solicitor shall bring to the court, on the day of the hearing, a paper copy of the hearing bundle"

![image](https://github.com/hmcts/civil-service/assets/148855113/5e335264-d267-44f4-a4c5-b337553343aa)
![image](https://github.com/hmcts/civil-service/assets/148855113/01833975-ce1a-4ce5-a189-5478ed33b6e9)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
