### PR TITLE
DTSCCI-1011 Ambiguous transitions MAIN.FULL_DEFENCE

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/stateflow/transitions/FullDefenceTransitionBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/stateflow/transitions/FullDefenceTransitionBuilder.java
@@ -56,16 +56,18 @@ public class FullDefenceTransitionBuilder extends MidTransitionBuilder {
                 flags.put(FlowFlag.SDO_ENABLED.name(), JudicialReferralUtils.shouldMoveToJudicialReferral(c, featureToggleService.isMultiOrIntermediateTrackEnabled(c)));
             })
             .moveTo(FULL_DEFENCE_PROCEED)
-            .onlyWhen(fullDefenceProceed.and(allAgreedToLrMediationSpec.negate().and(agreedToMediation.negate()))
-                .or(declinedMediation).and(applicantOutOfTime.negate()).and(demageMultiClaim))
+            .onlyWhen(fullDefenceProceed
+                          .and(allAgreedToLrMediationSpec.negate().and(agreedToMediation.negate()).or(declinedMediation))
+                          .and(applicantOutOfTime.negate()).and(demageMultiClaim))
             .set((c, flags) -> {
                 flags.put(FlowFlag.IS_MULTI_TRACK.name(), true);
                 flags.put(FlowFlag.MINTI_ENABLED.name(), featureToggleService.isMintiEnabled());
                 flags.put(FlowFlag.SDO_ENABLED.name(), JudicialReferralUtils.shouldMoveToJudicialReferral(c, featureToggleService.isMultiOrIntermediateTrackEnabled(c)));
             })
             .moveTo(FULL_DEFENCE_PROCEED)
-            .onlyWhen(fullDefenceProceed.and(allAgreedToLrMediationSpec.negate().and(agreedToMediation.negate()))
-                .or(declinedMediation).and(applicantOutOfTime.negate()).and(demageMultiClaim.negate()).and(isLipCase.negate()))
+            .onlyWhen(fullDefenceProceed
+                          .and(allAgreedToLrMediationSpec.negate().and(agreedToMediation.negate()).or(declinedMediation))
+                          .and(applicantOutOfTime.negate()).and(demageMultiClaim.negate()).and(isLipCase.negate()))
             .set((c, flags) -> {
                 flags.put(FlowFlag.SDO_ENABLED.name(), JudicialReferralUtils.shouldMoveToJudicialReferral(c, featureToggleService.isMultiOrIntermediateTrackEnabled(c)));
                 flags.put(FlowFlag.MINTI_ENABLED.name(), featureToggleService.isMintiEnabled());


### PR DESCRIPTION
Ambiguous transitions permitting state [MAIN.FULL_DEFENCE] to move to more than one next states [MAIN.FULL_DEFENCE_PROCEED,MAIN.FULL_DEFENCE_NOT_PROCEED].

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-1011

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
