### PR TITLE
CIV-15551 - Lift Stayed Case Dashboard Task Status

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/scenarios/claimant/StayLiftedClaimantScenarioTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/scenarios/claimant/StayLiftedClaimantScenarioTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.claimant.StayLiftedClaimantNotificationHandler;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
+import uk.gov.hmcts.reform.dashboard.data.TaskStatus;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -27,7 +28,8 @@ public class StayLiftedClaimantScenarioTest extends DashboardBaseIntegrationTest
         CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued1v1LiP().build().toBuilder()
             .legacyCaseReference("reference")
             .ccdCaseReference(Long.valueOf(caseId))
-            .ccdState(CaseState.JUDICIAL_REFERRAL)
+            .ccdState(CaseState.CASE_PROGRESSION)
+            .preStayState(CaseState.HEARING_READINESS.toString())
             .applicant1Represented(YesOrNo.NO)
             .build();
 
@@ -46,6 +48,31 @@ public class StayLiftedClaimantScenarioTest extends DashboardBaseIntegrationTest
                 jsonPath("$[0].titleCy").value("Mae'r ataliad wedi'i godi"),
                 jsonPath("$[0].descriptionCy").value(
                     "<p class=\"govuk-body\">Mae'r ataliad ar gyfer yr achos hwn wedi'i godi.</p>")
+            );
+
+        doGet(BEARER_TOKEN, GET_TASKS_ITEMS_URL, caseId, "CLAIMANT")
+            .andExpect(status().isOk()).andExpectAll(
+                status().is(HttpStatus.OK.value()),
+                jsonPath("$[0].reference").value(caseId),
+                jsonPath("$[0].taskNameEn").value("<a>View the hearing</a>"),
+                jsonPath("$[0].taskNameCy").value("<a>Gweld y gwrandawiad</a>"),
+                jsonPath("$[0].currentStatusEn").value(TaskStatus.NOT_AVAILABLE_YET.getName()),
+                jsonPath("$[0].currentStatusCy").value(TaskStatus.NOT_AVAILABLE_YET.getWelshName()),
+                jsonPath("$[1].reference").value(caseId),
+                jsonPath("$[1].taskNameEn").value("<a>Pay the hearing fee</a>"),
+                jsonPath("$[1].taskNameCy").value("<a>Talu ffi'r gwrandawiad</a>"),
+                jsonPath("$[1].currentStatusEn").value(TaskStatus.NOT_AVAILABLE_YET.getName()),
+                jsonPath("$[1].currentStatusCy").value(TaskStatus.NOT_AVAILABLE_YET.getWelshName()),
+                jsonPath("$[2].reference").value(caseId),
+                jsonPath("$[2].taskNameEn").value("<a>Add the trial arrangements</a>"),
+                jsonPath("$[2].taskNameCy").value("<a>Ychwanegu trefniadau'r treial</a>"),
+                jsonPath("$[2].currentStatusEn").value(TaskStatus.NOT_AVAILABLE_YET.getName()),
+                jsonPath("$[2].currentStatusCy").value(TaskStatus.NOT_AVAILABLE_YET.getWelshName()),
+                jsonPath("$[3].reference").value(caseId),
+                jsonPath("$[3].taskNameEn").value("<a>View the bundle</a>"),
+                jsonPath("$[3].taskNameCy").value("<a>Gweld y bwndel</a>"),
+                jsonPath("$[3].currentStatusEn").value(TaskStatus.NOT_AVAILABLE_YET.getName()),
+                jsonPath("$[3].currentStatusCy").value(TaskStatus.NOT_AVAILABLE_YET.getWelshName())
             );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/scenarios/defendant/StayLiftedDefendantScenarioTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/scenarios/defendant/StayLiftedDefendantScenarioTest.java
@@ -9,6 +9,7 @@ import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.defendant.StayLiftedDefendantNotificationHandler;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
+import uk.gov.hmcts.reform.dashboard.data.TaskStatus;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -27,7 +28,8 @@ public class StayLiftedDefendantScenarioTest extends DashboardBaseIntegrationTes
         CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued1v1LiP().build().toBuilder()
             .legacyCaseReference("reference")
             .ccdCaseReference(Long.valueOf(caseId))
-            .ccdState(CaseState.JUDICIAL_REFERRAL)
+            .ccdState(CaseState.CASE_PROGRESSION)
+            .preStayState(CaseState.HEARING_READINESS.toString())
             .respondent1Represented(YesOrNo.NO)
             .build();
 
@@ -46,6 +48,26 @@ public class StayLiftedDefendantScenarioTest extends DashboardBaseIntegrationTes
                 jsonPath("$[0].titleCy").value("Mae'r ataliad wedi'i godi"),
                 jsonPath("$[0].descriptionCy").value(
                     "<p class=\"govuk-body\">Mae'r ataliad ar gyfer yr achos hwn wedi'i godi.</p>")
+            );
+
+        doGet(BEARER_TOKEN, GET_TASKS_ITEMS_URL, caseId, "DEFENDANT")
+            .andExpect(status().isOk()).andExpectAll(
+                status().is(HttpStatus.OK.value()),
+                jsonPath("$[0].reference").value(caseId),
+                jsonPath("$[0].taskNameEn").value("<a>View the hearing</a>"),
+                jsonPath("$[0].taskNameCy").value("<a>Gweld y gwrandawiad</a>"),
+                jsonPath("$[0].currentStatusEn").value(TaskStatus.NOT_AVAILABLE_YET.getName()),
+                jsonPath("$[0].currentStatusCy").value(TaskStatus.NOT_AVAILABLE_YET.getWelshName()),
+                jsonPath("$[1].reference").value(caseId),
+                jsonPath("$[1].taskNameEn").value("<a>Add the trial arrangements</a>"),
+                jsonPath("$[1].taskNameCy").value("<a>Ychwanegu trefniadau'r treial</a>"),
+                jsonPath("$[1].currentStatusEn").value(TaskStatus.NOT_AVAILABLE_YET.getName()),
+                jsonPath("$[1].currentStatusCy").value(TaskStatus.NOT_AVAILABLE_YET.getWelshName()),
+                jsonPath("$[2].reference").value(caseId),
+                jsonPath("$[2].taskNameEn").value("<a>View the bundle</a>"),
+                jsonPath("$[2].taskNameCy").value("<a>Gweld y bwndel</a>"),
+                jsonPath("$[2].currentStatusEn").value(TaskStatus.NOT_AVAILABLE_YET.getName()),
+                jsonPath("$[2].currentStatusCy").value(TaskStatus.NOT_AVAILABLE_YET.getWelshName())
             );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/callback/DashboardCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/callback/DashboardCallbackHandler.java
@@ -10,8 +10,10 @@ import uk.gov.hmcts.reform.civil.service.DashboardNotificationsParamsMapper;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.dashboard.data.ScenarioRequestParams;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import static java.util.Optional.ofNullable;
 import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 
@@ -35,6 +37,10 @@ public abstract class DashboardCallbackHandler extends CallbackHandler {
         return null;
     }
 
+    protected Map<String, Boolean> getScenarios(CaseData caseData) {
+        return null;
+    }
+
     /**
      * Depending on the case data, the scenario may or may not be applicable.
      *
@@ -52,7 +58,7 @@ public abstract class DashboardCallbackHandler extends CallbackHandler {
     /**
      * Called just before a scenario is recorded, when the scenario is known and should record is true.
      *
-     * @param caseData case info
+     * @param caseData  case info
      * @param authToken auth token
      */
     protected void beforeRecordScenario(CaseData caseData, String authToken) {
@@ -86,6 +92,15 @@ public abstract class DashboardCallbackHandler extends CallbackHandler {
                 scenarioParams
             );
         }
+
+        ofNullable(getScenarios(caseData)).orElse(new HashMap<>())
+            .entrySet().stream()
+            .filter(scenarioEntry -> !Strings.isNullOrEmpty(scenarioEntry.getKey()) && scenarioEntry.getValue())
+            .forEach(scenarioEntry -> dashboardApiClient.recordScenario(
+                caseData.getCcdCaseReference().toString(),
+                scenarioEntry.getKey(),
+                authToken,
+                scenarioParams));
 
         return AboutToStartOrSubmitCallbackResponse.builder().build();
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/callback/DashboardCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/callback/DashboardCallbackHandler.java
@@ -58,7 +58,7 @@ public abstract class DashboardCallbackHandler extends CallbackHandler {
     /**
      * Called just before a scenario is recorded, when the scenario is known and should record is true.
      *
-     * @param caseData  case info
+     * @param caseData case info
      * @param authToken auth token
      */
     protected void beforeRecordScenario(CaseData caseData, String authToken) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/DashboardScenarios.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/DashboardScenarios.java
@@ -205,7 +205,10 @@ public enum DashboardScenarios {
     SCENARIO_AAA6_PROOF_OF_DEBT_PAYMENT_APPLICATION_CLAIMANT("Scenario.AAA6.ProofofDebtPayment.Application.Claimant"),
     SCENARIO_AAA6_PROOF_OF_DEBT_PAYMENT_APPLICATION_DEFENDANT("Scenario.AAA6.ProofofDebtPayment.Application.Defendant"),
     SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT("Scenario.AAA6.CP.Stay.Lifted.Claimant"),
-    SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT("Scenario.AAA6.CP.Stay.Lifted.Defendant");
+    SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT("Scenario.AAA6.CP.Stay.Lifted.Defendant"),
+    SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_FEE_PAID_TASK("Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Fee.Paid.Task"),
+    SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_CLAIMANT("Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Claimant"),
+    SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_DEFENDANT("Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Defendant");
 
     private final String scenario;
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/claimant/StayCaseClaimantNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/claimant/StayCaseClaimantNotificationHandler.java
@@ -42,12 +42,4 @@ public class StayCaseClaimantNotificationHandler extends CaseEventsDashboardCall
         return SCENARIO_AAA6_CP_CASE_STAYED_CLAIMANT.getScenario();
     }
 
-    @Override
-    protected void beforeRecordScenario(CaseData caseData, String authToken) {
-        dashboardApiClient.makeProgressAbleTasksInactiveForCaseIdentifierAndRole(
-            caseData.getCcdCaseReference().toString(),
-            "CLAIMANT",
-            authToken
-        );
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/StayCaseDefendantNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/StayCaseDefendantNotificationHandler.java
@@ -42,12 +42,4 @@ public class StayCaseDefendantNotificationHandler extends CaseEventsDashboardCal
         return SCENARIO_AAA6_CP_CASE_STAYED_DEFENDANT.getScenario();
     }
 
-    @Override
-    protected void beforeRecordScenario(CaseData caseData, String authToken) {
-        dashboardApiClient.makeProgressAbleTasksInactiveForCaseIdentifierAndRole(
-            caseData.getCcdCaseReference().toString(),
-            "DEFENDANT",
-            authToken
-        );
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/StayLiftedDefendantNotificationHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/StayLiftedDefendantNotificationHandler.java
@@ -5,14 +5,19 @@ import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.callback.CaseEventsDashboardCallbackHandler;
 import uk.gov.hmcts.reform.civil.client.DashboardApiClient;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.DashboardNotificationsParamsMapper;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 
 import java.util.List;
+import java.util.Map;
 
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_DEFENDANT;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.HEARING_READINESS;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.PREPARE_FOR_HEARING_CONDUCT_HEARING;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios.SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios.SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_DEFENDANT;
 
 @Service
 public class StayLiftedDefendantNotificationHandler extends CaseEventsDashboardCallbackHandler {
@@ -39,11 +44,24 @@ public class StayLiftedDefendantNotificationHandler extends CaseEventsDashboardC
 
     @Override
     public String getScenario(CaseData caseData) {
-        return SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT.getScenario();
+        return null;
     }
 
     @Override
-    public boolean shouldRecordScenario(CaseData caseData) {
-        return caseData.isRespondent1NotRepresented();
+    public Map<String, Boolean> getScenarios(CaseData caseData) {
+        if (caseData.isRespondent1NotRepresented()) {
+            return Map.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT.getScenario(), true,
+                SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_DEFENDANT.getScenario(), hadHearingScheduled(caseData));
+        }
+
+        return null;
+    }
+
+    private boolean hadHearingScheduled(CaseData caseData) {
+        return List.of(
+            HEARING_READINESS,
+            PREPARE_FOR_HEARING_CONDUCT_HEARING
+        ).contains(CaseState.valueOf(caseData.getPreStayState()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -125,6 +125,7 @@ import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.TWO_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.isOneVOne;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.isOneVTwoTwoLegalRep;
+import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS;
 import static uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec.FULL_ADMISSION;
 import static uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec.FULL_DEFENCE;
 import static uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec.PART_ADMISSION;
@@ -1592,5 +1593,11 @@ public class CaseData extends CaseDataParent implements MappableObject {
     @JsonIgnore
     public boolean isLipCase() {
         return this.isApplicant1NotRepresented() || this.isRespondent1LiP();
+    }
+
+    @JsonIgnore
+    public boolean isHearingFeePaid() {
+        return nonNull(this.getHearingFeePaymentDetails())
+            && SUCCESS.equals(this.getHearingFeePaymentDetails().getStatus()) || this.hearingFeePaymentDoneWithHWF();
     }
 }

--- a/src/main/resources/db/migration/V2024_11_01_1240__CIV-15551_stay_lifted_hearing_reset_tasks.sql
+++ b/src/main/resources/db/migration/V2024_11_01_1240__CIV-15551_stay_lifted_hearing_reset_tasks.sql
@@ -1,0 +1,24 @@
+/**
+ * Add scenarios
+ */
+INSERT INTO dbs.scenario (name, notifications_to_delete, notifications_to_create)
+VALUES ('Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Fee.Paid.Task', '{}', '{}'),
+       ('Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Claimant', '{}', '{}'),
+       ('Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Defendant', '{}', '{}');
+
+INSERT INTO dbs.task_item_template (task_name_en, category_en, task_name_cy, category_cy, template_name,
+                                    scenario_name, task_status_sequence, role, task_order)
+VALUES ('<a>View the hearing</a>', 'Hearing', '<a>Gweld y gwrandawiad</a>',
+        'Gwrandawiad', 'Hearing.View', 'Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Claimant', '{1, 1}', 'CLAIMANT', 8),
+       ('<a>Pay the hearing fee</a>', 'Hearing', '<a>Talu ffi''r gwrandawiad</a>',
+        'Gwrandawiad', 'Hearing.Fee.Pay', 'Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Fee.Paid.Task', '{1, 1}', 'CLAIMANT', 9),
+       ('<a>Add the trial arrangements</a>', 'Hearing', '<a>Ychwanegu trefniadau''r treial</a>',
+        'Gwrandawiad', 'Hearing.Arrangements.Add', 'Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Claimant', '{1, 1}', 'CLAIMANT', 12),
+       ('<a>View the bundle</a>', 'Hearing', '<a>Gweld y bwndel</a>',
+        'Gwrandawiad', 'Hearing.Bundle.View', 'Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Claimant', '{1, 1}', 'CLAIMANT', 13),
+       ('<a>View the hearing</a>', 'Hearing', '<a>Gweld y gwrandawiad</a>',
+        'Gwrandawiad', 'Hearing.View', 'Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Defendant', '{1, 1}', 'DEFENDANT', 8),
+       ('<a>Add the trial arrangements</a>', 'Hearing', '<a>Ychwanegu trefniadau''r treial</a>',
+        'Gwrandawiad', 'Hearing.Arrangements.Add', 'Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Defendant', '{1, 1}', 'DEFENDANT', 12),
+       ('<a>View the bundle</a>', 'Hearing', '<a>Gweld y bwndel</a>',
+        'Gwrandawiad', 'Hearing.Bundle.View', 'Scenario.AAA6.CP.Stay.Lifted.Reset.Hearing.Tasks.Defendant', '{1, 1}', 'DEFENDANT', 13);

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/claimant/StayCaseClaimantNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/claimant/StayCaseClaimantNotificationHandlerTest.java
@@ -79,12 +79,6 @@ public class StayCaseClaimantNotificationHandlerTest extends BaseCallbackHandler
 
         handler.handle(callbackParams);
 
-        verify(dashboardApiClient).makeProgressAbleTasksInactiveForCaseIdentifierAndRole(
-            caseData.getCcdCaseReference().toString(),
-            "CLAIMANT",
-            "BEARER_TOKEN"
-        );
-
         verify(dashboardApiClient, times(1)).recordScenario(
             caseData.getCcdCaseReference().toString(),
             SCENARIO_AAA6_CP_CASE_STAYED_CLAIMANT.getScenario(),

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/claimant/StayLiftedClaimantNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/claimant/StayLiftedClaimantNotificationHandlerTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.claimant;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -11,6 +13,7 @@ import uk.gov.hmcts.reform.civil.client.DashboardApiClient;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.handler.callback.BaseCallbackHandlerTest;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.PaymentDetails;
 import uk.gov.hmcts.reform.civil.sampledata.CallbackParamsBuilder;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.DashboardNotificationsParamsMapper;
@@ -18,15 +21,26 @@ import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.dashboard.data.ScenarioRequestParams;
 
 import java.util.HashMap;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_CLAIMANT;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.CASE_PROGRESSION;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.HEARING_READINESS;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.IN_MEDIATION;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.JUDICIAL_REFERRAL;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.PREPARE_FOR_HEARING_CONDUCT_HEARING;
+import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios.SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios.SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_FEE_PAID_TASK;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios.SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_CLAIMANT;
 
 @ExtendWith(MockitoExtension.class)
 public class StayLiftedClaimantNotificationHandlerTest extends BaseCallbackHandlerTest {
@@ -43,48 +57,214 @@ public class StayLiftedClaimantNotificationHandlerTest extends BaseCallbackHandl
     @Mock
     private FeatureToggleService featureToggleService;
 
-    public static final String TASK_ID = "DashboardNotificationStayLiftedClaimant";
+    private static final String TASK_ID = "DashboardNotificationStayLiftedClaimant";
+    private static final String CCD_REFERENCE = "1594901956117591";
 
-    @Test
-    void handleEventsReturnsTheExpectedCallbackEvent() {
-        assertThat(handler.handledEvents()).contains(CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_CLAIMANT);
+    private HashMap<String, Object> params;
+
+    @Nested
+    class EventsAndTasks {
+        @Test
+        void handleEventsReturnsTheExpectedCallbackEvent() {
+            assertThat(handler.handledEvents()).contains(CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_CLAIMANT);
+        }
+
+        @Test
+        void shouldReturnCorrectCamundaActivityId_whenInvoked() {
+            assertThat(handler.camundaActivityId(
+                CallbackParamsBuilder.builder()
+                    .request(CallbackRequest.builder()
+                                 .eventId(CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_CLAIMANT.name())
+                                 .build())
+                    .build()))
+                .isEqualTo(TASK_ID);
+        }
     }
 
-    @Test
-    void shouldReturnCorrectCamundaActivityId_whenInvoked() {
-        assertThat(handler.camundaActivityId(
-            CallbackParamsBuilder.builder()
-                .request(CallbackRequest.builder()
-                             .eventId(CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_CLAIMANT.name())
-                             .build())
-                .build()))
-            .isEqualTo(TASK_ID);
-    }
+    @Nested
+    class AboutToSubmit {
+        @BeforeEach
+        void setupTests() {
+            params = new HashMap<>();
+        }
 
-    @Test
-    void shouldConfigureDashboardNotificationsStayCase() {
+        @Test
+        void shouldNotRecordAnyScenarios_ifClaimantIsNotLip() {
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
 
-        HashMap<String, Object> params = new HashMap<>();
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .applicant1Represented(YesOrNo.YES)
+                .preStayState(IN_MEDIATION.toString())
+                .build();
 
-        when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
-        when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
 
-        CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
-            .toBuilder().applicant1Represented(YesOrNo.NO)
-            .build();
+            handler.handle(callbackParams);
 
-        CallbackParams callbackParams = CallbackParamsBuilder.builder()
-            .of(ABOUT_TO_SUBMIT, caseData)
-            .build();
+            verifyNoInteractions(dashboardApiClient);
+        }
 
-        handler.handle(callbackParams);
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStateInMediation() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
 
-        verify(dashboardApiClient, times(1)).recordScenario(
-            caseData.getCcdCaseReference().toString(),
-            SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT.getScenario(),
-            "BEARER_TOKEN",
-            ScenarioRequestParams.builder().params(params).build()
-        );
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .applicant1Represented(YesOrNo.NO)
+                .preStayState(IN_MEDIATION.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT.getScenario()
+            ));
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStateJudicialReferral() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .applicant1Represented(YesOrNo.NO)
+                .preStayState(JUDICIAL_REFERRAL.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT.getScenario()
+            ));
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStateCaseProgression() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .applicant1Represented(YesOrNo.NO)
+                .preStayState(CASE_PROGRESSION.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT.getScenario()
+            ));
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStateHearingReadiness() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .applicant1Represented(YesOrNo.NO)
+                .preStayState(HEARING_READINESS.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT.getScenario(),
+                SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_CLAIMANT.getScenario(),
+                SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_FEE_PAID_TASK.getScenario()
+            ));
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStatePfHcH_withFeePaid() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .applicant1Represented(YesOrNo.NO)
+                .preStayState(PREPARE_FOR_HEARING_CONDUCT_HEARING.toString())
+                .hearingFeePaymentDetails(PaymentDetails.builder().status(SUCCESS).build())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT.getScenario(),
+                SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_CLAIMANT.getScenario())
+            );
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStatePfHcH_withFeeNotRequired() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .applicant1Represented(YesOrNo.NO)
+                .preStayState(PREPARE_FOR_HEARING_CONDUCT_HEARING.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_CLAIMANT.getScenario(),
+                SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_FEE_PAID_TASK.getScenario(),
+                SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_CLAIMANT.getScenario())
+            );
+        }
+
+        void verifyRecordedScenario(String scenario) {
+            verify(dashboardApiClient, times(1)).recordScenario(
+                CCD_REFERENCE,
+                scenario,
+                "BEARER_TOKEN",
+                ScenarioRequestParams.builder().params(params).build()
+            );
+        }
+
+        void verifyRecordedScenarios(List<String> expectedScenarios) {
+            if (expectedScenarios == null || expectedScenarios.size() < 1) {
+                fail("Expected scenarios should be provided.");
+            }
+
+            // Ensure total numbers of scenarios recorded match expected
+            verify(dashboardApiClient, times(expectedScenarios.size())).recordScenario(any(), any(), any(), any());
+
+            // Ensure each scenario is only recorded once
+            expectedScenarios.forEach(this::verifyRecordedScenario);
+        }
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/StayCaseDefendantNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/StayCaseDefendantNotificationHandlerTest.java
@@ -79,12 +79,6 @@ public class StayCaseDefendantNotificationHandlerTest extends BaseCallbackHandle
 
         handler.handle(callbackParams);
 
-        verify(dashboardApiClient).makeProgressAbleTasksInactiveForCaseIdentifierAndRole(
-            caseData.getCcdCaseReference().toString(),
-            "DEFENDANT",
-            "BEARER_TOKEN"
-        );
-
         verify(dashboardApiClient, times(1)).recordScenario(
             caseData.getCcdCaseReference().toString(),
             SCENARIO_AAA6_CP_CASE_STAYED_DEFENDANT.getScenario(),

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/StayLiftedDefendantNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/dashboardnotifications/defendant/StayLiftedDefendantNotificationHandlerTest.java
@@ -1,5 +1,7 @@
 package uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.defendant;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -18,15 +20,24 @@ import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.dashboard.data.ScenarioRequestParams;
 
 import java.util.HashMap;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.callback.CallbackType.ABOUT_TO_SUBMIT;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_DEFENDANT;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.CASE_PROGRESSION;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.HEARING_READINESS;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.IN_MEDIATION;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.JUDICIAL_REFERRAL;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.PREPARE_FOR_HEARING_CONDUCT_HEARING;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios.SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardScenarios.SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_DEFENDANT;
 
 @ExtendWith(MockitoExtension.class)
 public class StayLiftedDefendantNotificationHandlerTest extends BaseCallbackHandlerTest {
@@ -43,48 +54,188 @@ public class StayLiftedDefendantNotificationHandlerTest extends BaseCallbackHand
     @Mock
     private FeatureToggleService featureToggleService;
 
-    public static final String TASK_ID = "DashboardNotificationStayLiftedDefendant";
+    private static final String TASK_ID = "DashboardNotificationStayLiftedDefendant";
+    private static final String CCD_REFERENCE = "1594901956117591";
 
-    @Test
-    void handleEventsReturnsTheExpectedCallbackEvent() {
-        assertThat(handler.handledEvents()).contains(CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_DEFENDANT);
+    private HashMap<String, Object> params;
+
+    @Nested
+    class EventsAndTasks {
+        @Test
+        void handleEventsReturnsTheExpectedCallbackEvent() {
+            assertThat(handler.handledEvents()).contains(CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_DEFENDANT);
+        }
+
+        @Test
+        void shouldReturnCorrectCamundaActivityId_whenInvoked() {
+            assertThat(handler.camundaActivityId(
+                CallbackParamsBuilder.builder()
+                    .request(CallbackRequest.builder()
+                                 .eventId(CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_DEFENDANT.name())
+                                 .build())
+                    .build()))
+                .isEqualTo(TASK_ID);
+        }
     }
 
-    @Test
-    void shouldReturnCorrectCamundaActivityId_whenInvoked() {
-        assertThat(handler.camundaActivityId(
-            CallbackParamsBuilder.builder()
-                .request(CallbackRequest.builder()
-                             .eventId(CREATE_DASHBOARD_NOTIFICATION_STAY_LIFTED_DEFENDANT.name())
-                             .build())
-                .build()))
-            .isEqualTo(TASK_ID);
-    }
+    @Nested
+    class AboutToSubmit {
+        @BeforeEach
+        void setupTests() {
+            params = new HashMap<>();
+        }
 
-    @Test
-    void shouldConfigureDashboardNotificationsStayCase() {
+        @Test
+        void shouldNotRecordAnyScenarios_ifRespondentIsNotLip() {
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
 
-        HashMap<String, Object> params = new HashMap<>();
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .respondent1Represented(YesOrNo.YES)
+                .preStayState(IN_MEDIATION.toString())
+                .build();
 
-        when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
-        when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
 
-        CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
-            .toBuilder().respondent1Represented(YesOrNo.NO)
-            .build();
+            handler.handle(callbackParams);
 
-        CallbackParams callbackParams = CallbackParamsBuilder.builder()
-            .of(ABOUT_TO_SUBMIT, caseData)
-            .build();
+            verifyNoInteractions(dashboardApiClient);
+        }
 
-        handler.handle(callbackParams);
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStateInMediation() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
 
-        verify(dashboardApiClient, times(1)).recordScenario(
-            caseData.getCcdCaseReference().toString(),
-            SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT.getScenario(),
-            "BEARER_TOKEN",
-            ScenarioRequestParams.builder().params(params).build()
-        );
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .respondent1Represented(YesOrNo.NO)
+                .preStayState(IN_MEDIATION.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT.getScenario()
+            ));
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStateJudicialReferral() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .respondent1Represented(YesOrNo.NO)
+                .preStayState(JUDICIAL_REFERRAL.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT.getScenario()
+            ));
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStateCaseProgression() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .respondent1Represented(YesOrNo.NO)
+                .preStayState(CASE_PROGRESSION.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT.getScenario()
+            ));
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStateHearingReadiness() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .respondent1Represented(YesOrNo.NO)
+                .preStayState(HEARING_READINESS.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT.getScenario(),
+                SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_DEFENDANT.getScenario()
+            ));
+        }
+
+        @Test
+        void shouldRecordExpectedScenarios_whenPreStatePfHcH() {
+            when(dashboardNotificationsParamsMapper.mapCaseDataToParams(any())).thenReturn(params);
+            when(featureToggleService.isCaseEventsEnabled()).thenReturn(true);
+
+            CaseData caseData = CaseDataBuilder.builder().atStateClaimIssued().build()
+                .toBuilder()
+                .respondent1Represented(YesOrNo.NO)
+                .preStayState(PREPARE_FOR_HEARING_CONDUCT_HEARING.toString())
+                .build();
+
+            CallbackParams callbackParams = CallbackParamsBuilder.builder()
+                .of(ABOUT_TO_SUBMIT, caseData)
+                .build();
+
+            handler.handle(callbackParams);
+
+            verifyRecordedScenarios(List.of(
+                SCENARIO_AAA6_CP_STAY_LIFTED_DEFENDANT.getScenario(),
+                SCENARIO_AAA6_CP_STAY_LIFTED_RESET_HEARING_TASKS_DEFENDANT.getScenario())
+            );
+        }
+
+        void verifyRecordedScenario(String scenario) {
+            verify(dashboardApiClient, times(1)).recordScenario(
+                CCD_REFERENCE,
+                scenario,
+                "BEARER_TOKEN",
+                ScenarioRequestParams.builder().params(params).build()
+            );
+        }
+
+        void verifyRecordedScenarios(List<String> expectedScenarios) {
+            if (expectedScenarios == null || expectedScenarios.size() < 1) {
+                fail("Expected scenarios should be provided.");
+            }
+
+            // Ensure total numbers of scenarios recorded match expected
+            verify(dashboardApiClient, times(expectedScenarios.size())).recordScenario(any(), any(), any(), any());
+
+            // Ensure each scenario is only recorded once
+            expectedScenarios.forEach(this::verifyRecordedScenario);
+        }
     }
 
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/CaseDataTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/CaseDataTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.civil.handler.callback.user.spec.show.ResponseOneVOne
 import uk.gov.hmcts.reform.civil.model.citizenui.CaseDataLiP;
 import uk.gov.hmcts.reform.civil.model.citizenui.ClaimantLiPResponse;
 import uk.gov.hmcts.reform.civil.model.citizenui.ClaimantMediationLip;
+import uk.gov.hmcts.reform.civil.model.citizenui.FeePaymentOutcomeDetails;
 import uk.gov.hmcts.reform.civil.model.citizenui.dto.RepaymentDecisionType;
 import uk.gov.hmcts.reform.civil.model.common.DynamicList;
 import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
@@ -42,6 +43,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.reform.civil.documentmanagement.model.DocumentType.DEFENCE_TRANSLATED_DOCUMENT;
 import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.FAST_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.MULTI_CLAIM;
+import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.FAILED;
+import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS;
 import static uk.gov.hmcts.reform.civil.enums.RespondentResponseTypeSpec.FULL_ADMISSION;
 import static uk.gov.hmcts.reform.civil.documentmanagement.model.DocumentType.SDO_ORDER;
 import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
@@ -1178,6 +1181,58 @@ public class CaseDataTest {
             boolean isPaidLessThanClaimAmount = caseData.isPaidLessThanClaimAmount();
             //Then
             assertFalse(isPaidLessThanClaimAmount);
+        }
+
+        @Test
+        void shouldReturnTrueIfHearingFeePaymentStatusSuccess() {
+            //Given
+            CaseData caseData = CaseData.builder()
+                .hearingFeePaymentDetails(PaymentDetails.builder().status(SUCCESS).build())
+                .build();
+            //When
+            boolean isHearingFeePaid = caseData.isHearingFeePaid();
+            //Then
+            assertTrue(isHearingFeePaid);
+        }
+
+        @Test
+        void shouldReturnTrueIfHearingFeePaidWithHWF() {
+            //Given
+            CaseData caseData = CaseData.builder()
+                .hearingHelpFeesReferenceNumber("hwf-ref")
+                .feePaymentOutcomeDetails(
+                    FeePaymentOutcomeDetails.builder()
+                        .hwfFullRemissionGrantedForHearingFee(YES)
+                        .build())
+                .applicant1Represented(NO)
+                .respondent1Represented(NO)
+                .build();
+            //When
+            boolean isHearingFeePaid = caseData.isHearingFeePaid();
+            //Then
+            assertTrue(isHearingFeePaid);
+        }
+
+        @Test
+        void shouldReturnFalseIfHearingPaymentIsNotSuccess() {
+            //Given
+            CaseData caseData = CaseData.builder()
+                .hearingFeePaymentDetails(PaymentDetails.builder().status(FAILED).build())
+                .build();
+            //When
+            boolean isHearingFeePaid = caseData.isHearingFeePaid();
+            //Then
+            assertFalse(isHearingFeePaid);
+        }
+
+        @Test
+        void shouldReturnFalseIfHearingPaymentIsNullAndNoHWF() {
+            //Given
+            CaseData caseData = CaseData.builder().build();
+            //When
+            boolean isHearingFeePaid = caseData.isHearingFeePaid();
+            //Then
+            assertFalse(isHearingFeePaid);
         }
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CIV-15551

- Removed triggering dashboard api to set done and available tasks to inactive, in StayCase dashboard notification handlers. This will now be done on the fly when rendering tasks in cui if case state is CASE_STAYED.
- Added new scenarios to reset hearing dashboard tasks when case stay is lifted.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
