### PR TITLE
CIV-17618 - Translation status incorrectly displayed following Claimant Intent

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudgeDecisionOnReconsiderationRequestCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/JudgeDecisionOnReconsiderationRequestCallbackHandler.java
@@ -135,8 +135,7 @@ public class JudgeDecisionOnReconsiderationRequestCallbackHandler extends Callba
                 List<Element<CaseDocument>> systemGeneratedCaseDocuments =
                     callbackParams.getCaseData().getSystemGeneratedCaseDocuments();
                 if (featureToggleService.isWelshEnabledForMainCase() && (callbackParams.getCaseData().isClaimantBilingual()
-                    || callbackParams.getCaseData().isRespondentResponseBilingual()
-                    || callbackParams.getCaseData().isLipDefendantSpecifiedBilingualDocuments())) {
+                    || callbackParams.getCaseData().isRespondentResponseBilingual())) {
                     caseDataBuilder.preTranslationDocuments(List.of(ElementUtils.element(requestForReconsiderationDocument)));
                     caseDataBuilder.bilingualHint(YesOrNo.YES);
                     caseDataBuilder.preTranslationDocumentType(DECISION_MADE_ON_APPLICATIONS);

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/CaseData.java
@@ -35,7 +35,6 @@ import uk.gov.hmcts.reform.civil.enums.ResponseIntention;
 import uk.gov.hmcts.reform.civil.enums.SuperClaimType;
 import uk.gov.hmcts.reform.civil.enums.TimelineUploadTypeSpec;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
-import uk.gov.hmcts.reform.civil.enums.dq.Language;
 import uk.gov.hmcts.reform.civil.enums.settlediscontinue.SettleDiscontinueYesOrNoList;
 import uk.gov.hmcts.reform.civil.handler.callback.user.spec.show.ResponseOneVOneShowTag;
 import uk.gov.hmcts.reform.civil.model.breathing.BreathingSpaceInfo;
@@ -108,7 +107,6 @@ import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.FAST_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.AllocatedTrack.SMALL_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.BusinessProcessStatus.FINISHED;
 import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
-import static uk.gov.hmcts.reform.civil.enums.CaseCategory.UNSPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.TWO_V_ONE;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.isOneVOne;
 import static uk.gov.hmcts.reform.civil.enums.MultiPartyScenario.isOneVTwoTwoLegalRep;
@@ -921,16 +919,6 @@ public class CaseData extends CaseDataParent implements MappableObject {
     }
 
     @JsonIgnore
-    public boolean isUnSpecClaim() {
-        return UNSPEC_CLAIM.equals(getCaseAccessCategory());
-    }
-
-    @JsonIgnore
-    public boolean isSpecClaim() {
-        return SPEC_CLAIM.equals(getCaseAccessCategory());
-    }
-
-    @JsonIgnore
     public boolean isLRvLipOneVOne() {
         return isRespondent1LiP()
             && !isApplicant1NotRepresented()
@@ -1620,22 +1608,6 @@ public class CaseData extends CaseDataParent implements MappableObject {
     }
 
     @JsonIgnore
-    public boolean isLipClaimantSpecifiedBilingualDocuments() {
-        return isApplicant1NotRepresented()
-            && getApplicant1DQ() != null
-            && getApplicant1DQ().getApplicant1DQLanguage() != null
-            && (getApplicant1DQ().getApplicant1DQLanguage().getDocuments() == Language.BOTH || getApplicant1DQ().getApplicant1DQLanguage().getDocuments() == Language.WELSH);
-    }
-
-    @JsonIgnore
-    public boolean isLipDefendantSpecifiedBilingualDocuments() {
-        return isRespondent1NotRepresented()
-            && getRespondent1DQ() != null
-            && getRespondent1DQ().getRespondent1DQLanguage() != null
-            && (getRespondent1DQ().getRespondent1DQLanguage().getDocuments() == Language.BOTH || getRespondent1DQ().getRespondent1DQLanguage().getDocuments() == Language.WELSH);
-    }
-
-    @JsonIgnore
     public String getApplicantSolicitor1UserDetailsEmail() {
         return applicantSolicitor1UserDetails == null ? null : applicantSolicitor1UserDetails.getEmail();
     }
@@ -1656,5 +1628,17 @@ public class CaseData extends CaseDataParent implements MappableObject {
     public String getRespondent2PartyEmail() {
         final Party party = getRespondent2();
         return party == null ? null : party.getPartyEmail();
+    }
+
+    @JsonIgnore
+    public boolean isClaimUnderTranslationAfterDefResponse() {
+        return this.getRespondent1ClaimResponseTypeForSpec() != null
+            && this.getCcdState() == CaseState.AWAITING_RESPONDENT_ACKNOWLEDGEMENT;
+    }
+
+    @JsonIgnore
+    public boolean isClaimUnderTranslationAfterClaimantResponse() {
+        return this.getApplicant1ResponseDate() != null
+            && this.getCcdState() == CaseState.AWAITING_APPLICANT_INTENTION;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardClaimantClaimMatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardClaimantClaimMatcher.java
@@ -416,10 +416,12 @@ public class CcdDashboardClaimantClaimMatcher extends CcdDashboardClaimMatcher i
 
     @Override
     public boolean pausedForTranslationAfterResponse() {
-        return (caseData.getRespondent1ClaimResponseTypeForSpec() != null
-            && caseData.getCcdState() == CaseState.AWAITING_RESPONDENT_ACKNOWLEDGEMENT)
-            || (caseData.getApplicant1ResponseDate() != null
-            && caseData.getCcdState() == CaseState.AWAITING_APPLICANT_INTENTION);
+        if (!featureToggleService.isWelshEnabledForMainCase() && (caseData.isClaimUnderTranslationAfterDefResponse() && caseData.isRespondentResponseBilingual())
+            || (caseData.isClaimUnderTranslationAfterClaimantResponse() && caseData.isClaimantBilingual())) {
+            return true;
+        } else return featureToggleService.isWelshEnabledForMainCase()
+            && (caseData.isClaimUnderTranslationAfterDefResponse() || caseData.isClaimUnderTranslationAfterClaimantResponse())
+            && (caseData.isRespondentResponseBilingual() || caseData.isClaimantBilingual());
     }
 
     public boolean isNocForDefendant() {

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardClaimantClaimMatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardClaimantClaimMatcher.java
@@ -419,9 +419,11 @@ public class CcdDashboardClaimantClaimMatcher extends CcdDashboardClaimMatcher i
         if (!featureToggleService.isWelshEnabledForMainCase() && (caseData.isClaimUnderTranslationAfterDefResponse() && caseData.isRespondentResponseBilingual())
             || (caseData.isClaimUnderTranslationAfterClaimantResponse() && caseData.isClaimantBilingual())) {
             return true;
-        } else return featureToggleService.isWelshEnabledForMainCase()
-            && (caseData.isClaimUnderTranslationAfterDefResponse() || caseData.isClaimUnderTranslationAfterClaimantResponse())
-            && (caseData.isRespondentResponseBilingual() || caseData.isClaimantBilingual());
+        } else {
+            return featureToggleService.isWelshEnabledForMainCase()
+                && (caseData.isClaimUnderTranslationAfterDefResponse() || caseData.isClaimUnderTranslationAfterClaimantResponse())
+                && (caseData.isRespondentResponseBilingual() || caseData.isClaimantBilingual());
+        }
     }
 
     public boolean isNocForDefendant() {

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardDefendantClaimMatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardDefendantClaimMatcher.java
@@ -395,11 +395,12 @@ public class CcdDashboardDefendantClaimMatcher extends CcdDashboardClaimMatcher 
 
     @Override
     public boolean pausedForTranslationAfterResponse() {
-        if (!featureToggleService.isLipVLipEnabled()) {
-            return false;
-        }
-        return (caseData.getRespondent1ClaimResponseTypeForSpec() != null && caseData.getCcdState() == CaseState.AWAITING_RESPONDENT_ACKNOWLEDGEMENT)
-            || (caseData.getApplicant1ResponseDate() != null && caseData.getCcdState() == CaseState.AWAITING_APPLICANT_INTENTION);
+        if (!featureToggleService.isWelshEnabledForMainCase() && (caseData.isClaimUnderTranslationAfterDefResponse() && caseData.isRespondentResponseBilingual())
+            || (caseData.isClaimUnderTranslationAfterClaimantResponse() && caseData.isClaimantBilingual())) {
+            return true;
+        } else return featureToggleService.isWelshEnabledForMainCase()
+            && (caseData.isClaimUnderTranslationAfterDefResponse() || caseData.isClaimUnderTranslationAfterClaimantResponse())
+            && (caseData.isRespondentResponseBilingual() || caseData.isClaimantBilingual());
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardDefendantClaimMatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardDefendantClaimMatcher.java
@@ -398,9 +398,11 @@ public class CcdDashboardDefendantClaimMatcher extends CcdDashboardClaimMatcher 
         if (!featureToggleService.isWelshEnabledForMainCase() && (caseData.isClaimUnderTranslationAfterDefResponse() && caseData.isRespondentResponseBilingual())
             || (caseData.isClaimUnderTranslationAfterClaimantResponse() && caseData.isClaimantBilingual())) {
             return true;
-        } else return featureToggleService.isWelshEnabledForMainCase()
-            && (caseData.isClaimUnderTranslationAfterDefResponse() || caseData.isClaimUnderTranslationAfterClaimantResponse())
-            && (caseData.isRespondentResponseBilingual() || caseData.isClaimantBilingual());
+        } else {
+            return featureToggleService.isWelshEnabledForMainCase()
+                && (caseData.isClaimUnderTranslationAfterDefResponse() || caseData.isClaimUnderTranslationAfterClaimantResponse())
+                && (caseData.isRespondentResponseBilingual() || caseData.isClaimantBilingual());
+        }
     }
 
     @Override


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17618


### Change description ###
Refactored the code to correctly display the Dashboard status after the claimants intention is submitted.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
