### PR TITLE
DTSCCI-1512: fix npe hearingDuration

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/HearingUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/HearingUtils.java
@@ -64,6 +64,9 @@ public class HearingUtils {
     }
 
     public static String formatHearingDuration(HearingDuration hearingDuration) {
+        if (hearingDuration == null) {
+            return null;
+        }
         switch (hearingDuration) {
             case MINUTES_05:
                 return "5 minutes";

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/HearingUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/HearingUtilsTest.java
@@ -22,9 +22,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class HearingUtilsTest {
+class HearingUtilsTest {
 
     @Test
     void shouldThrowNullException_whenGivenNullDate() {
@@ -60,6 +61,12 @@ public class HearingUtilsTest {
     @EnumSource(HearingDuration.class)
     void shouldReturnHearingDuration_whenGivenAnyHearingDuration(HearingDuration hearingDuration) {
         assertThat(HearingUtils.formatHearingDuration(hearingDuration)).isNotEmpty();
+    }
+
+    @Test
+    void shouldReturnHearingDuration_whenGivenAnyHearingDuration_extended() {
+        HearingDuration hearingDuration = null;
+        assertNull(HearingUtils.formatHearingDuration(hearingDuration));
     }
 
     @ParameterizedTest


### PR DESCRIPTION

### JIRA link (if applicable) ###

DTSCCI-1512:

### Change description ###
 "hearingDuration" is null when attempting to confirm trial arrangements 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
