### PR TITLE
CIV-17167 - Fix Query Document Message Dates

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateQueryDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateQueryDocumentHandler.java
@@ -92,7 +92,8 @@ public class GenerateQueryDocumentHandler extends CallbackHandler {
     private void updateQueryDocument(LocalDateTime timeQueryRaised, CaseDocument newQueryDocument, CaseData.CaseDataBuilder builder) {
         CaseData caseData = builder.build();
         Element<CaseDocument> existingQueryDocument = caseData.getQueryDocuments()
-                .stream().filter(doc -> doc.getValue().getCreatedDatetime().equals(timeQueryRaised)).findFirst()
+                .stream().filter(doc -> doc.getValue().getCreatedDatetime().withNano(0)
+                .equals(timeQueryRaised.withNano(0))).findFirst()
                 .orElse(null);
 
         boolean queryDocumentExists = nonNull(existingQueryDocument);

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateQueryDocumentHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateQueryDocumentHandler.java
@@ -82,7 +82,7 @@ public class GenerateQueryDocumentHandler extends CallbackHandler {
             queryDocumentCategory
         );
 
-        updateQueryDocument(messageThread.get(0).getValue().getCreatedOn(), caseDocument, builder);
+        updateQueryDocument(messageThread.get(0).getValue().getCreatedOn().toLocalDateTime(), caseDocument, builder);
 
         return AboutToStartOrSubmitCallbackResponse.builder()
             .data(builder.build().toMap(objectMapper)).build();

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/docmosis/querymanagement/DocumentQueryMessage.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/docmosis/querymanagement/DocumentQueryMessage.java
@@ -14,6 +14,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 import static java.util.Objects.nonNull;
+import static uk.gov.hmcts.reform.civil.utils.DateUtils.convertFromUTC;
 
 @Data
 @Builder(toBuilder = true)
@@ -47,7 +48,7 @@ public class DocumentQueryMessage {
             .name(isCaseworkerMessage ? "Caseworker" : caseMessage.getName())
             .subject(isInitialQueryMessage ? caseMessage.getSubject() : null)
             .body(caseMessage.getBody())
-            .createdOn(caseMessage.getCreatedOn().format(DateTimeFormatter.ofPattern(CREATED_ON_FORMAT)))
+            .createdOn(convertFromUTC(caseMessage.getCreatedOn().toLocalDateTime()).format(DateTimeFormatter.ofPattern(CREATED_ON_FORMAT)))
             .isHearingRelated(isInitialQueryMessage ? caseMessage.getIsHearingRelated() : null)
             .hearingDate(nonNull(caseMessage.getHearingDate()) && isInitialQueryMessage
                              ? caseMessage.getHearingDate().format(DateTimeFormatter.ofPattern(HEARING_DATE_FORMAT)) : null)

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/querymanagement/CaseMessage.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/querymanagement/CaseMessage.java
@@ -10,7 +10,7 @@ import uk.gov.hmcts.reform.civil.enums.YesOrNo;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 @Data
@@ -26,7 +26,7 @@ public class CaseMessage {
     private List<Element<Document>> attachments;
     private YesOrNo isHearingRelated;
     private LocalDate hearingDate;
-    private LocalDateTime createdOn;
+    private OffsetDateTime createdOn;
     private String createdBy;
     private String parentId;
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/QueryDocumentGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/QueryDocumentGenerator.java
@@ -42,7 +42,7 @@ public class QueryDocumentGenerator {
             )
         );
         assignCategoryId.assignCategoryIdToCaseDocument(caseDocument, documentCategory.getValue());
-        caseDocument.setCreatedDatetime(messageThread.get(0).getValue().getCreatedOn());
+        caseDocument.setCreatedDatetime(messageThread.get(0).getValue().getCreatedOn().toLocalDateTime());
         return caseDocument;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateQueryDocumentHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/docmosis/GenerateQueryDocumentHandlerTest.java
@@ -26,7 +26,7 @@ import uk.gov.hmcts.reform.civil.service.QueryDocumentGenerator;
 import uk.gov.hmcts.reform.civil.service.querymanagement.QueryManagementCamundaService;
 import uk.gov.hmcts.reform.civil.service.querymanagement.QueryManagementVariables;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -68,7 +68,7 @@ class GenerateQueryDocumentHandlerTest extends BaseCallbackHandlerTest {
         );
     }
 
-    private static LocalDateTime DATE_QUERY_RAISED = LocalDateTime.now();
+    private static OffsetDateTime DATE_QUERY_RAISED = OffsetDateTime.now();
     private static Long CASE_ID = 1L;
     private static String QUERY_ID = "query-id";
     private static String PARENT_QUERY_ID = "parent-id";
@@ -80,7 +80,7 @@ class GenerateQueryDocumentHandlerTest extends BaseCallbackHandlerTest {
     private static final CaseDocument INITIAL_QUERY_DOCUMENT = CaseDocumentBuilder.builder()
         .documentName(queryDocumentFilename)
         .documentType(DocumentType.QUERY_DOCUMENT)
-        .createdDatetime(DATE_QUERY_RAISED)
+        .createdDatetime(DATE_QUERY_RAISED.toLocalDateTime())
         .build().toBuilder()
         .documentLink(Document.builder().documentBinaryUrl(
                 "http://dm-store:4506/documents/73526424-8434-4b1f-aaaa-bd33a3f8338f/binary")
@@ -91,7 +91,7 @@ class GenerateQueryDocumentHandlerTest extends BaseCallbackHandlerTest {
     private static final CaseDocument OTHER_QUERY_DOCUMENT = CaseDocumentBuilder.builder()
         .documentName(String.format(QUERY_DOCUMENT.getDocumentTitle(), "Other query doc"))
         .documentType(DocumentType.QUERY_DOCUMENT)
-        .createdDatetime(DATE_QUERY_RAISED.minusDays(2))
+        .createdDatetime(DATE_QUERY_RAISED.minusDays(2).toLocalDateTime())
         .build().toBuilder()
         .documentLink(Document.builder().documentBinaryUrl(
                 "http://dm-store:4506/documents/73526424-8434-4b1f-bbbb-bd33a3f8338f/binary")
@@ -163,7 +163,7 @@ class GenerateQueryDocumentHandlerTest extends BaseCallbackHandlerTest {
         CaseDocument updatedQueryDocument = CaseDocumentBuilder.builder()
             .documentName(queryDocumentFilename)
             .documentType(DocumentType.QUERY_DOCUMENT)
-            .createdDatetime(DATE_QUERY_RAISED)
+            .createdDatetime(DATE_QUERY_RAISED.toLocalDateTime())
             .build().toBuilder()
             .documentLink(Document.builder().documentBinaryUrl(
                     "http://dm-store:4506/documents/73526424-8434-4b1f-cccc-bd33a3f8338f/binary")

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/NotifyOtherPartyQueryHasResponseNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/NotifyOtherPartyQueryHasResponseNotificationHandlerTest.java
@@ -33,7 +33,7 @@ import uk.gov.hmcts.reform.civil.service.OrganisationService;
 import uk.gov.hmcts.reform.civil.service.querymanagement.QueryManagementCamundaService;
 import uk.gov.hmcts.reform.civil.service.querymanagement.QueryManagementVariables;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -222,32 +222,32 @@ class NotifyOtherPartyQueryHasResponseNotificationHandlerTest extends BaseCallba
                                            CaseMessage.builder()
                                                .id("5")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(3))
+                                               .createdOn(OffsetDateTime.now().minusHours(3))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("6")
                                                .createdBy("LR")
-                                               .createdOn(LocalDateTime.now().minusHours(2))
+                                               .createdOn(OffsetDateTime.now().minusHours(2))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("7")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(1))
+                                               .createdOn(OffsetDateTime.now().minusHours(1))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("7")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now())
+                                               .createdOn(OffsetDateTime.now())
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("8")
                                                .createdBy("LR")
                                                .parentId("80")
-                                               .createdOn(LocalDateTime.now().plusDays(1))
+                                               .createdOn(OffsetDateTime.now().plusDays(1))
                                                .build()))
                 .build();
 
@@ -260,26 +260,26 @@ class NotifyOtherPartyQueryHasResponseNotificationHandlerTest extends BaseCallba
                                            CaseMessage.builder()
                                                .id("9")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(2))
+                                               .createdOn(OffsetDateTime.now().minusHours(2))
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("10")
                                                .createdBy("LR")
-                                               .createdOn(LocalDateTime.now().minusHours(1))
+                                               .createdOn(OffsetDateTime.now().minusHours(1))
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("11")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now())
+                                               .createdOn(OffsetDateTime.now())
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("8")
                                                .createdBy("LR")
                                                .parentId("80")
-                                               .createdOn(LocalDateTime.now().plusDays(1))
+                                               .createdOn(OffsetDateTime.now().plusDays(1))
                                                .build()))
                 .build();
 
@@ -292,26 +292,26 @@ class NotifyOtherPartyQueryHasResponseNotificationHandlerTest extends BaseCallba
                                            CaseMessage.builder()
                                                .id("13")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(2))
+                                               .createdOn(OffsetDateTime.now().minusHours(2))
                                                .parentId("3")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("14")
                                                .createdBy("LR")
-                                               .createdOn(LocalDateTime.now().minusHours(1))
+                                               .createdOn(OffsetDateTime.now().minusHours(1))
                                                .parentId("3")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("15")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now())
+                                               .createdOn(OffsetDateTime.now())
                                                .parentId("3")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("8")
                                                .createdBy("LR")
                                                .parentId("80")
-                                               .createdOn(LocalDateTime.now().plusDays(1))
+                                               .createdOn(OffsetDateTime.now().plusDays(1))
                                                .build()))
                 .build();
             return CaseDataBuilder.builder().atStateClaimIssued().build()
@@ -344,32 +344,32 @@ class NotifyOtherPartyQueryHasResponseNotificationHandlerTest extends BaseCallba
                                            CaseMessage.builder()
                                                .id("5")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(3))
+                                               .createdOn(OffsetDateTime.now().minusHours(3))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("6")
                                                .createdBy("LR")
-                                               .createdOn(LocalDateTime.now().minusHours(2))
+                                               .createdOn(OffsetDateTime.now().minusHours(2))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("7")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(1))
+                                               .createdOn(OffsetDateTime.now().minusHours(1))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("7")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now())
+                                               .createdOn(OffsetDateTime.now())
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("8")
                                                .createdBy("LR")
                                                .parentId("80")
-                                               .createdOn(LocalDateTime.now().plusDays(1))
+                                               .createdOn(OffsetDateTime.now().plusDays(1))
                                                .build()))
                 .build();
 
@@ -382,26 +382,26 @@ class NotifyOtherPartyQueryHasResponseNotificationHandlerTest extends BaseCallba
                                            CaseMessage.builder()
                                                .id("9")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(2))
+                                               .createdOn(OffsetDateTime.now().minusHours(2))
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("10")
                                                .createdBy("LR")
-                                               .createdOn(LocalDateTime.now().minusHours(1))
+                                               .createdOn(OffsetDateTime.now().minusHours(1))
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("11")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now())
+                                               .createdOn(OffsetDateTime.now())
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("8")
                                                .createdBy("LR")
                                                .parentId("80")
-                                               .createdOn(LocalDateTime.now().plusDays(1))
+                                               .createdOn(OffsetDateTime.now().plusDays(1))
                                                .build()))
                 .build();
 
@@ -429,32 +429,32 @@ class NotifyOtherPartyQueryHasResponseNotificationHandlerTest extends BaseCallba
                                            CaseMessage.builder()
                                                .id("5")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(3))
+                                               .createdOn(OffsetDateTime.now().minusHours(3))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("6")
                                                .createdBy("LR")
-                                               .createdOn(LocalDateTime.now().minusHours(2))
+                                               .createdOn(OffsetDateTime.now().minusHours(2))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("7")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(1))
+                                               .createdOn(OffsetDateTime.now().minusHours(1))
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("7")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now())
+                                               .createdOn(OffsetDateTime.now())
                                                .parentId("1")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("8")
                                                .createdBy("LR")
                                                .parentId("80")
-                                               .createdOn(LocalDateTime.now().plusDays(1))
+                                               .createdOn(OffsetDateTime.now().plusDays(1))
                                                .build()))
                 .build();
 
@@ -467,26 +467,26 @@ class NotifyOtherPartyQueryHasResponseNotificationHandlerTest extends BaseCallba
                                            CaseMessage.builder()
                                                .id("9")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(2))
+                                               .createdOn(OffsetDateTime.now().minusHours(2))
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("10")
                                                .createdBy("LR")
-                                               .createdOn(LocalDateTime.now().minusHours(1))
+                                               .createdOn(OffsetDateTime.now().minusHours(1))
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("11")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now())
+                                               .createdOn(OffsetDateTime.now())
                                                .parentId("2")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("8")
                                                .createdBy("LR")
                                                .parentId("80")
-                                               .createdOn(LocalDateTime.now().plusDays(1))
+                                               .createdOn(OffsetDateTime.now().plusDays(1))
                                                .build()))
                 .build();
 
@@ -499,26 +499,26 @@ class NotifyOtherPartyQueryHasResponseNotificationHandlerTest extends BaseCallba
                                            CaseMessage.builder()
                                                .id("13")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now().minusHours(2))
+                                               .createdOn(OffsetDateTime.now().minusHours(2))
                                                .parentId("3")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("14")
                                                .createdBy("LR")
-                                               .createdOn(LocalDateTime.now().minusHours(1))
+                                               .createdOn(OffsetDateTime.now().minusHours(1))
                                                .parentId("3")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("15")
                                                .createdBy("admin")
-                                               .createdOn(LocalDateTime.now())
+                                               .createdOn(OffsetDateTime.now())
                                                .parentId("3")
                                                .build(),
                                            CaseMessage.builder()
                                                .id("8")
                                                .createdBy("LR")
                                                .parentId("80")
-                                               .createdOn(LocalDateTime.now().plusDays(1))
+                                               .createdOn(OffsetDateTime.now().plusDays(1))
                                                .build()))
                 .build();
             return CaseDataBuilder.builder().atStateClaimIssued().build()

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/QueryResponseSolicitorNotificationHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/notification/QueryResponseSolicitorNotificationHandlerTest.java
@@ -29,6 +29,7 @@ import uk.gov.hmcts.reform.civil.service.querymanagement.QueryManagementCamundaS
 import uk.gov.hmcts.reform.civil.service.querymanagement.QueryManagementVariables;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,7 +66,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
     @InjectMocks
     private QueryResponseSolicitorNotificationHandler handler;
 
-    private CaseData createCaseDataWithMultipleFollowUpQueries(LocalDateTime now) {
+    private CaseData createCaseDataWithMultipleFollowUpQueries(OffsetDateTime now) {
         CaseQueriesCollection applicantQuery = CaseQueriesCollection.builder()
             .roleOnCase(CaseRole.APPLICANTSOLICITORONE.toString())
             .caseMessages(wrapElements(
@@ -223,7 +224,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
             .build();
     }
 
-    private CaseData createCaseDataWithQueries(LocalDateTime now) {
+    private CaseData createCaseDataWithQueries(OffsetDateTime now) {
         CaseQueriesCollection applicantQuery = CaseQueriesCollection.builder()
             .roleOnCase(CaseRole.APPLICANTSOLICITORONE.toString())
             .caseMessages(wrapElements(
@@ -386,7 +387,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any(),
                 any()
             )).thenReturn(List.of(CaseRole.APPLICANTSOLICITORONE.toString()));
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithMultipleFollowUpQueries(now);
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -395,7 +396,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
             verify(notificationService).sendMail(
                 "applicant@email.com",
                 TEMPLATE_ID,
-                getNotificationDataMap(caseData, now.minusHours(1)),
+                getNotificationDataMap(caseData, now.minusHours(1).toLocalDateTime()),
                 "response-to-query-notification-000DC001"
             );
         }
@@ -410,7 +411,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any(),
                 any()
             )).thenReturn(List.of(CaseRole.RESPONDENTSOLICITORONE.toString()));
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithMultipleFollowUpQueries(now);
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -419,7 +420,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
             verify(notificationService).sendMail(
                 "respondent1@email.com",
                 TEMPLATE_ID,
-                getNotificationDataMap(caseData, now.minusHours(1)),
+                getNotificationDataMap(caseData, now.minusHours(1).toLocalDateTime()),
                 "response-to-query-notification-000DC001"
             );
         }
@@ -434,7 +435,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any(),
                 any()
             )).thenReturn(List.of(CaseRole.RESPONDENTSOLICITORTWO.toString()));
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithMultipleFollowUpQueries(now);
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -443,7 +444,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
             verify(notificationService).sendMail(
                 "respondent2@email.com",
                 TEMPLATE_ID,
-                getNotificationDataMap(caseData, now.minusHours(1)),
+                getNotificationDataMap(caseData, now.minusHours(1).toLocalDateTime()),
                 "response-to-query-notification-000DC001"
             );
         }
@@ -458,7 +459,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any(),
                 any()
             )).thenReturn(List.of(CaseRole.APPLICANTSOLICITORONE.toString()));
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithQueries(now);
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -467,7 +468,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
             verify(notificationService).sendMail(
                 "applicant@email.com",
                 TEMPLATE_ID,
-                getNotificationDataMap(caseData, now),
+                getNotificationDataMap(caseData, now.toLocalDateTime()),
                 "response-to-query-notification-000DC001"
             );
         }
@@ -482,7 +483,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any(),
                 any()
             )).thenReturn(List.of(CaseRole.RESPONDENTSOLICITORONE.toString()));
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithQueries(now);
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -491,7 +492,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
             verify(notificationService).sendMail(
                 "respondent1@email.com",
                 TEMPLATE_ID,
-                getNotificationDataMap(caseData, now),
+                getNotificationDataMap(caseData, now.toLocalDateTime()),
                 "response-to-query-notification-000DC001"
             );
         }
@@ -506,7 +507,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any(),
                 any()
             )).thenReturn(List.of(CaseRole.RESPONDENTSOLICITORTWO.toString()));
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithQueries(now);
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -515,7 +516,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
             verify(notificationService).sendMail(
                 "respondent2@email.com",
                 TEMPLATE_ID,
-                getNotificationDataMap(caseData, now),
+                getNotificationDataMap(caseData, now.toLocalDateTime()),
                 "response-to-query-notification-000DC001"
             );
         }
@@ -534,7 +535,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any()
             )).thenReturn(List.of(CaseRole.CLAIMANT.toString()));
             when(notificationsProperties.getQueryLipResponseReceivedEnglish()).thenReturn(TEMPLATE_ID);
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithQueries(now);
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -559,7 +560,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any()
             )).thenReturn(List.of(CaseRole.CLAIMANT.toString()));
             when(notificationsProperties.getQueryLipResponseReceivedWelsh()).thenReturn(TEMPLATE_ID);
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithQueries(now);
             caseData = caseData.toBuilder().claimantBilingualLanguagePreference(Language.BOTH.toString()).build();
             CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
@@ -585,7 +586,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any()
             )).thenReturn(List.of(CaseRole.DEFENDANT.toString()));
             when(notificationsProperties.getQueryLipResponseReceivedEnglish()).thenReturn(TEMPLATE_ID);
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithQueries(now);
             caseData = caseData.toBuilder()
                 .defendantUserDetails(IdamUserDetails.builder().email("sole.trader@email.com").build()).build();
@@ -621,7 +622,7 @@ class QueryResponseSolicitorNotificationHandlerTest extends BaseCallbackHandlerT
                 any()
             )).thenReturn(List.of(CaseRole.DEFENDANT.toString()));
             when(notificationsProperties.getQueryLipResponseReceivedWelsh()).thenReturn(TEMPLATE_ID);
-            LocalDateTime now = LocalDateTime.now();
+            OffsetDateTime now = OffsetDateTime.now();
             CaseData caseData = createCaseDataWithQueries(now);
             caseData = caseData.toBuilder()
                 .defendantUserDetails(IdamUserDetails.builder().email("sole.trader@email.com").build())

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RaiseQueryCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/RaiseQueryCallbackHandlerTest.java
@@ -26,6 +26,8 @@ import uk.gov.hmcts.reform.civil.utils.AssignCategoryId;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -50,7 +52,7 @@ class RaiseQueryCallbackHandlerTest extends BaseCallbackHandlerTest {
     private static final String USER_ID = "UserId";
     private static final Long CASE_ID = Long.parseLong("1234123412341234");
     private static final String QUERY_ID = "QueryId";
-    private static final LocalDateTime NOW = LocalDateTime.of(2025, 3, 1, 7, 0, 0);
+    private static final OffsetDateTime NOW = OffsetDateTime.of(LocalDateTime.of(2025, 3, 1, 7, 0, 0), ZoneOffset.UTC);
 
     @InjectMocks
     private RaiseQueryCallbackHandler handler;
@@ -470,7 +472,7 @@ class RaiseQueryCallbackHandlerTest extends BaseCallbackHandlerTest {
             }
         }
 
-        private CaseQueriesCollection mockQueriesCollection(String queryId, LocalDateTime latestDate) {
+        private CaseQueriesCollection mockQueriesCollection(String queryId, OffsetDateTime latestDate) {
             return CaseQueriesCollection.builder()
                 .partyName("partyName")
                 .roleOnCase("roleOnCase")
@@ -496,7 +498,7 @@ class RaiseQueryCallbackHandlerTest extends BaseCallbackHandlerTest {
                 .build();
         }
 
-        private CaseQueriesCollection mockQueriesCollectionWithAttachments(String queryId, LocalDateTime latestDate) {
+        private CaseQueriesCollection mockQueriesCollectionWithAttachments(String queryId, OffsetDateTime latestDate) {
             return CaseQueriesCollection.builder()
                 .partyName("partyName")
                 .roleOnCase("roleOnCase")

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/docmosis/querymanagement/DocumentQueryMessageTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/docmosis/querymanagement/DocumentQueryMessageTest.java
@@ -15,7 +15,7 @@ import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 class DocumentQueryMessageTest {
 
     private static final LocalDate HEARING_DATE = LocalDate.of(2025, 3, 15);
-    private static final OffsetDateTime DATE_QUERY_RAISED = OffsetDateTime.of(LocalDateTime.of(2025, 1, 15, 12, 0, 0), ZoneOffset.UTC);
+    private static final OffsetDateTime DATE_QUERY_RAISED = OffsetDateTime.of(LocalDateTime.of(2025, 5, 15, 12, 0, 0), ZoneOffset.UTC);
     private static final UUID SOLICITOR_ID = UUID.randomUUID();
     private static final UUID CASEWORKER_ID = UUID.randomUUID();
     private static final String QUERY_ID = "query-id";
@@ -38,7 +38,7 @@ class DocumentQueryMessageTest {
             .id(PARENT_QUERY_ID)
             .name("Solicitor")
             .subject("initial query")
-            .createdOn("15-01-2025 12:00")
+            .createdOn("15-05-2025 13:00")
             .isHearingRelated(YES)
             .hearingDate("15-03-2025")
             .build();
@@ -63,7 +63,7 @@ class DocumentQueryMessageTest {
             .messageType("Caseworker response")
             .id(QUERY_ID)
             .name("Caseworker")
-            .createdOn("16-01-2025 12:00")
+            .createdOn("16-05-2025 13:00")
             .build();
 
         DocumentQueryMessage actual = DocumentQueryMessage.from(queryResponse, true);
@@ -86,7 +86,7 @@ class DocumentQueryMessageTest {
             .messageType("Follow up")
             .id(QUERY_ID)
             .name("Solicitor")
-            .createdOn("17-01-2025 12:00")
+            .createdOn("17-05-2025 13:00")
             .build();
 
         DocumentQueryMessage actual = DocumentQueryMessage.from(queryFollowUp, false);

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/docmosis/querymanagement/DocumentQueryMessageTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/docmosis/querymanagement/DocumentQueryMessageTest.java
@@ -5,6 +5,8 @@ import uk.gov.hmcts.reform.civil.model.querymanagement.CaseMessage;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,7 +15,7 @@ import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 class DocumentQueryMessageTest {
 
     private static final LocalDate HEARING_DATE = LocalDate.of(2025, 3, 15);
-    private static final LocalDateTime DATE_QUERY_RAISED = LocalDateTime.of(2025, 1, 15, 12, 0, 0);
+    private static final OffsetDateTime DATE_QUERY_RAISED = OffsetDateTime.of(LocalDateTime.of(2025, 1, 15, 12, 0, 0), ZoneOffset.UTC);
     private static final UUID SOLICITOR_ID = UUID.randomUUID();
     private static final UUID CASEWORKER_ID = UUID.randomUUID();
     private static final String QUERY_ID = "query-id";

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/docmosis/querymanagement/QueryDocumentTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/docmosis/querymanagement/QueryDocumentTest.java
@@ -6,6 +6,8 @@ import uk.gov.hmcts.reform.civil.model.querymanagement.CaseMessage;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -16,7 +18,7 @@ import static uk.gov.hmcts.reform.civil.utils.ElementUtils.element;
 class QueryDocumentTest {
 
     private static LocalDate HEARING_DATE = LocalDate.of(2025, 3, 15);
-    private static LocalDateTime DATE_QUERY_RAISED = LocalDateTime.of(2025, 1, 15, 12, 0, 0);
+    private static OffsetDateTime DATE_QUERY_RAISED = OffsetDateTime.of(LocalDateTime.of(2025, 1, 15, 12, 0, 0), ZoneOffset.UTC);
     private static String CASE_ID = "1111222233334444";
     private static UUID SOLICITOR_ID = UUID.randomUUID();
     private static UUID CASEWORKER_ID = UUID.randomUUID();

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/querymanagement/CaseQueriesCollectionTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/querymanagement/CaseQueriesCollectionTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 
@@ -19,7 +21,7 @@ class CaseQueriesCollectionTest {
 
     @Test
     void shouldReturnLatestCaseMessage() {
-        LocalDateTime now = LocalDateTime.of(2025, 3, 1, 7, 0, 0);
+        OffsetDateTime now = OffsetDateTime.of(LocalDateTime.of(2025, 3, 1, 7, 0, 0), ZoneOffset.UTC);
         CaseQueriesCollection caseQueries = CaseQueriesCollection.builder()
             .partyName("John Doe")
             .roleOnCase("applicant-solicitor")

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/QueryDocumentGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/QueryDocumentGeneratorTest.java
@@ -19,7 +19,7 @@ import uk.gov.hmcts.reform.civil.model.querymanagement.CaseMessage;
 import uk.gov.hmcts.reform.civil.service.docmosis.DocumentGeneratorService;
 import uk.gov.hmcts.reform.civil.utils.AssignCategoryId;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +47,7 @@ class QueryDocumentGeneratorTest {
     private static final Long CASE_ID = 12345L;
     private static final String AUTHORIZATION = "Bearer token";
     private static final DocCategory DOCUMENT_CATEGORY = DocCategory.CLAIMANT_QUERY_DOCUMENTS;
-    private static final LocalDateTime CREATED_ON = LocalDateTime.now();
+    private static final OffsetDateTime CREATED_ON = OffsetDateTime.now();
     private static final byte[] DOCUMENT_BYTES = "sample bytes".getBytes();
     private static final String SUBJECT = "Query Subject";
     private static final String CREATED_BY = "testUser";
@@ -81,7 +81,7 @@ class QueryDocumentGeneratorTest {
         uploadedCaseDocument = CaseDocument.builder()
             .documentName(generatedDocmosisDocument.getDocumentTitle())
             .documentType(DocumentType.QUERY_DOCUMENT)
-            .createdDatetime(CREATED_ON)
+            .createdDatetime(CREATED_ON.toLocalDateTime())
             .build();
 
         when(documentGeneratorService.generateDocmosisDocument(any(QueryDocument.class), eq(QUERY_DOCUMENT)))

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/CaseQueriesUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/CaseQueriesUtilTest.java
@@ -23,7 +23,7 @@ import uk.gov.hmcts.reform.civil.model.querymanagement.LatestQuery;
 import uk.gov.hmcts.reform.civil.service.CoreCaseUserService;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -132,7 +132,7 @@ class CaseQueriesUtilTest {
 
     @Test
     void shouldBuildLatestQueryFromCaseMessage() {
-        LocalDateTime createdOn = LocalDateTime.now();
+        OffsetDateTime createdOn = OffsetDateTime.now();
         CaseMessage caseMessage = buildCaseMessage("id", "Query 3")
             .toBuilder()
             .createdOn(createdOn)
@@ -158,7 +158,7 @@ class CaseQueriesUtilTest {
     void shouldAssignCategoryIDToAttachments_whenApplicantUploadsAttachment() {
         CaseMessage caseMessage = buildCaseMessage("id", "Query 3")
             .toBuilder()
-            .createdOn(LocalDateTime.now())
+            .createdOn(OffsetDateTime.now())
             .attachments(wrapElements(
                 Document.builder().documentFileName("a").build(),
                 Document.builder().documentFileName("b").build()))
@@ -177,7 +177,7 @@ class CaseQueriesUtilTest {
     void shouldAssignCategoryIDToAttachments_whenDefendantUploadsAttachment() {
         CaseMessage caseMessage = buildCaseMessage("id", "Query 3")
             .toBuilder()
-            .createdOn(LocalDateTime.now())
+            .createdOn(OffsetDateTime.now())
             .attachments(wrapElements(
                 Document.builder().documentFileName("a").build(),
                 Document.builder().documentFileName("b").build()
@@ -198,7 +198,7 @@ class CaseQueriesUtilTest {
     void shouldAssignCategoryIDToAttachments_whenClaimantUploadsAttachment() {
         CaseMessage caseMessage = buildCaseMessage("id", "Query 3")
             .toBuilder()
-            .createdOn(LocalDateTime.now())
+            .createdOn(OffsetDateTime.now())
             .attachments(wrapElements(
                 Document.builder().documentFileName("a").build(),
                 Document.builder().documentFileName("b").build()
@@ -219,7 +219,7 @@ class CaseQueriesUtilTest {
     void shouldAssignCategoryIDToAttachments_whenRespondent1UploadsAttachment() {
         CaseMessage caseMessage = buildCaseMessage("id", "Query 3")
             .toBuilder()
-            .createdOn(LocalDateTime.now())
+            .createdOn(OffsetDateTime.now())
             .attachments(wrapElements(
                 Document.builder().documentFileName("a").build(),
                 Document.builder().documentFileName("b").build()))
@@ -238,7 +238,7 @@ class CaseQueriesUtilTest {
     void shouldAssignCategoryIDToAttachments_whenRespondent2UploadsAttachment() {
         CaseMessage caseMessage = buildCaseMessage("id", "Query 3")
             .toBuilder()
-            .createdOn(LocalDateTime.now())
+            .createdOn(OffsetDateTime.now())
             .attachments(wrapElements(
                 Document.builder().documentFileName("a").build(),
                 Document.builder().documentFileName("b").build()))
@@ -257,7 +257,7 @@ class CaseQueriesUtilTest {
     void shouldThrowError_whenUserHasUnsupportedRole() {
         CaseMessage caseMessage = buildCaseMessage("id", "Query 3")
             .toBuilder()
-            .createdOn(LocalDateTime.now())
+            .createdOn(OffsetDateTime.now())
             .attachments(wrapElements(
                 Document.builder().documentFileName("a").build(),
                 Document.builder().documentFileName("b").build()))
@@ -373,10 +373,10 @@ class CaseQueriesUtilTest {
             .partyName("John Doe")
             .roleOnCase("applicant-solicitor")
             .caseMessages(wrapElements(CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now())
+                                           .createdOn(OffsetDateTime.now())
                                            .build(),
                                        CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusDays(1))
+                                           .createdOn(OffsetDateTime.now().minusDays(1))
                                            .build()))
             .build();
 
@@ -384,7 +384,7 @@ class CaseQueriesUtilTest {
             .partyName("John Smith")
             .roleOnCase("respondent-solicitor-1")
             .caseMessages(wrapElements(CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusDays(2))
+                                           .createdOn(OffsetDateTime.now().minusDays(2))
                                            .build()))
             .build();
 
@@ -404,10 +404,10 @@ class CaseQueriesUtilTest {
             .partyName("John Doe")
             .roleOnCase("applicant-solicitor")
             .caseMessages(wrapElements(CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusDays(2))
+                                           .createdOn(OffsetDateTime.now().minusDays(2))
                                            .build(),
                                        CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusDays(1))
+                                           .createdOn(OffsetDateTime.now().minusDays(1))
                                            .build()))
             .build();
 
@@ -415,10 +415,10 @@ class CaseQueriesUtilTest {
             .partyName("John Smith")
             .roleOnCase("respondent-solicitor-1")
             .caseMessages(wrapElements(CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now())
+                                           .createdOn(OffsetDateTime.now())
                                            .build(),
                                        CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusMinutes(1))
+                                           .createdOn(OffsetDateTime.now().minusMinutes(1))
                                            .build()))
             .build();
 
@@ -426,7 +426,7 @@ class CaseQueriesUtilTest {
             .partyName("Jane Doe")
             .roleOnCase("respondent-solicitor-2")
             .caseMessages(wrapElements(CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusMinutes(2))
+                                           .createdOn(OffsetDateTime.now().minusMinutes(2))
                                            .build()))
             .build();
 
@@ -447,10 +447,10 @@ class CaseQueriesUtilTest {
             .partyName("John Doe")
             .roleOnCase("applicant-solicitor")
             .caseMessages(wrapElements(CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusDays(2))
+                                           .createdOn(OffsetDateTime.now().minusDays(2))
                                            .build(),
                                        CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusDays(1))
+                                           .createdOn(OffsetDateTime.now().minusDays(1))
                                            .build()))
             .build();
 
@@ -458,7 +458,7 @@ class CaseQueriesUtilTest {
             .partyName("John Smith")
             .roleOnCase("respondent-solicitor-1")
             .caseMessages(wrapElements(CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusHours(2))
+                                           .createdOn(OffsetDateTime.now().minusHours(2))
                                            .build()))
             .build();
 
@@ -466,10 +466,10 @@ class CaseQueriesUtilTest {
             .partyName("Jane Doe")
             .roleOnCase("respondent-solicitor-2")
             .caseMessages(wrapElements(CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now().minusMinutes(2))
+                                           .createdOn(OffsetDateTime.now().minusMinutes(2))
                                            .build(),
                                        CaseMessage.builder()
-                                           .createdOn(LocalDateTime.now())
+                                           .createdOn(OffsetDateTime.now())
                                            .build()))
             .build();
 
@@ -855,20 +855,6 @@ class CaseQueriesUtilTest {
         assertEquals("Unsupported case role for query management.", exception.getMessage());
     }
 
-    private CaseMessage buildCaseMessageAt(String id, String subject, LocalDateTime createdDate) {
-        return CaseMessage.builder()
-            .id(id)
-            .subject(subject)
-            .name("John Doe")
-            .body("Sample body text")
-            .attachments(List.of())
-            .isHearingRelated(NO)
-            .hearingDate(LocalDate.now())
-            .createdOn(createdDate)
-            .createdBy("System")
-            .build();
-    }
-
     private CaseMessage buildCaseMessage(String id, String subject) {
         return CaseMessage.builder()
             .id(id)
@@ -878,7 +864,7 @@ class CaseQueriesUtilTest {
             .attachments(List.of())
             .isHearingRelated(NO)
             .hearingDate(LocalDate.now())
-            .createdOn(LocalDateTime.now())
+            .createdOn(OffsetDateTime.now())
             .createdBy("System")
             .build();
     }
@@ -895,7 +881,7 @@ class CaseQueriesUtilTest {
                     Document.builder().documentFileName("b").build()))
                 .isHearingRelated(NO)
                 .hearingDate(LocalDate.now())
-                .createdOn(LocalDateTime.now())
+                .createdOn(OffsetDateTime.now())
                 .createdBy("System")
                 .build(),
             CaseMessage.builder()
@@ -908,7 +894,7 @@ class CaseQueriesUtilTest {
                     Document.builder().documentFileName("d").build()))
                 .isHearingRelated(NO)
                 .hearingDate(LocalDate.now())
-                .createdOn(LocalDateTime.now())
+                .createdOn(OffsetDateTime.now())
                 .createdBy("System")
                 .parentId("id")
                 .build());
@@ -916,7 +902,7 @@ class CaseQueriesUtilTest {
 
     @Test
     void shouldReturnMatchingCollection_WhenMessageExistsInApplicantSolicitorQueries() {
-        LocalDateTime createdOn = LocalDateTime.now();
+        OffsetDateTime createdOn = OffsetDateTime.now();
         CaseMessage caseMessage = buildCaseMessage("id", "Query 1")
             .toBuilder()
             .createdOn(createdOn)
@@ -937,7 +923,7 @@ class CaseQueriesUtilTest {
 
     @Test
     void shouldReturnMatchingCollection_WhenMessageExistsInRespondentSolicitor1Queries() {
-        LocalDateTime createdOn = LocalDateTime.now();
+        OffsetDateTime createdOn = OffsetDateTime.now();
         CaseMessage caseMessage = buildCaseMessage("id", "Query 2")
             .toBuilder()
             .createdOn(createdOn)
@@ -958,7 +944,7 @@ class CaseQueriesUtilTest {
 
     @Test
     void shouldReturnMatchingCollection_WhenMessageExistsInRespondentSolicitor2Queries() {
-        LocalDateTime createdOn = LocalDateTime.now();
+        OffsetDateTime createdOn = OffsetDateTime.now();
         CaseMessage caseMessage = buildCaseMessage("id", "Query 3")
             .toBuilder()
             .createdOn(createdOn)
@@ -979,7 +965,7 @@ class CaseQueriesUtilTest {
 
     @Test
     void shouldReturnNull_WhenMessageDoesNotExistInAnyCollection() {
-        LocalDateTime createdOn = LocalDateTime.now();
+        OffsetDateTime createdOn = OffsetDateTime.now();
         CaseMessage caseMessage = buildCaseMessage("id", "Query 4")
             .toBuilder()
             .createdOn(createdOn)
@@ -994,7 +980,7 @@ class CaseQueriesUtilTest {
 
     @Test
     void shouldReturnNull_WhenCaseMessagesAreNull() {
-        LocalDateTime createdOn = LocalDateTime.now();
+        OffsetDateTime createdOn = OffsetDateTime.now();
         CaseMessage caseMessage = buildCaseMessage("id", "Query 5")
             .toBuilder()
             .createdOn(createdOn)


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17167

### Change description ###
Updated CaseMEssage model createdOn field from LocalDateTime to OffsettDateTime to preserve UTC date formatting. Converted the createdOn utc date from UTC to local time for the generated query documents.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
