### PR TITLE
CIV-17529 Other party query email null pointer

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/client/CcdCaseEventsConsumer.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/client/CcdCaseEventsConsumer.java
@@ -5,6 +5,7 @@ import com.azure.messaging.servicebus.ServiceBusReceiverClient;
 import com.azure.messaging.servicebus.ServiceBusSessionReceiverClient;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.civil.config.CcdEventServiceBusConfiguration;
@@ -13,6 +14,7 @@ import uk.gov.hmcts.reform.civil.service.servicebus.CcdEventMessageReceiverServi
 @Slf4j
 @Component
 @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+@ConditionalOnProperty("reference.database.enabled")
 @SuppressWarnings("PMD.DoNotUseThreads")
 public class CcdCaseEventsConsumer implements Runnable {
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/QueryNotificationUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/QueryNotificationUtils.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.ONE_V_TWO_TWO_LEGAL_REP;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.getMultiPartyScenario;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.CLAIM_LEGAL_ORG_NAME_SPEC;
@@ -141,10 +142,12 @@ public class QueryNotificationUtils {
                 emailDetailsList.add(createLipOnCaseEmailDetails(email, lipName, lipOtherPartyWelsh));
                 break;
             case "lipRespondent":
-                email = caseData.getDefendantUserDetails().getEmail();
-                lipName = caseData.getRespondent1().getPartyName();
-                lipOtherPartyWelsh = caseData.isRespondentResponseBilingual() ? "WELSH" : "NON_WELSH";
-                emailDetailsList.add(createLipOnCaseEmailDetails(email, lipName, lipOtherPartyWelsh));
+                if (nonNull(caseData.getDefendantUserDetails())) {
+                    email = caseData.getDefendantUserDetails().getEmail();
+                    lipName = caseData.getRespondent1().getPartyName();
+                    lipOtherPartyWelsh = caseData.isRespondentResponseBilingual() ? "WELSH" : "NON_WELSH";
+                    emailDetailsList.add(createLipOnCaseEmailDetails(email, lipName, lipOtherPartyWelsh));
+                }
                 break;
             case "lrApplicant":
                 email = caseData.getApplicantSolicitor1UserDetails().getEmail();


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17529


### Change description ###
Defendant lip user details, including their account email is not populated in case data until they have gained access to the case. This results in a null pointer when claimant raises a query before the defendant has linked the case.
 
-Skipping sending defendant lip the query raised/responded other party email when defendantUserDetails is null.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
