### PR TITLE
Dtscci 3488 fix dashboard action db

### DIFF
--- a/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/data/Notification.java
+++ b/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/data/Notification.java
@@ -62,7 +62,7 @@ public class Notification {
         return notificationActions.stream()
             .max(Comparator.comparing(
                 NotificationActionEntity::getCreatedAt,
-                Comparator.nullsLast(Comparator.naturalOrder())
+                Comparator.nullsFirst(Comparator.naturalOrder())
             ))
             .map(NotificationAction::from)
             .orElse(null);

--- a/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/data/Notification.java
+++ b/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/data/Notification.java
@@ -1,13 +1,16 @@
 package uk.gov.hmcts.reform.dashboard.data;
 
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.dashboard.entities.DashboardNotificationsEntity;
+import uk.gov.hmcts.reform.dashboard.entities.NotificationActionEntity;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -50,8 +53,15 @@ public class Notification {
             dashboardNotificationsEntity.getDeadline()
         );
 
-        Optional.ofNullable(dashboardNotificationsEntity.getNotificationAction())
+        Optional.ofNullable(dashboardNotificationsEntity.getNotificationActions())
+            .stream()
+            .flatMap(List::stream)
+            .max(Comparator.comparing(
+                NotificationActionEntity::getCreatedAt,
+                Comparator.nullsLast(Comparator.naturalOrder())
+            ))
             .ifPresent(action -> notification.setNotificationAction(NotificationAction.from(action)));
+
         return notification;
     }
 }

--- a/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/data/Notification.java
+++ b/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/data/Notification.java
@@ -11,7 +11,6 @@ import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Data
@@ -40,28 +39,32 @@ public class Notification {
     private LocalDateTime deadline;
 
     public static Notification from(DashboardNotificationsEntity dashboardNotificationsEntity) {
-        Notification notification = new Notification(
+        return new Notification(
             dashboardNotificationsEntity.getId(),
             dashboardNotificationsEntity.getTitleEn(),
             dashboardNotificationsEntity.getTitleCy(),
             dashboardNotificationsEntity.getDescriptionEn(),
             dashboardNotificationsEntity.getDescriptionCy(),
             dashboardNotificationsEntity.getTimeToLive(),
-            null,
+            getLatestNotificationAction(dashboardNotificationsEntity),
             dashboardNotificationsEntity.getParams(),
             dashboardNotificationsEntity.getCreatedAt(),
             dashboardNotificationsEntity.getDeadline()
         );
+    }
 
-        Optional.ofNullable(dashboardNotificationsEntity.getNotificationActions())
-            .stream()
-            .flatMap(List::stream)
+    private static NotificationAction getLatestNotificationAction(DashboardNotificationsEntity dashboardNotificationsEntity) {
+        List<NotificationActionEntity> notificationActions = dashboardNotificationsEntity.getNotificationActions();
+        if (notificationActions == null || notificationActions.isEmpty()) {
+            return null;
+        }
+
+        return notificationActions.stream()
             .max(Comparator.comparing(
                 NotificationActionEntity::getCreatedAt,
                 Comparator.nullsLast(Comparator.naturalOrder())
             ))
-            .ifPresent(action -> notification.setNotificationAction(NotificationAction.from(action)));
-
-        return notification;
+            .map(NotificationAction::from)
+            .orElse(null);
     }
 }

--- a/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/entities/DashboardNotificationsEntity.java
+++ b/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/entities/DashboardNotificationsEntity.java
@@ -9,12 +9,13 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.UUID;
 
 @lombok.Data
@@ -31,9 +32,9 @@ public class DashboardNotificationsEntity implements Serializable {
     @Schema(name = "id")
     private UUID id;
 
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "dashboardNotification")
+    @OneToMany(mappedBy = "dashboardNotification", cascade = CascadeType.ALL)
     @Schema(name = "notification_action_id")
-    private NotificationActionEntity notificationAction;
+    private List<NotificationActionEntity> notificationActions;
 
     @Schema(name = "reference")
     private String reference;

--- a/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/entities/NotificationActionEntity.java
+++ b/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/entities/NotificationActionEntity.java
@@ -10,7 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -48,7 +48,7 @@ public class NotificationActionEntity implements Serializable {
     private OffsetDateTime createdAt;
 
     @ToString.Exclude
-    @OneToOne(cascade = CascadeType.ALL)
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "dashboard_notifications_id", referencedColumnName = "id")
     @Schema(name = "dashboard_notifications_id")
     private DashboardNotificationsEntity dashboardNotification;

--- a/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
+++ b/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
@@ -150,7 +150,7 @@ public class DashboardNotificationService {
     private DashboardNotificationsEntity copyNotification(DashboardNotificationsEntity notification) {
         return new DashboardNotificationsEntity(
             notification.getId(),
-            notification.getNotificationActions(),
+            notification.getNotificationActions() != null ? new java.util.ArrayList<>(notification.getNotificationActions()) : null,
             notification.getReference(),
             notification.getName(),
             notification.getCitizenRole(),

--- a/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
+++ b/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
@@ -110,22 +110,24 @@ public class DashboardNotificationService {
     }
 
     public void recordClick(UUID id, String authToken) {
-        Optional<DashboardNotificationsEntity> dashboardNotification = dashboardNotificationsRepository.findById(id);
+        dashboardNotificationsRepository.findById(id).ifPresent(notification -> {
+            NotificationActionEntity notificationAction = notification.getNotificationActions() != null
+                ? notification.getNotificationActions().stream()
+                .filter(action -> clickAction.equals(action.getActionPerformed()))
+                .findFirst()
+                .orElse(new NotificationActionEntity())
+                : new NotificationActionEntity();
 
-        dashboardNotification.ifPresent(notification -> {
-            NotificationActionEntity notificationAction = new NotificationActionEntity(
-                null,
-                notification.getReference(),
-                clickAction,
-                idamApi.retrieveUserDetails(authToken).getFullName(),
-                OffsetDateTime.now(),
-                notification
-            );
+            notificationAction.setReference(notification.getReference());
+            notificationAction.setActionPerformed(clickAction);
+            notificationAction.setCreatedBy(idamApi.retrieveUserDetails(authToken).getFullName());
+            notificationAction.setCreatedAt(OffsetDateTime.now());
+            notificationAction.setDashboardNotification(notification);
 
-            if (nonNull(notification.getNotificationActions())) {
-                notification.getNotificationActions().add(notificationAction);
-            } else {
+            if (notification.getNotificationActions() == null) {
                 notification.setNotificationActions(new java.util.ArrayList<>(java.util.List.of(notificationAction)));
+            } else if (!notification.getNotificationActions().contains(notificationAction)) {
+                notification.getNotificationActions().add(notificationAction);
             }
 
             dashboardNotificationsRepository.save(notification);

--- a/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
+++ b/dashboard-notifications/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
@@ -122,11 +122,12 @@ public class DashboardNotificationService {
                 notification
             );
 
-            if (nonNull(notification.getNotificationAction())
-                && notification.getNotificationAction().getActionPerformed().equals(clickAction)) {
-                notificationAction.setId(notification.getNotificationAction().getId());
+            if (nonNull(notification.getNotificationActions())) {
+                notification.getNotificationActions().add(notificationAction);
+            } else {
+                notification.setNotificationActions(new java.util.ArrayList<>(java.util.List.of(notificationAction)));
             }
-            notification.setNotificationAction(notificationAction);
+
             dashboardNotificationsRepository.save(notification);
         });
     }
@@ -147,7 +148,7 @@ public class DashboardNotificationService {
     private DashboardNotificationsEntity copyNotification(DashboardNotificationsEntity notification) {
         return new DashboardNotificationsEntity(
             notification.getId(),
-            notification.getNotificationAction(),
+            notification.getNotificationActions(),
             notification.getReference(),
             notification.getName(),
             notification.getCitizenRole(),

--- a/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/data/NotificationTest.java
+++ b/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/data/NotificationTest.java
@@ -1,0 +1,56 @@
+package uk.gov.hmcts.reform.dashboard.data;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.dashboard.entities.DashboardNotificationsEntity;
+import uk.gov.hmcts.reform.dashboard.entities.NotificationActionEntity;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationTest {
+
+    @Test
+    void shouldReturnLatestNotificationAction_whenMultipleActionsExist() {
+
+        NotificationActionEntity olderAction = new NotificationActionEntity();
+        olderAction.setId(1L);
+        olderAction.setReference("reference");
+        olderAction.setActionPerformed("Click");
+        olderAction.setCreatedBy("User 1");
+        olderAction.setCreatedAt(OffsetDateTime.now().minusHours(2));
+
+        NotificationActionEntity latestAction = new NotificationActionEntity();
+        latestAction.setId(2L);
+        latestAction.setReference("reference");
+        latestAction.setActionPerformed("Click");
+        latestAction.setCreatedBy("User 2");
+        latestAction.setCreatedAt(OffsetDateTime.now());
+
+        UUID notificationId = UUID.randomUUID();
+        DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+        entity.setId(notificationId);
+        entity.setNotificationActions(new ArrayList<>(List.of(olderAction, latestAction)));
+
+        Notification notification = Notification.from(entity);
+
+        assertThat(notification.getNotificationAction()).isNotNull();
+        assertThat(notification.getNotificationAction().getId()).isEqualTo(2L);
+        assertThat(notification.getNotificationAction().getCreatedBy()).isEqualTo("User 2");
+        assertThat(notification.getNotificationAction().getCreatedAt()).isEqualTo(latestAction.getCreatedAt());
+    }
+
+    @Test
+    void shouldReturnNullNotificationAction_whenNoActionsExist() {
+        DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setNotificationActions(null);
+
+        Notification notification = Notification.from(entity);
+
+        assertThat(notification.getNotificationAction()).isNull();
+    }
+}

--- a/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/data/NotificationTest.java
+++ b/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/data/NotificationTest.java
@@ -44,6 +44,48 @@ class NotificationTest {
     }
 
     @Test
+    void shouldReturnLatestNotificationAction_whenSomeActionsHaveNullCreatedAt() {
+        NotificationActionEntity nullAction = new NotificationActionEntity();
+        nullAction.setId(1L);
+        nullAction.setCreatedAt(null);
+
+        NotificationActionEntity latestAction = new NotificationActionEntity();
+        latestAction.setId(2L);
+        latestAction.setCreatedAt(OffsetDateTime.now());
+
+        DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setNotificationActions(new ArrayList<>(List.of(nullAction, latestAction)));
+
+        Notification notification = Notification.from(entity);
+
+        assertThat(notification.getNotificationAction()).isNotNull();
+        assertThat(notification.getNotificationAction().getId()).isEqualTo(2L);
+    }
+
+    @Test
+    void shouldReturnAction_whenAllActionsHaveNullCreatedAt() {
+        NotificationActionEntity action1 = new NotificationActionEntity();
+        action1.setId(1L);
+        action1.setCreatedAt(null);
+
+        NotificationActionEntity action2 = new NotificationActionEntity();
+        action2.setId(2L);
+        action2.setCreatedAt(null);
+
+        DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+        entity.setId(UUID.randomUUID());
+        entity.setNotificationActions(new ArrayList<>(List.of(action1, action2)));
+
+        Notification notification = Notification.from(entity);
+
+        assertThat(notification.getNotificationAction()).isNotNull();
+        // Since both are null, it depends on which one stream max picks if they are equal,
+        // but it should at least not throw exception and return one of them.
+        assertThat(notification.getNotificationAction().getId()).isIn(1L, 2L);
+    }
+
+    @Test
     void shouldReturnNullNotificationAction_whenNoActionsExist() {
         DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
         entity.setId(UUID.randomUUID());

--- a/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
+++ b/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
@@ -203,7 +203,10 @@ public class DashboardNotificationServiceTest {
     public void saveOrUpdate() {
 
         DashboardNotificationsEntity notification1 = createDashboardNotificationsEntity();
+        notification1.setReference("reference");
         DashboardNotificationsEntity notification2 = createDashboardNotificationsEntity();
+        notification2.setReference("reference");
+
         when(
             dashboardNotificationsRepository
                 .findByReferenceAndCitizenRoleAndName(
@@ -219,6 +222,7 @@ public class DashboardNotificationServiceTest {
         verify(dashboardNotificationsRepository).save(captor.capture());
         assertThat(captor.getValue()).isNotNull();
         assertThat(captor.getValue().getId()).isEqualTo(notification1.getId());
+        assertThat(captor.getValue().getReference()).isEqualTo("reference");
     }
 
     @Test

--- a/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
+++ b/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.dashboard.data.Notification;
 import uk.gov.hmcts.reform.dashboard.entities.DashboardNotificationsEntity;
@@ -25,6 +24,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -127,6 +127,39 @@ public class DashboardNotificationServiceTest {
 
             assertThat(notifications).extracting(Notification::getId).containsExactly(laterId, earlierId);
         }
+
+        @Test
+        void should_keep_getNotifications_working_when_entity_has_multiple_actions() {
+            DashboardNotificationsEntity notification = getNotification(UUID.randomUUID());
+
+            NotificationActionEntity olderAction = new NotificationActionEntity();
+            olderAction.setId(1L);
+            olderAction.setActionPerformed("Click");
+            olderAction.setReference(notification.getReference());
+            olderAction.setCreatedBy("Older user");
+            olderAction.setCreatedAt(OffsetDateTime.now().minusHours(2));
+            olderAction.setDashboardNotification(notification);
+
+            NotificationActionEntity latestAction = new NotificationActionEntity();
+            latestAction.setId(2L);
+            latestAction.setActionPerformed("Click");
+            latestAction.setReference(notification.getReference());
+            latestAction.setCreatedBy("Latest user");
+            latestAction.setCreatedAt(OffsetDateTime.now());
+            latestAction.setDashboardNotification(notification);
+
+            notification.setNotificationActions(List.of(olderAction, latestAction));
+
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRole("case", "Claimant"))
+                .thenReturn(List.of(notification));
+
+            List<Notification> actual = dashboardNotificationService.getNotifications("case", "Claimant");
+
+            assertThat(actual).hasSize(1);
+            assertThat(actual.get(0).getNotificationAction()).isNotNull();
+            assertThat(actual.get(0).getNotificationAction().getId()).isEqualTo(2L);
+            assertThat(actual.get(0).getNotificationAction().getCreatedBy()).isEqualTo("Latest user");
+        }
     }
 
     @Nested
@@ -146,7 +179,7 @@ public class DashboardNotificationServiceTest {
             String reference = "reference";
             String claimant = "CLAIMANT";
             dashboardNotificationService.deleteByReferenceAndCitizenRole(reference, claimant);
-            Mockito.verify(dashboardNotificationsRepository).deleteByReferenceAndCitizenRole(reference, claimant);
+            verify(dashboardNotificationsRepository).deleteByReferenceAndCitizenRole(reference, claimant);
         }
 
         @Test
@@ -154,7 +187,7 @@ public class DashboardNotificationServiceTest {
             String reference = "reference";
             String defendant = "DEFENDANT";
             dashboardNotificationService.deleteByReferenceAndCitizenRole(reference, defendant);
-            Mockito.verify(dashboardNotificationsRepository).deleteByReferenceAndCitizenRole(reference, defendant);
+            verify(dashboardNotificationsRepository).deleteByReferenceAndCitizenRole(reference, defendant);
         }
 
         @Test
@@ -162,7 +195,7 @@ public class DashboardNotificationServiceTest {
             String templateName = "template.name";
             String reference = "reference";
             dashboardNotificationService.deleteByNameAndReference(templateName, reference);
-            Mockito.verify(dashboardNotificationsRepository).deleteByNameAndReference(templateName, reference);
+            verify(dashboardNotificationsRepository).deleteByNameAndReference(templateName, reference);
         }
     }
 
@@ -222,7 +255,7 @@ public class DashboardNotificationServiceTest {
             when(dashboardNotificationsRepository.findById(id)).thenReturn(Optional.of(notification));
             when(dashboardNotificationsRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
-            UserDetails userDetails = Mockito.mock(UserDetails.class);
+            UserDetails userDetails = mock(UserDetails.class);
             when(userDetails.getFullName()).thenReturn("Claimant user");
             when(idamApi.retrieveUserDetails(authToken)).thenReturn(userDetails);
 
@@ -230,7 +263,12 @@ public class DashboardNotificationServiceTest {
 
             ArgumentCaptor<DashboardNotificationsEntity> captor = ArgumentCaptor.forClass(DashboardNotificationsEntity.class);
             verify(dashboardNotificationsRepository).save(captor.capture());
-            NotificationActionEntity action = captor.getValue().getNotificationAction();
+            DashboardNotificationsEntity saved = captor.getValue();
+
+            assertThat(saved.getNotificationActions()).isNotNull();
+            assertThat(saved.getNotificationActions()).hasSize(1);
+
+            NotificationActionEntity action = saved.getNotificationActions().get(0);
             assertThat(action).isNotNull();
             assertThat(action.getActionPerformed()).isEqualTo("Click");
             assertThat(action.getCreatedBy()).isEqualTo("Claimant user");
@@ -239,19 +277,22 @@ public class DashboardNotificationServiceTest {
         }
 
         @Test
-        void shouldReuseExistingClickActionIdWhenRecordingSecondClick() {
+        void shouldAppendNewClickActionWhenNotificationAlreadyHasActions() {
             DashboardNotificationsEntity notification = getNotification(id);
+
             NotificationActionEntity existingAction = new NotificationActionEntity();
             existingAction.setId(99L);
             existingAction.setActionPerformed("Click");
             existingAction.setReference(notification.getReference());
-            notification.setNotificationAction(existingAction);
+            existingAction.setDashboardNotification(notification);
+
+            notification.setNotificationActions(new ArrayList<>(List.of(existingAction)));
 
             when(dashboardNotificationsRepository.findById(id)).thenReturn(Optional.of(notification));
             when(dashboardNotificationsRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
 
             String authToken = "Auth-token";
-            UserDetails userDetails = Mockito.mock(UserDetails.class);
+            UserDetails userDetails = mock(UserDetails.class);
             when(userDetails.getFullName()).thenReturn("Claimant user");
             when(idamApi.retrieveUserDetails(authToken)).thenReturn(userDetails);
 
@@ -259,11 +300,12 @@ public class DashboardNotificationServiceTest {
 
             ArgumentCaptor<DashboardNotificationsEntity> captor = ArgumentCaptor.forClass(DashboardNotificationsEntity.class);
             verify(dashboardNotificationsRepository).save(captor.capture());
-            NotificationActionEntity action = captor.getValue().getNotificationAction();
-            assertThat(action.getId()).isEqualTo(99L);
-            assertThat(action.getCreatedBy()).isEqualTo("Claimant user");
-            assertThat(action.getActionPerformed()).isEqualTo("Click");
+
+            DashboardNotificationsEntity saved = captor.getValue();
+            assertThat(saved.getNotificationActions()).hasSize(2);
+            assertThat(saved.getNotificationActions())
+                .extracting(NotificationActionEntity::getActionPerformed)
+                .containsExactly("Click", "Click");
         }
     }
-
 }

--- a/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
+++ b/dashboard-notifications/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
@@ -277,7 +277,7 @@ public class DashboardNotificationServiceTest {
         }
 
         @Test
-        void shouldAppendNewClickActionWhenNotificationAlreadyHasActions() {
+        void shouldReuseExistingClickActionWhenNotificationAlreadyHasActions() {
             DashboardNotificationsEntity notification = getNotification(id);
 
             NotificationActionEntity existingAction = new NotificationActionEntity();
@@ -302,10 +302,9 @@ public class DashboardNotificationServiceTest {
             verify(dashboardNotificationsRepository).save(captor.capture());
 
             DashboardNotificationsEntity saved = captor.getValue();
-            assertThat(saved.getNotificationActions()).hasSize(2);
-            assertThat(saved.getNotificationActions())
-                .extracting(NotificationActionEntity::getActionPerformed)
-                .containsExactly("Click", "Click");
+            assertThat(saved.getNotificationActions()).hasSize(1);
+            assertThat(saved.getNotificationActions().get(0).getId()).isEqualTo(99L);
+            assertThat(saved.getNotificationActions().get(0).getCreatedBy()).isEqualTo("Claimant user");
         }
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/GetNotificationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/GetNotificationControllerTest.java
@@ -8,9 +8,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.gov.hmcts.reform.civil.controllers.BaseIntegrationTest;
 import uk.gov.hmcts.reform.dashboard.data.Notification;
+import uk.gov.hmcts.reform.dashboard.data.NotificationAction;
 
 import java.util.List;
 import java.util.UUID;
@@ -22,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Testcontainers
 @Sql("/scripts/dashboardNotifications/get_notifications_data.sql")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@Transactional
 public class GetNotificationControllerTest extends BaseIntegrationTest {
 
     @Test
@@ -33,6 +36,16 @@ public class GetNotificationControllerTest extends BaseIntegrationTest {
             .andExpect(content().json(toJson(getNotificationList())));
     }
 
+    @Test
+    @SneakyThrows
+    @Sql(scripts = "/scripts/dashboardNotifications/get_notifications_multiple_actions.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    void shouldReturnNotificationWithLatestActionWhenMultipleActionsExist() {
+        String getNotificationsEndpoint = "/dashboard/notifications/{ccd-case-identifier}/role/{role-type}";
+        doGet(BEARER_TOKEN, getNotificationsEndpoint, "128", "defendant")
+            .andExpect(status().isOk())
+            .andExpect(content().json(toJson(getNotificationListWithMultipleActions())));
+    }
+
     private List<Notification> getNotificationList() {
         Notification notification = new Notification();
         notification.setId(UUID.fromString("8c2712da-47ce-4050-bbee-650134a7b9e5"));
@@ -42,6 +55,27 @@ public class GetNotificationControllerTest extends BaseIntegrationTest {
         notification.setDescriptionCy("description_cy");
         notification.setCreatedAt(OffsetDateTime.of(LocalDateTime.parse("2024-02-10T10:00:00"), ZoneOffset.UTC));
         notification.setTimeToLive("Click");
+        return List.of(notification);
+    }
+
+    private List<Notification> getNotificationListWithMultipleActions() {
+        Notification notification = new Notification();
+        notification.setId(UUID.fromString("8c2712da-47ce-4050-bbee-650134a7b9e6"));
+        notification.setTitleEn("title_en");
+        notification.setTitleCy("title_cy");
+        notification.setDescriptionEn("description_en");
+        notification.setDescriptionCy("description_cy");
+        notification.setCreatedAt(OffsetDateTime.of(LocalDateTime.parse("2026-02-05T10:00:00.110362"), ZoneOffset.UTC));
+        notification.setTimeToLive("Click");
+
+        NotificationAction action = new NotificationAction();
+        action.setId(1002L);
+        action.setReference("128");
+        action.setActionPerformed("Click");
+        action.setCreatedBy("User 1");
+        action.setCreatedAt(OffsetDateTime.of(LocalDateTime.parse("2026-02-06T13:08:04.163939"), ZoneOffset.UTC));
+        notification.setNotificationAction(action);
+
         return List.of(notification);
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/GetNotificationControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/GetNotificationControllerTest.java
@@ -43,7 +43,7 @@ public class GetNotificationControllerTest extends BaseIntegrationTest {
         String getNotificationsEndpoint = "/dashboard/notifications/{ccd-case-identifier}/role/{role-type}";
         doGet(BEARER_TOKEN, getNotificationsEndpoint, "128", "defendant")
             .andExpect(status().isOk())
-            .andExpect(content().json(toJson(getNotificationListWithMultipleActions())));
+            .andExpect(content().json(toJson(expectedNotificationListWithLatestAction())));
     }
 
     private List<Notification> getNotificationList() {
@@ -58,7 +58,7 @@ public class GetNotificationControllerTest extends BaseIntegrationTest {
         return List.of(notification);
     }
 
-    private List<Notification> getNotificationListWithMultipleActions() {
+    private List<Notification> expectedNotificationListWithLatestAction() {
         Notification notification = new Notification();
         notification.setId(UUID.fromString("8c2712da-47ce-4050-bbee-650134a7b9e6"));
         notification.setTitleEn("title_en");

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/RecordNotificationClickControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/RecordNotificationClickControllerTest.java
@@ -4,9 +4,9 @@ import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.jdbc.Sql;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.hmcts.reform.civil.controllers.BaseIntegrationTest;
 import uk.gov.hmcts.reform.dashboard.entities.DashboardNotificationsEntity;
 import uk.gov.hmcts.reform.dashboard.entities.NotificationActionEntity;
@@ -22,6 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
+@Transactional
 public class RecordNotificationClickControllerTest extends BaseIntegrationTest {
 
     public static final String CCD_CASE_ID = "130";
@@ -35,8 +36,8 @@ public class RecordNotificationClickControllerTest extends BaseIntegrationTest {
 
     @Test
     @SneakyThrows
-    @Sql("/scripts/dashboardNotifications/record_notification_click.sql")
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
+    @Sql(scripts = "/scripts/dashboardNotifications/record_notification_click.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+    @Sql(statements = "DELETE FROM dbs.dashboard_notifications WHERE id = '8c2712da-47ce-4050-bbee-650134a7b945'", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
     void shouldRecordNotificationClick() {
         doPut(BEARER_TOKEN, null, NOTIFICATION_CLICK_END_POINT, NOTIFICATION_ID.toString())
             .andExpect(status().isOk());

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/RecordNotificationClickControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/RecordNotificationClickControllerTest.java
@@ -44,7 +44,7 @@ public class RecordNotificationClickControllerTest extends BaseIntegrationTest {
         Optional<DashboardNotificationsEntity> notification = dashboardNotificationsRepository.findById(NOTIFICATION_ID);
         assertThat(notification).isPresent();
         DashboardNotificationsEntity dashboardNotificationsEntity = notification.get();
-        NotificationActionEntity notificationAction = dashboardNotificationsEntity.getNotificationAction();
+        NotificationActionEntity notificationAction = dashboardNotificationsEntity.getNotificationActions().getFirst();
         assertThat(notificationAction.getDashboardNotification().getId())
             .isEqualTo(dashboardNotificationsEntity.getId());
         assertThat(notificationAction.getActionPerformed()).isEqualTo(ACTION_PAERFORMED);

--- a/src/integrationTest/resources/scripts/dashboardNotifications/get_notifications_multiple_actions.sql
+++ b/src/integrationTest/resources/scripts/dashboardNotifications/get_notifications_multiple_actions.sql
@@ -1,0 +1,14 @@
+
+INSERT INTO dbs.dashboard_notifications
+(id, reference, notification_name, citizen_role, title_en, title_cy, description_en, description_cy, message_params, created_by,
+ created_at, updated_by, updated_on, time_to_live)
+VALUES('8c2712da-47ce-4050-bbee-650134a7b9e6', '128', 'notification_multiple_actions', 'defendant', 'title_en', 'title_cy', 'description_en',
+       'description_cy', null, 'admin', '2026-02-05 10:00:00.110362', 'admin', '2024-02-10 10:00:00', 'Click');
+
+INSERT INTO dbs.notification_action
+(id, reference, action_performed, created_by, created_at, dashboard_notifications_id)
+VALUES(1001, '128', 'Click', 'User 1', '2026-02-06 13:08:04.110362', '8c2712da-47ce-4050-bbee-650134a7b9e6');
+
+INSERT INTO dbs.notification_action
+(id, reference, action_performed, created_by, created_at, dashboard_notifications_id)
+VALUES(1002, '128', 'Click', 'User 1', '2026-02-06 13:08:04.163939', '8c2712da-47ce-4050-bbee-650134a7b9e6');


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-3488


### Change description ###
This PR transitions the relationship between dashboard notifications and their associated actions from a one-to-one to a one-to-many relationship. This change addresses issues where duplicate notification actions in the database were causing errors or inconsistencies. The new model allows the system to store multiple actions while providing logic to consistently select the most relevant (latest) action for display and ensuring that new click actions do not create redundant records.
Key Changes
1. Data Model & Entity Relationships
•
Relationship Update: Modified DashboardNotificationsEntity and NotificationActionEntity to use @OneToMany and @ManyToOne relationship mapping respectively.
•
Cascade Operations: Configured CascadeType.ALL to ensure notification actions are managed alongside their parent notification.
2. Core Service Logic (DashboardNotificationService)
•
Enforced Single "Click" Action: Updated recordClick logic to look for an existing "Click" action for a given notification. If found, it updates the existing record's metadata (timestamp, user) instead of creating a new one.
•
Resilient Saving (saveOrUpdate): Added logic to remove existing "Click" actions when a notification is being re-saved/updated by its template name and reference, ensuring a clean state for updated notifications.
•
Defensive Copying: Implemented defensive copying of the notification actions list in copyNotification.
3. API Mapping & UI Consistency (Notification)
•
Latest Action Selection: Refactored the Notification data class to handle the list of actions. It now uses a stream pipeline with Comparator.nullsFirst to select the most recent action based on its creation timestamp.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
