### PR TITLE
CIV-17629 Claim fee DJ tab

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/judgmentsonline/DefaultJudgmentOnlineMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/judgmentsonline/DefaultJudgmentOnlineMapper.java
@@ -36,7 +36,8 @@ public class DefaultJudgmentOnlineMapper extends JudgmentOnlineMapper {
     public JudgmentDetails addUpdateActiveJudgment(CaseData caseData) {
 
         BigInteger orderAmount = MonetaryConversions.poundsToPennies(JudgmentsOnlineHelper.getDebtAmount(caseData, interestCalculator));
-        BigInteger costs = MonetaryConversions.poundsToPennies(JudgmentsOnlineHelper.getCostOfJudgmentForDJ(caseData));
+        BigInteger costs = MonetaryConversions.poundsToPennies(JudgmentsOnlineHelper.getFixedCostsOfJudgmentForDJ(caseData));
+        BigInteger claimFee = MonetaryConversions.poundsToPennies(JudgmentsOnlineHelper.getClaimFeeOfJudgmentForDJ(caseData));
         isNonDivergent =  JudgmentsOnlineHelper.isNonDivergentForDJ(caseData);
         JudgmentDetails activeJudgment = super.addUpdateActiveJudgment(caseData);
         activeJudgment = super.updateDefendantDetails(activeJudgment, caseData, addressMapper);
@@ -51,8 +52,9 @@ public class DefaultJudgmentOnlineMapper extends JudgmentOnlineMapper {
             .rtlState(isNonDivergent ? JudgmentRTLStatus.ISSUED.getRtlState() : null)
             .issueDate(LocalDate.now())
             .orderedAmount(orderAmount.toString())
+            .claimFeeAmount(claimFee.toString())
             .costs(costs.toString())
-            .totalAmount(orderAmount.add(costs).toString())
+            .totalAmount(orderAmount.add(costs).add(claimFee).toString())
             .build();
         super.updateJudgmentTabDataWithActiveJudgment(judgmentDetails, caseData);
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/judgmentsonline/JudgmentsOnlineHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/judgmentsonline/JudgmentsOnlineHelper.java
@@ -83,29 +83,38 @@ public class JudgmentsOnlineHelper {
             || caseData.isLRvLipOneVOne();
     }
 
-    public static BigDecimal getCostOfJudgmentForDJ(CaseData data) {
+    public static BigDecimal getClaimFeeOfJudgmentForDJ(CaseData data) {
 
         if (data.getOutstandingFeeInPounds() != null) {
             return data.getOutstandingFeeInPounds();
         }
 
         String repaymentSummary = data.getRepaymentSummaryObject();
-        BigDecimal fixedCost = null;
         BigDecimal claimCost = null;
         if (null != repaymentSummary) {
-            fixedCost = repaymentSummary.contains("Fixed")
-                ? new BigDecimal(repaymentSummary.substring(
-                repaymentSummary.indexOf("Fixed cost amount \n£") + 20,
-                repaymentSummary.indexOf("\n### Claim fee amount ")
-            )) : null;
             claimCost = new BigDecimal(repaymentSummary.substring(
                 repaymentSummary.indexOf("Claim fee amount \n £") + 20,
                 repaymentSummary.indexOf("\n ## Subtotal")
             ));
         }
 
-        return fixedCost != null && claimCost != null ? fixedCost.add(claimCost)
-            : claimCost != null ? claimCost : ZERO;
+        return claimCost != null ? claimCost : ZERO;
+
+    }
+
+    public static BigDecimal getFixedCostsOfJudgmentForDJ(CaseData data) {
+
+        String repaymentSummary = data.getRepaymentSummaryObject();
+        BigDecimal fixedCost = null;
+        if (null != repaymentSummary) {
+            fixedCost = repaymentSummary.contains("Fixed")
+                ? new BigDecimal(repaymentSummary.substring(
+                repaymentSummary.indexOf("Fixed cost amount \n£") + 20,
+                repaymentSummary.indexOf("\n### Claim fee amount ")
+            )) : null;
+        }
+
+        return fixedCost != null ? fixedCost : ZERO;
 
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/robotics/mapper/EventHistoryMapper.java
@@ -416,7 +416,8 @@ public class EventHistoryMapper {
                               .amountOfJudgment(amountClaimedWithInterest.setScale(2))
                               .amountOfCosts((caseData.isApplicantLipOneVOne() && featureToggleService.isLipVLipEnabled())
                                                  ? MonetaryConversions.penniesToPounds(caseData.getClaimFee().getCalculatedAmountInPence())
-                                                 : JudgmentsOnlineHelper.getCostOfJudgmentForDJ(caseData))
+                                                 : JudgmentsOnlineHelper.getFixedCostsOfJudgmentForDJ(caseData).add(
+                                                     JudgmentsOnlineHelper.getClaimFeeOfJudgmentForDJ(caseData)))
                               .amountPaidBeforeJudgment((caseData.getPartialPayment() == YesOrNo.YES) ? partialPaymentPounds : ZERO)
                               .isJudgmentForthwith(caseData.getPaymentTypeSelection().equals(DJPaymentTypeSelection.IMMEDIATELY))
                               .paymentInFullDate(paymentInFullDate)

--- a/src/test/java/uk/gov/hmcts/reform/civil/helpers/judgmentsonline/JudgmentsOnlineHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/helpers/judgmentsonline/JudgmentsOnlineHelperTest.java
@@ -21,7 +21,8 @@ import uk.gov.hmcts.reform.civil.model.judgmentonline.PaymentPlanSelection;
 import uk.gov.hmcts.reform.civil.model.judgmentonline.JudgmentDetails;
 import uk.gov.hmcts.reform.civil.model.judgmentonline.JudgmentPaymentPlan;
 import static uk.gov.hmcts.reform.civil.helpers.judgmentsonline.JudgmentsOnlineHelper.checkIfDateDifferenceIsGreaterThan31Days;
-import static uk.gov.hmcts.reform.civil.helpers.judgmentsonline.JudgmentsOnlineHelper.getCostOfJudgmentForDJ;
+import static uk.gov.hmcts.reform.civil.helpers.judgmentsonline.JudgmentsOnlineHelper.getFixedCostsOfJudgmentForDJ;
+import static uk.gov.hmcts.reform.civil.helpers.judgmentsonline.JudgmentsOnlineHelper.getClaimFeeOfJudgmentForDJ;
 import static uk.gov.hmcts.reform.civil.helpers.judgmentsonline.JudgmentsOnlineHelper.getMoneyValue;
 import static uk.gov.hmcts.reform.civil.helpers.judgmentsonline.JudgmentsOnlineHelper.getPartialPayment;
 import static uk.gov.hmcts.reform.civil.helpers.judgmentsonline.JudgmentsOnlineHelper.isNonDivergentForDJ;
@@ -94,7 +95,8 @@ public class JudgmentsOnlineHelperTest {
             .repaymentSummaryObject(
                 REPAYMENT_SUMMARY_OBJECT)
             .build();
-        assertThat(getCostOfJudgmentForDJ(caseData)).isEqualTo("172.00");
+        assertThat(getFixedCostsOfJudgmentForDJ(caseData).add(getClaimFeeOfJudgmentForDJ(caseData)))
+            .isEqualTo("172.00");
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17629


### Change description ###
In DefaultJudgmentOnlineMapper, I have separated the method used to calculate and add the fixed costs and the claim fee into two methods, which now calculate them separately.

The claim fee is added separately to the repayment object, so it is now displayed in the Judgment Tab.

They are also added separately to the totalAmount.

<img width="1063" height="626" alt="image" src="https://github.com/user-attachments/assets/9e0946bd-640b-47f4-8870-2751e042768e" />



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
