### PR TITLE
CIV-14483 - Postgres image substitution 

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/config/ContainerImageNameSubstitutor.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/config/ContainerImageNameSubstitutor.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.civil.config;
+
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.ImageNameSubstitutor;
+
+public class ContainerImageNameSubstitutor extends ImageNameSubstitutor {
+
+    private final DockerImageName hmctsPostgresDockerImage = DockerImageName
+        .parse("hmctspublic.azurecr.io/imported/postgres:15")
+        .asCompatibleSubstituteFor("postgres");
+
+    @Override
+    public DockerImageName apply(DockerImageName original) {
+
+        if (original.asCanonicalNameString().contains("postgres")) {
+            return hmctsPostgresDockerImage;
+        }
+
+        return original;
+    }
+
+    @Override
+    protected String getDescription() {
+        return "hmcts acr substitutor";
+    }
+}

--- a/src/integrationTest/resources/testcontainers.properties
+++ b/src/integrationTest/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+image.substitutor=uk.gov.hmcts.reform.civil.config.ContainerImageNameSubstitutor


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-14483

- Added test containers configuration to switch the source of the postgres image from dockerhub to hmcts cached postgres image


**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
