### PR TITLE
CIV-14458 Spec Claimant - Add Draft Directions to DQ

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/DQResponseDocumentUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/DQResponseDocumentUtils.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.civil.utils;
+
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.DocumentType;
+import uk.gov.hmcts.reform.civil.enums.DocCategory;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.common.Element;
+import uk.gov.hmcts.reform.civil.model.dq.DQ;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Objects.nonNull;
+import static uk.gov.hmcts.reform.civil.utils.ElementUtils.buildElemCaseDocument;
+
+@Component
+@AllArgsConstructor
+public class DQResponseDocumentUtils {
+
+    private static final String CLAIMANT = "Claimant";
+
+    private final AssignCategoryId assignCategoryId;
+
+    public List<Element<CaseDocument>> buildClaimantResponseDocuments(CaseData caseData) {
+        return buildDQResponseDocuments(
+                caseData.getApplicant1DQ(),
+                CLAIMANT,
+                DocCategory.DQ_APP1,
+                caseData.getApplicant1ResponseDate());
+    }
+
+    private List<Element<CaseDocument>> buildDQResponseDocuments(DQ dq, String createdBy, DocCategory docCategory, LocalDateTime date) {
+        List<Element<CaseDocument>> documents = new ArrayList<>();
+
+        if (!nonNull(dq)) {
+            return documents;
+        }
+
+        if (nonNull(dq.getDraftDirections())) {
+            documents.add(buildElemCaseDocument(dq.getDraftDirections(), createdBy, date, DocumentType.CLAIMANT_DRAFT_DIRECTIONS));
+        }
+
+        if (!documents.isEmpty()) {
+            assignCategoryId.assignCategoryIdToCollection(
+                documents,
+                document -> document.getValue().getDocumentLink(),
+                docCategory.getValue()
+            );
+        }
+        return documents;
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceSpecCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RespondToDefenceSpecCallbackHandlerTest.java
@@ -73,6 +73,7 @@ import uk.gov.hmcts.reform.civil.model.mediation.MediationAvailability;
 import uk.gov.hmcts.reform.civil.referencedata.model.LocationRefData;
 import uk.gov.hmcts.reform.civil.sampledata.CallbackParamsBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
+import uk.gov.hmcts.reform.civil.sampledata.DocumentBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.PartyBuilder;
 import uk.gov.hmcts.reform.civil.service.DeadlinesCalculator;
 import uk.gov.hmcts.reform.civil.service.ExitSurveyContentService;
@@ -88,6 +89,7 @@ import uk.gov.hmcts.reform.civil.service.referencedata.LocationReferenceDataServ
 import uk.gov.hmcts.reform.civil.utils.AssignCategoryId;
 import uk.gov.hmcts.reform.civil.utils.CaseFlagsInitialiser;
 import uk.gov.hmcts.reform.civil.utils.CourtLocationUtils;
+import uk.gov.hmcts.reform.civil.utils.DQResponseDocumentUtils;
 import uk.gov.hmcts.reform.civil.utils.ElementUtils;
 import uk.gov.hmcts.reform.civil.utils.FrcDocumentsUtils;
 import uk.gov.hmcts.reform.civil.utils.MonetaryConversions;
@@ -102,6 +104,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import static java.time.LocalDateTime.now;
@@ -111,6 +114,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_START;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
@@ -141,6 +146,7 @@ import static uk.gov.hmcts.reform.civil.helpers.DateFormatHelper.formatLocalDate
 import static uk.gov.hmcts.reform.civil.model.Party.Type.COMPANY;
 import static uk.gov.hmcts.reform.civil.model.Party.Type.INDIVIDUAL;
 import static uk.gov.hmcts.reform.civil.model.common.DynamicList.fromList;
+import static uk.gov.hmcts.reform.civil.service.flowstate.FlowState.Main.FULL_DEFENCE_PROCEED;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.element;
 import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
 
@@ -200,6 +206,9 @@ class RespondToDefenceSpecCallbackHandlerTest extends BaseCallbackHandlerTest {
 
     @MockBean
     private LocationReferenceDataService locationRefDataService;
+
+    @MockBean
+    private DQResponseDocumentUtils dqResponseDocumentUtils;
 
     @Autowired
     private AssignCategoryId assignCategoryId;
@@ -757,6 +766,7 @@ class RespondToDefenceSpecCallbackHandlerTest extends BaseCallbackHandlerTest {
                 .respondent2(Party.builder().partyName("name").type(INDIVIDUAL).primaryAddress(address).build())
                 .build();
             when(caseDetailsConverter.toCaseData(any(CaseDetails.class))).thenReturn(oldCaseData);
+            when(dqResponseDocumentUtils.buildClaimantResponseDocuments(any(CaseData.class))).thenReturn(new ArrayList<>());
         }
 
         @ParameterizedTest
@@ -776,6 +786,40 @@ class RespondToDefenceSpecCallbackHandlerTest extends BaseCallbackHandlerTest {
                 .containsExactly(READY.name(), CLAIMANT_RESPONSE_SPEC.name());
 
             assertThat(response.getData()).containsEntry("applicant1ResponseDate", localDateTime.format(ISO_DATE_TIME));
+            verify(dqResponseDocumentUtils, times(1)).buildClaimantResponseDocuments(any(CaseData.class));
+        }
+
+        @Test
+        void shouldSetClaimantResponseDocs() {
+            Document document = DocumentBuilder.builder().build();
+            CaseData fullDefenceData = CaseDataBuilder.builder().atState(FULL_DEFENCE_PROCEED).build();
+            CaseData caseData = fullDefenceData.toBuilder()
+                .applicant1DQ(fullDefenceData.getApplicant1DQ().toBuilder()
+                                  .applicant1DQDraftDirections(document)
+                    .build())
+                .build();
+            var expectedResponseDocuments = List.of(
+                Element.<CaseDocument>builder()
+                    .id(UUID.randomUUID())
+                    .value(CaseDocument.builder()
+                               .documentLink(document)
+                               .documentName("doc-name")
+                               .createdBy("Claimant")
+                               .createdDatetime(LocalDateTime.now())
+                               .build())
+                    .build());
+            when(dqResponseDocumentUtils.buildClaimantResponseDocuments(any(CaseData.class))).thenReturn(expectedResponseDocuments);
+
+            var params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
+
+            var response = (AboutToStartOrSubmitCallbackResponse) handler.handle(params);
+
+            var actualCaseData = getCaseData(response);
+
+            assertThat(actualCaseData.getClaimantResponseDocuments()).isEqualTo(expectedResponseDocuments);
+            assertThat(actualCaseData.getApplicant1DQ().getApplicant1DQDraftDirections()).isEqualTo(null);
+
+            verify(dqResponseDocumentUtils, times(1)).buildClaimantResponseDocuments(any(CaseData.class));
         }
 
         @ParameterizedTest
@@ -801,7 +845,7 @@ class RespondToDefenceSpecCallbackHandlerTest extends BaseCallbackHandlerTest {
         @Test
         void shouldAddExperts_whenAtFullDefenceStateV1() {
             CaseData caseData = CaseDataBuilder.builder()
-                .atState(FlowState.Main.FULL_DEFENCE_PROCEED)
+                .atState(FULL_DEFENCE_PROCEED)
                 .build();
             var params = callbackParamsOf(
                 CallbackVersion.V_1,
@@ -835,7 +879,7 @@ class RespondToDefenceSpecCallbackHandlerTest extends BaseCallbackHandlerTest {
         @Test
         void shouldMoveCaseToIn_MediationAndUpdateDate_V2() {
             CaseData caseData = CaseDataBuilder.builder()
-                .atState(FlowState.Main.FULL_DEFENCE_PROCEED)
+                .atState(FULL_DEFENCE_PROCEED)
                 .build();
             var params = callbackParamsOf(
                 CallbackVersion.V_2,

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/DQResponseDocumentUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/DQResponseDocumentUtilsTest.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.reform.civil.utils;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.Document;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.DocumentType;
+import uk.gov.hmcts.reform.civil.enums.DocCategory;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.common.Element;
+import uk.gov.hmcts.reform.civil.model.dq.Applicant1DQ;
+import uk.gov.hmcts.reform.civil.sampledata.DocumentBuilder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class DQResponseDocumentUtilsTest {
+
+    @InjectMocks
+    private DQResponseDocumentUtils dqResponseDocumentUtils;
+
+    @Mock
+    private AssignCategoryId assignCategoryId;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Nested
+    class BuildClaimantResponseDocuments {
+
+        @Test
+        void shouldReturnEmptyListWhenDQIsNull() {
+
+            CaseData caseData = CaseData.builder()
+                .applicant1DQ(null)
+                .applicant1ResponseDate(LocalDateTime.now())
+                .build();
+
+            List<Element<CaseDocument>> result = dqResponseDocumentUtils.buildClaimantResponseDocuments(caseData);
+
+            assertThat(result).isEmpty();
+            verifyNoInteractions(assignCategoryId);
+        }
+
+        @Test
+        void shouldReturnEmptyListWhenDQHasNoDocuments() {
+            Applicant1DQ dq = Applicant1DQ.builder().build();
+            CaseData caseData = CaseData.builder()
+                .applicant1DQ(dq)
+                .applicant1ResponseDate(LocalDateTime.now())
+                .build();
+
+            List<Element<CaseDocument>> result = dqResponseDocumentUtils.buildClaimantResponseDocuments(caseData);
+
+            assertThat(result).isEmpty();
+            verifyNoInteractions(assignCategoryId);
+        }
+
+        @Test
+        void shouldReturnListWithDocumentsWhenDQHasDraftDirections() {
+            Document document = DocumentBuilder.builder().build();
+
+            Applicant1DQ dq = Applicant1DQ.builder()
+                .applicant1DQDraftDirections(document)
+                .build();
+
+            CaseData caseData = CaseData.builder()
+                .applicant1DQ(dq)
+                .applicant1ResponseDate(LocalDateTime.now())
+                .build();
+
+            List<Element<CaseDocument>> result = dqResponseDocumentUtils.buildClaimantResponseDocuments(caseData);
+
+            assertThat(result).isNotEmpty();
+            assertThat(result).hasSize(1);
+
+            CaseDocument caseDocument = result.get(0).getValue();
+            assertThat(caseDocument.getDocumentLink().getDocumentUrl()).isEqualTo(document.getDocumentUrl());
+            assertThat(caseDocument.getDocumentType()).isEqualTo(DocumentType.CLAIMANT_DRAFT_DIRECTIONS);
+
+            verify(assignCategoryId, times(1)).assignCategoryIdToCollection(
+                any(), any(), eq(DocCategory.DQ_APP1.getValue())
+            );
+        }
+
+        @Test
+        void shouldNotAssignCategoryIdWhenNoDocumentsAdded() {
+            Applicant1DQ dq = Applicant1DQ.builder().build();
+            CaseData caseData = CaseData.builder()
+                .applicant1DQ(dq)
+                .applicant1ResponseDate(LocalDateTime.now())
+                .build();
+
+            List<Element<CaseDocument>> result = dqResponseDocumentUtils.buildClaimantResponseDocuments(caseData);
+
+            assertThat(result).isEmpty();
+            verifyNoInteractions(assignCategoryId);
+        }
+    }
+}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-14458

- Updated RespondToDefenceSpecCallbackHandler to update Claimant responsse docs with claimant draft directions

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
