### PR TITLE
CIV-0000 Fix isClaimantLR process var

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/tasks/CoscApplicationAfterPaymentTaskHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/tasks/CoscApplicationAfterPaymentTaskHandler.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.util.Optional.ofNullable;
-import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
 import static uk.gov.hmcts.reform.civil.utils.CaseDataContentConverter.caseDataContentFromStartEventResponse;
 
 @RequiredArgsConstructor
@@ -65,7 +64,7 @@ public class CoscApplicationAfterPaymentTaskHandler extends BaseExternalTaskHand
         variables.putValue(FLOW_STATE, stateFlow.getState().getName());
         variables.putValue(FLOW_FLAGS, stateFlow.getFlags());
         variables.putValue("isJudgmentMarkedPaidInFull", checkMarkPaidInFull(data));
-        variables.putValue("isClaimantLR", isClaimantLR(data));
+        variables.putValue("isClaimantLR", !data.isApplicant1NotRepresented());
         return variables;
     }
 
@@ -73,7 +72,4 @@ public class CoscApplicationAfterPaymentTaskHandler extends BaseExternalTaskHand
         return (Objects.nonNull(data.getActiveJudgment()) && (data.getActiveJudgment().getFullyPaymentMadeDate() != null));
     }
 
-    private boolean isClaimantLR(CaseData caseData) {
-        return YES.equals(caseData.getApplicant1Represented());
-    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Updated Cosc payment task handler to set the isClaimantLR to false if applicant1Represented = NO.
This ensures that if applicant1Represented is null it will be treated as claimant is represented.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
