### PR TITLE
DTSCCI-1836: ambiguous transitions claim submitted 

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/stateflow/transitions/ClaimSubmittedTransitionBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/stateflow/transitions/ClaimSubmittedTransitionBuilder.java
@@ -42,7 +42,7 @@ public class ClaimSubmittedTransitionBuilder extends MidTransitionBuilder {
             .moveTo(TAKEN_OFFLINE_BY_STAFF, transitions).onlyWhen(takenOfflineByStaffBeforeClaimIssued, transitions)
             .moveTo(CLAIM_ISSUED_PAYMENT_FAILED, transitions).onlyWhen(paymentFailed, transitions)
             .moveTo(PENDING_CLAIM_ISSUED_UNREPRESENTED_DEFENDANT_ONE_V_ONE_SPEC, transitions).onlyWhen(
-                isLipCase,
+                isLipCase.and(takenOfflineByStaffBeforeClaimIssued.negate()),
                 transitions
             )
             .set(

--- a/src/test/java/uk/gov/hmcts/reform/civil/stateflow/transitions/ClaimSubmittedTransitionBuilderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/stateflow/transitions/ClaimSubmittedTransitionBuilderTest.java
@@ -31,7 +31,7 @@ import static uk.gov.hmcts.reform.civil.stateflow.transitions.ClaimSubmittedTran
 import static uk.gov.hmcts.reform.civil.stateflow.transitions.ClaimSubmittedTransitionBuilder.takenOfflineByStaffBeforeClaimIssued;
 
 @ExtendWith(MockitoExtension.class)
-public class ClaimSubmittedTransitionBuilderTest {
+class ClaimSubmittedTransitionBuilderTest {
 
     @Mock
     private FeatureToggleService mockFeatureToggleService;


### PR DESCRIPTION


### JIRA link (if applicable) ###
DTSCCI-1836


### Change description ###
Ambiguous transitions claim submitted and case Taken offline by staff


Ambiguous transitions permitting state [MAIN.CLAIM_SUBMITTED] to move to more than one next states [MAIN.TAKEN_OFFLINE_BY_STAFF,MAIN.PENDING_CLAIM_ISSUED_UNREPRESENTED_DEFENDANT_ONE_V_ONE_SPEC].  




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
