### PR TITLE
CIV-17574 - Don't send trial readiness emails for MINTI

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/TrialReadyNotificationSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/TrialReadyNotificationSearchService.java
@@ -37,8 +37,10 @@ public class TrialReadyNotificationSearchService extends ElasticSearchService {
                                       .minimumShouldMatch(1)
                                       .should(beState(PREPARE_FOR_HEARING_CONDUCT_HEARING))
                                       .should(beState(HEARING_READINESS)))
-                            .mustNot(matchQuery("data.allocatedTrack", "SMALL_CLAIM"))
-                            .mustNot(matchQuery("data.responseClaimTrack", "SMALL_CLAIM"))
+                            .must(boolQuery()
+                                      .minimumShouldMatch(1)
+                                      .should(matchQuery("data.allocatedTrack", "FAST_CLAIM"))
+                                      .should(matchQuery("data.responseClaimTrack", "FAST_CLAIM")))
                             .mustNot(matchQuery("data.listingOrRelisting", ListingOrRelisting.RELISTING))
                             .mustNot(matchQuery("data.trialReadyNotified", YesOrNo.YES))),
             List.of("reference"),

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/search/TrialReadyNotificationSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/search/TrialReadyNotificationSearchServiceTest.java
@@ -32,8 +32,10 @@ class TrialReadyNotificationSearchServiceTest extends ElasticSearchServiceTest {
                           .minimumShouldMatch(1)
                           .should(boolQuery().must(matchQuery("state", "PREPARE_FOR_HEARING_CONDUCT_HEARING")))
                           .should(boolQuery().must(matchQuery("state", "HEARING_READINESS"))))
-                .mustNot(matchQuery("data.allocatedTrack", "SMALL_CLAIM"))
-                .mustNot(matchQuery("data.responseClaimTrack", "SMALL_CLAIM"))
+                .must(boolQuery()
+                          .minimumShouldMatch(1)
+                          .should(matchQuery("data.allocatedTrack", "FAST_CLAIM"))
+                          .should(matchQuery("data.responseClaimTrack", "FAST_CLAIM")))
                 .mustNot(matchQuery("data.listingOrRelisting", ListingOrRelisting.RELISTING))
                 .mustNot(matchQuery("data.trialReadyNotified", YesOrNo.YES)));
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CIV-17574


### Change description ###
Updated trial ready notification scheduler to only pickup cases with a FAST_CLAIM track.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
