### PR TITLE
CIV-15268 hearing documents on further hearing

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/scenarios/claimant/UploadHearingDocumentsClaimantScenarioTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/scenarios/claimant/UploadHearingDocumentsClaimantScenarioTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.civil.controllers.DashboardBaseIntegrationTest;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.claimant.UploadHearingDocumentsClaimantHandler;
@@ -35,6 +36,7 @@ public class UploadHearingDocumentsClaimantScenarioTest extends DashboardBaseInt
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
             .responseClaimMediationSpecRequired(YesOrNo.NO)
             .totalClaimAmount(new BigDecimal(1000))
+            .ccdState(CaseState.CASE_PROGRESSION)
             .build();
 
         handler.handle(callbackParams(caseData));

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/scenarios/defendant/UploadHearingDocumentsDefendantScenarioTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/scenarios/defendant/UploadHearingDocumentsDefendantScenarioTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import uk.gov.hmcts.reform.civil.controllers.DashboardBaseIntegrationTest;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.defendant.UploadHearingDocumentsDefendantHandler;
@@ -35,6 +36,7 @@ public class UploadHearingDocumentsDefendantScenarioTest extends DashboardBaseIn
             .respondent1ClaimResponseTypeForSpec(RespondentResponseTypeSpec.FULL_DEFENCE)
             .responseClaimMediationSpecRequired(YesOrNo.NO)
             .totalClaimAmount(new BigDecimal(1000))
+            .ccdState(CaseState.CASE_PROGRESSION)
             .build();
 
         handler.handle(callbackParams(caseData));

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/claimant/UploadHearingDocumentsClaimantHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/claimant/UploadHearingDocumentsClaimantHandler.java
@@ -5,6 +5,7 @@ import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.callback.CaseProgressionDashboardCallbackHandler;
 import uk.gov.hmcts.reform.civil.client.DashboardApiClient;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.DashboardNotificationsParamsMapper;
@@ -43,6 +44,7 @@ public class UploadHearingDocumentsClaimantHandler extends CaseProgressionDashbo
     @Override
     public boolean shouldRecordScenario(CaseData caseData) {
         return caseData.isApplicantNotRepresented()
+            && CaseState.CASE_PROGRESSION.equals(caseData.getCcdState())
             && featureToggleService.isCaseProgressionEnabled();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/UploadHearingDocumentsDefendantHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/UploadHearingDocumentsDefendantHandler.java
@@ -5,6 +5,7 @@ import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.callback.CaseProgressionDashboardCallbackHandler;
 import uk.gov.hmcts.reform.civil.client.DashboardApiClient;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.DashboardNotificationsParamsMapper;
@@ -43,6 +44,7 @@ public class UploadHearingDocumentsDefendantHandler extends CaseProgressionDashb
     @Override
     public boolean shouldRecordScenario(CaseData caseData) {
         return caseData.isRespondent1NotRepresented()
+            && CaseState.CASE_PROGRESSION.equals(caseData.getCcdState())
             && featureToggleService.isCaseProgressionEnabled();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/UploadHearingDocumentsClaimantHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/UploadHearingDocumentsClaimantHandlerTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.client.DashboardApiClient;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.enums.sdo.ClaimsTrack;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
@@ -77,6 +78,7 @@ class UploadHearingDocumentsClaimantHandlerTest extends BaseCallbackHandlerTest 
             .ccdCaseReference(12349988L)
             .drawDirectionsOrderRequired(YesOrNo.NO)
             .claimsTrack(ClaimsTrack.fastTrack)
+            .ccdState(CaseState.CASE_PROGRESSION)
             .build();
 
         CallbackParams callbackParams = CallbackParamsBuilder.builder()

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/UploadHearingDocumentsDefendantHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/UploadHearingDocumentsDefendantHandlerTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CallbackRequest;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.client.DashboardApiClient;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.model.CaseData;
@@ -73,6 +74,7 @@ class UploadHearingDocumentsDefendantHandlerTest extends BaseCallbackHandlerTest
             .legacyCaseReference("reference")
             .respondent1Represented(YesOrNo.NO)
             .ccdCaseReference(12349988L)
+            .ccdState(CaseState.CASE_PROGRESSION)
             .build();
 
         CallbackParams callbackParams = CallbackParamsBuilder.builder()


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-15268


### Change description ###
Because the hearing documents scenario will now be called from the final orders process, a check is added to ensure that it is only executed when the status is CASE_PROGRESSION.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
