### PR TITLE
DTSCCI-2198 Dashboard notification flag should be enabled only if it is spec case

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/FeatureToggleService.java
@@ -102,6 +102,10 @@ public class FeatureToggleService {
     }
 
     public boolean isDashboardEnabledForCase(CaseData caseData) {
+        if (!SPEC_CLAIM.equals(caseData.getCaseAccessCategory())) {
+            return false;
+        }
+
         ZoneId zoneId = ZoneId.systemDefault();
         long epoch;
         if (caseData.getSubmittedDate() == null) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/FeatureToggleServiceTest.java
@@ -1,12 +1,14 @@
 package uk.gov.hmcts.reform.civil.service;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.civil.enums.CaseCategory;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleApi;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -15,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -214,6 +217,18 @@ class FeatureToggleServiceTest {
     private void givenToggle(String feature, boolean state) {
         when(featureToggleApi.isFeatureEnabled(eq(feature)))
             .thenReturn(state);
+    }
+
+    @Test
+    void shouldReturnFalse_whenCaseIsNotSpecClaim() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .atStateClaimIssued()
+            .caseAccessCategory(CaseCategory.UNSPEC_CLAIM)
+            .build();
+
+        assertThat(featureToggleService.isDashboardEnabledForCase(caseData)).isFalse();
+
+        verifyNoInteractions(featureToggleApi);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSCCI-2198

Issue was in unspec LR v Lip claim which can stay online for 14 days waiting for any NoC. If the case happened to be transferred offline via case proceeds in caseman, then we are trying to generate dashboard notificiation and the offline bpmn goes stuck for that case and will not admin to do any actions like adding case note/ manage documents etc.

<img width="1190" alt="Screenshot 2025-05-19 at 10 49 37" src="https://github.com/user-attachments/assets/264f2e37-f094-4d27-b41b-94b8ed6d51cf" />

