### PR TITLE
CIV-15068 dashboard status for case stayed

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardClaimantClaimMatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardClaimantClaimMatcher.java
@@ -458,4 +458,9 @@ public class CcdDashboardClaimantClaimMatcher extends CcdDashboardClaimMatcher i
     public boolean isDefaultJudgementIssued() {
         return false;
     }
+
+    @Override
+    public boolean isCaseStayed() {
+        return caseData.getCcdState() == CaseState.CASE_STAYED;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardDefendantClaimMatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardDefendantClaimMatcher.java
@@ -442,4 +442,9 @@ public class CcdDashboardDefendantClaimMatcher extends CcdDashboardClaimMatcher 
             && JudgmentState.ISSUED.equals(caseData.getActiveJudgment().getState());
     }
 
+    @Override
+    public boolean isCaseStayed() {
+        return caseData.getCcdState() == CaseState.CASE_STAYED;
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/Claim.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/Claim.java
@@ -131,4 +131,6 @@ public interface Claim {
     boolean isCaseStruckOut();
 
     boolean isDefaultJudgementIssued();
+
+    boolean isCaseStayed();
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/DashboardClaimStatus.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/DashboardClaimStatus.java
@@ -4,8 +4,12 @@ import lombok.Getter;
 
 import java.util.function.Predicate;
 
+/**
+ * Using DashboardClaimStatusFactory means the order of the values of this enum reflect priority
+ */
 public enum DashboardClaimStatus {
 
+    CASE_STAYED(Claim::isCaseStayed),
     DEFENDANT_APPLY_NOC(
         Claim::isNocForDefendant
     ),

--- a/src/main/java/uk/gov/hmcts/reform/cmc/model/CmcClaim.java
+++ b/src/main/java/uk/gov/hmcts/reform/cmc/model/CmcClaim.java
@@ -567,4 +567,9 @@ public class CmcClaim implements Claim {
     public boolean isDefaultJudgementIssued() {
         return false;
     }
+
+    @Override
+    public boolean isCaseStayed() {
+        return false;
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/citizenui/DashboardClaimStatusFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/citizenui/DashboardClaimStatusFactoryTest.java
@@ -1,0 +1,38 @@
+package uk.gov.hmcts.reform.civil.model.citizenui;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DashboardClaimStatusFactoryTest {
+
+    private final DashboardClaimStatusFactory claimStatusFactory = new DashboardClaimStatusFactory();
+
+    static Stream<Arguments> caseToExpectedStatus() {
+        FeatureToggleService toggleService = Mockito.mock(FeatureToggleService.class);
+        CaseData caseData = CaseData.builder()
+            .ccdState(CaseState.CASE_STAYED)
+            .build();
+        CcdDashboardDefendantClaimMatcher defendant = new CcdDashboardDefendantClaimMatcher(caseData, toggleService);
+        CcdDashboardClaimantClaimMatcher claimant = new CcdDashboardClaimantClaimMatcher(caseData, toggleService);
+
+        return Stream.of(
+            Arguments.arguments(defendant, DashboardClaimStatus.CASE_STAYED),
+            Arguments.arguments(claimant, DashboardClaimStatus.CASE_STAYED)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("caseToExpectedStatus")
+    void shouldReturnCorrectStatus_whenInvoked(Claim claim, DashboardClaimStatus status) {
+        assertEquals(status, claimStatusFactory.getDashboardClaimStatus(claim));
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
CIV-15068


### Change description ###
Added case status for case stayed
Test is on DashboardStatusFactory instead of Claim implementations because Factory's implementation implies precedence between different statuses


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
