### PR TITLE
DTSCCI-3976 Dashboard Notification Mapping

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/RecordNotificationClickControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/dashboard/RecordNotificationClickControllerTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.civil.controllers.dashboard;
 
 import lombok.SneakyThrows;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -11,7 +12,9 @@ import uk.gov.hmcts.reform.civil.controllers.BaseIntegrationTest;
 import uk.gov.hmcts.reform.dashboard.entities.DashboardNotificationsEntity;
 import uk.gov.hmcts.reform.dashboard.entities.NotificationActionEntity;
 import uk.gov.hmcts.reform.dashboard.repositories.DashboardNotificationsRepository;
+import uk.gov.hmcts.reform.dashboard.repositories.NotificationActionRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,6 +25,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Testcontainers
+@Sql("/scripts/dashboardNotifications/record_notification_click.sql")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SuppressWarnings("java:S1874")
 public class RecordNotificationClickControllerTest extends BaseIntegrationTest {
 
     public static final String CCD_CASE_ID = "130";
@@ -33,10 +39,17 @@ public class RecordNotificationClickControllerTest extends BaseIntegrationTest {
     @Autowired
     private DashboardNotificationsRepository dashboardNotificationsRepository;
 
+    @Autowired
+    private NotificationActionRepository notificationActionRepository;
+
+    @AfterEach
+    public void after() {
+        notificationActionRepository.deleteAll();
+        dashboardNotificationsRepository.deleteAll();
+    }
+
     @Test
     @SneakyThrows
-    @Sql("/scripts/dashboardNotifications/record_notification_click.sql")
-    @DirtiesContext(methodMode = DirtiesContext.MethodMode.AFTER_METHOD)
     void shouldRecordNotificationClick() {
         doPut(BEARER_TOKEN, null, NOTIFICATION_CLICK_END_POINT, NOTIFICATION_ID.toString())
             .andExpect(status().isOk());
@@ -44,26 +57,39 @@ public class RecordNotificationClickControllerTest extends BaseIntegrationTest {
         Optional<DashboardNotificationsEntity> notification = dashboardNotificationsRepository.findById(NOTIFICATION_ID);
         assertThat(notification).isPresent();
         DashboardNotificationsEntity dashboardNotificationsEntity = notification.get();
-        NotificationActionEntity notificationAction = dashboardNotificationsEntity.getNotificationAction();
-        assertThat(notificationAction.getDashboardNotification().getId())
+        List<NotificationActionEntity> notificationActions = notificationActionRepository
+            .findByDashboardNotificationIdIn(List.of(NOTIFICATION_ID));
+        assertThat(notificationActions).isNotEmpty();
+        NotificationActionEntity latestAction = notificationActions.get(0);
+        assertThat(latestAction.getDashboardNotificationId())
             .isEqualTo(dashboardNotificationsEntity.getId());
-        assertThat(notificationAction.getActionPerformed()).isEqualTo(ACTION_PAERFORMED);
-        assertThat(notificationAction.getReference()).isEqualTo(CCD_CASE_ID);
+        assertThat(latestAction.getActionPerformed()).isEqualTo(ACTION_PAERFORMED);
+        assertThat(latestAction.getReference()).isEqualTo(CCD_CASE_ID);
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturnOkWhenNotificationDoesNotExist() {
+        UUID randomUUID = UUID.randomUUID();
+        doPut(BEARER_TOKEN, null, NOTIFICATION_CLICK_END_POINT, randomUUID)
+            .andExpect(status().isOk());
+
+        Optional<DashboardNotificationsEntity> notification = dashboardNotificationsRepository.findById(randomUUID);
+        assertThat(notification).isNotPresent();
     }
 
     @Test
     @SneakyThrows
     void shouldReturnUnauthorisedWhenBearerTokenMissing() {
         when(userRequestAuthorizerMock.authorise(any())).thenReturn(null);
-        doDelete("", null, NOTIFICATION_CLICK_END_POINT, NOTIFICATION_ID.toString())
+        doPut("", null, NOTIFICATION_CLICK_END_POINT, UUID.randomUUID())
             .andExpect(status().isForbidden());
     }
 
     @Test
     @SneakyThrows
     void shouldReturnBadRequestWhenUuidNotInCorrectFormat() {
-
-        doDelete(BEARER_TOKEN, null, NOTIFICATION_CLICK_END_POINT, "126")
+        doPut(BEARER_TOKEN, null, NOTIFICATION_CLICK_END_POINT, "126")
             .andExpect(status().isBadRequest());
 
     }

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/data/Notification.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/data/Notification.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.hmcts.reform.dashboard.entities.DashboardNotificationsEntity;
+import uk.gov.hmcts.reform.dashboard.entities.NotificationActionEntity;
 
 import java.util.HashMap;
 import java.util.Optional;
@@ -36,22 +37,23 @@ public class Notification {
 
     private LocalDateTime deadline;
 
-    public static Notification from(DashboardNotificationsEntity dashboardNotificationsEntity) {
+    public static Notification from(DashboardNotificationsEntity entity, NotificationActionEntity latestAction) {
         Notification notification = new Notification(
-            dashboardNotificationsEntity.getId(),
-            dashboardNotificationsEntity.getTitleEn(),
-            dashboardNotificationsEntity.getTitleCy(),
-            dashboardNotificationsEntity.getDescriptionEn(),
-            dashboardNotificationsEntity.getDescriptionCy(),
-            dashboardNotificationsEntity.getTimeToLive(),
+            entity.getId(),
+            entity.getTitleEn(),
+            entity.getTitleCy(),
+            entity.getDescriptionEn(),
+            entity.getDescriptionCy(),
+            entity.getTimeToLive(),
             null,
-            dashboardNotificationsEntity.getParams(),
-            dashboardNotificationsEntity.getCreatedAt(),
-            dashboardNotificationsEntity.getDeadline()
+            entity.getParams(),
+            entity.getCreatedAt(),
+            entity.getDeadline()
         );
 
-        Optional.ofNullable(dashboardNotificationsEntity.getNotificationAction())
+        Optional.ofNullable(latestAction)
             .ifPresent(action -> notification.setNotificationAction(NotificationAction.from(action)));
+
         return notification;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/entities/DashboardNotificationsEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/entities/DashboardNotificationsEntity.java
@@ -5,11 +5,9 @@ import java.time.LocalDateTime;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
@@ -30,10 +28,6 @@ public class DashboardNotificationsEntity implements Serializable {
     @NotNull
     @Schema(name = "id")
     private UUID id;
-
-    @OneToOne(cascade = CascadeType.ALL, mappedBy = "dashboardNotification")
-    @Schema(name = "notification_action_id")
-    private NotificationActionEntity notificationAction;
 
     @Schema(name = "reference")
     private String reference;

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/entities/NotificationActionEntity.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/entities/NotificationActionEntity.java
@@ -1,21 +1,18 @@
 package uk.gov.hmcts.reform.dashboard.entities;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.ToString;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 @lombok.Data
 @lombok.NoArgsConstructor
@@ -47,9 +44,7 @@ public class NotificationActionEntity implements Serializable {
     @Schema(name = "created_at")
     private OffsetDateTime createdAt;
 
-    @ToString.Exclude
-    @OneToOne(cascade = CascadeType.ALL)
-    @JoinColumn(name = "dashboard_notifications_id", referencedColumnName = "id")
+    @Column(name = "dashboard_notifications_id")
     @Schema(name = "dashboard_notifications_id")
-    private DashboardNotificationsEntity dashboardNotification;
+    private UUID dashboardNotificationId;
 }

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/repositories/DashboardNotificationsRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/repositories/DashboardNotificationsRepository.java
@@ -18,6 +18,8 @@ public interface DashboardNotificationsRepository extends CrudRepository<Dashboa
     List<DashboardNotificationsEntity> findByReferenceAndCitizenRoleAndName(
         String reference, String role, String name);
 
+    List<DashboardNotificationsEntity> findByReferenceAndName(String reference, String name);
+
     int deleteByNameAndReferenceAndCitizenRole(String name, String reference, String role);
 
     int deleteByReferenceAndCitizenRole(String reference, String role);

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/repositories/DashboardNotificationsRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/repositories/DashboardNotificationsRepository.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.reform.dashboard.repositories;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.dashboard.entities.DashboardNotificationsEntity;
 
@@ -20,9 +23,7 @@ public interface DashboardNotificationsRepository extends CrudRepository<Dashboa
 
     List<DashboardNotificationsEntity> findByReferenceAndName(String reference, String name);
 
-    int deleteByNameAndReferenceAndCitizenRole(String name, String reference, String role);
-
-    int deleteByReferenceAndCitizenRole(String reference, String role);
-
-    int deleteByNameAndReference(String name, String reference);
+    @Modifying
+    @Query("DELETE FROM DashboardNotificationsEntity d WHERE d.id IN :ids")
+    void deleteByDashboardNotificationIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/repositories/NotificationActionRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/repositories/NotificationActionRepository.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.reform.dashboard.repositories;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import uk.gov.hmcts.reform.dashboard.entities.NotificationActionEntity;
 
@@ -14,5 +17,7 @@ public interface NotificationActionRepository extends CrudRepository<Notificatio
 
     void deleteByDashboardNotificationIdAndActionPerformed(UUID dashboardNotificationId, String actionPerformed);
 
-    void deleteByDashboardNotificationId(UUID dashboardNotificationId);
+    @Modifying
+    @Query("DELETE FROM NotificationActionEntity a WHERE a.dashboardNotificationId IN :ids")
+    void deleteByDashboardNotificationIdIn(@Param("ids") List<UUID> ids);
 }

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/repositories/NotificationActionRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/repositories/NotificationActionRepository.java
@@ -2,11 +2,17 @@ package uk.gov.hmcts.reform.dashboard.repositories;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
-import uk.gov.hmcts.reform.dashboard.entities.DashboardNotificationsEntity;
 import uk.gov.hmcts.reform.dashboard.entities.NotificationActionEntity;
+
+import java.util.List;
+import java.util.UUID;
 
 @Repository
 public interface NotificationActionRepository extends CrudRepository<NotificationActionEntity, Long> {
 
-    void deleteByDashboardNotificationAndActionPerformed(DashboardNotificationsEntity entity, String action);
+    List<NotificationActionEntity> findByDashboardNotificationIdIn(List<UUID> dashboardNotificationIds);
+
+    void deleteByDashboardNotificationIdAndActionPerformed(UUID dashboardNotificationId, String actionPerformed);
+
+    void deleteByDashboardNotificationId(UUID dashboardNotificationId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.dashboard.repositories.NotificationActionRepository;
 import uk.gov.hmcts.reform.idam.client.IdamApi;
 
 import java.time.OffsetDateTime;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
 
@@ -28,16 +30,16 @@ import static java.util.Objects.nonNull;
 @SuppressWarnings("deprecation")
 public class DashboardNotificationService {
 
-    private final DashboardNotificationsRepository dashboardNotificationsRepository;
-    private final NotificationActionRepository notificationActionRepository;
     private static final Set<String> CASE_STAY_TEMPLATES = Set.of(
         "Notice.AAA6.CP.Case.Stayed.Claimant",
         "Notice.AAA6.CP.Case.Stayed.Defendant"
     );
+    private static final String CLICK_ACTION = "Click";
+
+    private final DashboardNotificationsRepository dashboardNotificationsRepository;
+    private final NotificationActionRepository notificationActionRepository;
 
     private final IdamApi idamApi;
-
-    private final String clickAction = "Click";
 
     @Autowired
     public DashboardNotificationService(DashboardNotificationsRepository dashboardNotificationsRepository,
@@ -74,8 +76,11 @@ public class DashboardNotificationService {
         List<DashboardNotificationsEntity> result =
             caseStayedNotification.isEmpty() ? sortedAllNotifications : caseStayedNotification;
 
+        List<UUID> notificationIds = result.stream().map(DashboardNotificationsEntity::getId).toList();
+        Map<UUID, NotificationActionEntity> latestActions = findLatestNotificationActions(notificationIds);
+
         return result.stream()
-            .map(Notification::from)
+            .map(entity -> Notification.from(entity, latestActions.get(entity.getId())))
             .toList();
     }
 
@@ -95,11 +100,8 @@ public class DashboardNotificationService {
         DashboardNotificationsEntity updated = notification;
         if (nonNull(notification.getName())) {
             log.info("Query for dashboard notifications using notification reference= {}, citizenRole = {}, templateName = {}",
-                notification.getReference(),
-                notification.getCitizenRole(),
-                notification.getName()
-            );
-            List<DashboardNotificationsEntity> existingNotification = dashboardNotificationsRepository
+                notification.getReference(), notification.getCitizenRole(), notification.getName());
+            List<DashboardNotificationsEntity> existingNotifications = dashboardNotificationsRepository
                 .findByReferenceAndCitizenRoleAndName(
                     notification.getReference(),
                     notification.getCitizenRole(),
@@ -107,62 +109,70 @@ public class DashboardNotificationService {
                 );
 
             log.info("Found {} dashboard notifications in database for reference {}",
-                nonNull(existingNotification) ? existingNotification.size() : null,
-                notification.getReference());
-            if (nonNull(existingNotification) && !existingNotification.isEmpty()) {
-                DashboardNotificationsEntity dashboardNotification = existingNotification.get(0);
+                     existingNotifications.size(), notification.getReference());
+
+            if (!existingNotifications.isEmpty()) {
+                DashboardNotificationsEntity match = findMatchingOrLatestNotification(existingNotifications, notification);
                 updated = copyNotification(notification);
-                updated.setId(dashboardNotification.getId());
-                for (DashboardNotificationsEntity dashNotification : existingNotification) {
-                    notificationActionRepository.deleteByDashboardNotificationAndActionPerformed(
-                        dashNotification,
-                        clickAction
+                updated.setId(match.getId());
+                // Delete click actions so the notification is unread after content changes.
+                // This applies to both reconfigured notifications and reapplied scenarios where
+                // the content may have been updated.
+                for (DashboardNotificationsEntity dashNotification : existingNotifications) {
+                    notificationActionRepository.deleteByDashboardNotificationIdAndActionPerformed(
+                        dashNotification.getId(),
+                        CLICK_ACTION
                     );
-                    log.info("Existing notification deleted reference = {}, id = {}", notification.getReference(), dashNotification.getId());
+                    log.debug("Existing {} notification action deleted reference = {}, id = {}",
+                              CLICK_ACTION, notification.getReference(), dashNotification.getId());
                 }
+            } else {
+                log.debug("Existing notification not present reference = {}", notification.getReference());
             }
         } else {
-            log.info("Existing notification not present reference = {}", notification.getReference());
+            log.warn("Notification 'name' not provided reference = {}", notification.getReference());
         }
 
         return dashboardNotificationsRepository.save(updated);
     }
 
-    public void deleteById(UUID id) {
-        dashboardNotificationsRepository.deleteById(id);
-    }
-
     public void recordClick(UUID id, String authToken) {
-        Optional<DashboardNotificationsEntity> dashboardNotification = dashboardNotificationsRepository.findById(id);
-
-        dashboardNotification.ifPresent(notification -> {
+        dashboardNotificationsRepository.findById(id).ifPresent(notification -> {
             NotificationActionEntity notificationAction = new NotificationActionEntity(
                 null,
                 notification.getReference(),
-                clickAction,
+                CLICK_ACTION,
                 idamApi.retrieveUserDetails(authToken).getFullName(),
                 OffsetDateTime.now(),
-                notification
+                id
             );
 
-            if (nonNull(notification.getNotificationAction())
-                && notification.getNotificationAction().getActionPerformed().equals(clickAction)) {
-                notificationAction.setId(notification.getNotificationAction().getId());
-            }
-            notification.setNotificationAction(notificationAction);
-            dashboardNotificationsRepository.save(notification);
+            findLatestClickAction(id).ifPresent(e -> notificationAction.setId(e.getId()));
+
+            notificationActionRepository.save(notificationAction);
         });
     }
 
+    public void deleteById(UUID id) {
+        notificationActionRepository.deleteByDashboardNotificationId(id);
+        dashboardNotificationsRepository.deleteById(id);
+    }
+
     public int deleteByNameAndReferenceAndCitizenRole(String name, String reference, String citizenRole) {
+        dashboardNotificationsRepository.findByReferenceAndCitizenRoleAndName(reference, citizenRole, name)
+            .forEach(n -> notificationActionRepository.deleteByDashboardNotificationId(n.getId()));
         return dashboardNotificationsRepository.deleteByNameAndReferenceAndCitizenRole(name, reference, citizenRole);
     }
 
     public int deleteByNameAndReference(String name, String reference) {
+        dashboardNotificationsRepository.findByReferenceAndName(reference, name)
+            .forEach(n -> notificationActionRepository.deleteByDashboardNotificationId(n.getId()));
         return dashboardNotificationsRepository.deleteByNameAndReference(name, reference);
     }
 
     public void deleteByReferenceAndCitizenRole(String reference, String citizenRole) {
+        dashboardNotificationsRepository.findByReferenceAndCitizenRole(reference, citizenRole)
+            .forEach(n -> notificationActionRepository.deleteByDashboardNotificationId(n.getId()));
         int deleted = dashboardNotificationsRepository.deleteByReferenceAndCitizenRole(reference, citizenRole);
         log.info("{} notifications removed for claim = {}", deleted, reference);
     }
@@ -170,7 +180,6 @@ public class DashboardNotificationService {
     private DashboardNotificationsEntity copyNotification(DashboardNotificationsEntity notification) {
         return new DashboardNotificationsEntity(
             notification.getId(),
-            notification.getNotificationAction(),
             notification.getReference(),
             notification.getName(),
             notification.getCitizenRole(),
@@ -186,5 +195,48 @@ public class DashboardNotificationService {
             notification.getDeadline(),
             notification.getTimeToLive()
         );
+    }
+
+    private Optional<NotificationActionEntity> findLatestClickAction(UUID dashboardNotificationId) {
+        return notificationActionRepository
+            .findByDashboardNotificationIdIn(List.of(dashboardNotificationId))
+            .stream()
+            .filter(a -> CLICK_ACTION.equals(a.getActionPerformed()))
+            .max(Comparator.comparing(
+                NotificationActionEntity::getCreatedAt,
+                Comparator.nullsFirst(Comparator.naturalOrder())
+            ));
+    }
+
+    private Map<UUID, NotificationActionEntity> findLatestNotificationActions(List<UUID> dashboardNotificationIds) {
+        if (dashboardNotificationIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return notificationActionRepository
+            .findByDashboardNotificationIdIn(dashboardNotificationIds)
+            .stream()
+            .collect(Collectors.groupingBy(
+                NotificationActionEntity::getDashboardNotificationId,
+                Collectors.collectingAndThen(
+                    Collectors.maxBy(Comparator.comparing(
+                        NotificationActionEntity::getCreatedAt,
+                        Comparator.nullsFirst(Comparator.naturalOrder())
+                    )),
+                    opt -> opt.orElse(null)
+                )
+            ));
+    }
+
+    private DashboardNotificationsEntity findMatchingOrLatestNotification(List<DashboardNotificationsEntity> existingNotifications,
+                                                                          DashboardNotificationsEntity notification) {
+        return existingNotifications.stream()
+            .filter(n -> n.getId().equals(notification.getId()))
+            .findFirst()
+            .orElseGet(() -> existingNotifications.stream()
+                .max(Comparator.comparing(
+                    DashboardNotificationsEntity::getCreatedAt,
+                    Comparator.nullsFirst(Comparator.naturalOrder())
+                ).thenComparing(DashboardNotificationsEntity::getId))
+                .orElse(existingNotifications.getFirst()));
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationService.java
@@ -154,27 +154,43 @@ public class DashboardNotificationService {
     }
 
     public void deleteById(UUID id) {
-        notificationActionRepository.deleteByDashboardNotificationId(id);
-        dashboardNotificationsRepository.deleteById(id);
+        performBulkDelete(List.of(id));
     }
 
     public int deleteByNameAndReferenceAndCitizenRole(String name, String reference, String citizenRole) {
-        dashboardNotificationsRepository.findByReferenceAndCitizenRoleAndName(reference, citizenRole, name)
-            .forEach(n -> notificationActionRepository.deleteByDashboardNotificationId(n.getId()));
-        return dashboardNotificationsRepository.deleteByNameAndReferenceAndCitizenRole(name, reference, citizenRole);
+        List<DashboardNotificationsEntity> notifications = dashboardNotificationsRepository
+            .findByReferenceAndCitizenRoleAndName(reference, citizenRole, name);
+
+        performBulkDelete(notifications.stream().map(DashboardNotificationsEntity::getId).toList());
+
+        return notifications.size();
     }
 
     public int deleteByNameAndReference(String name, String reference) {
-        dashboardNotificationsRepository.findByReferenceAndName(reference, name)
-            .forEach(n -> notificationActionRepository.deleteByDashboardNotificationId(n.getId()));
-        return dashboardNotificationsRepository.deleteByNameAndReference(name, reference);
+        List<DashboardNotificationsEntity> notifications = dashboardNotificationsRepository
+            .findByReferenceAndName(reference, name);
+
+        performBulkDelete(notifications.stream().map(DashboardNotificationsEntity::getId).toList());
+
+        return notifications.size();
     }
 
     public void deleteByReferenceAndCitizenRole(String reference, String citizenRole) {
-        dashboardNotificationsRepository.findByReferenceAndCitizenRole(reference, citizenRole)
-            .forEach(n -> notificationActionRepository.deleteByDashboardNotificationId(n.getId()));
-        int deleted = dashboardNotificationsRepository.deleteByReferenceAndCitizenRole(reference, citizenRole);
-        log.info("{} notifications removed for claim = {}", deleted, reference);
+        List<DashboardNotificationsEntity> notifications = dashboardNotificationsRepository
+            .findByReferenceAndCitizenRole(reference, citizenRole);
+
+        performBulkDelete(notifications.stream().map(DashboardNotificationsEntity::getId).toList());
+
+        log.info("{} notifications removed for claim = {}", notifications.size(), reference);
+    }
+
+    private void performBulkDelete(List<UUID> ids) {
+        if (ids.isEmpty()) {
+            return;
+        }
+
+        notificationActionRepository.deleteByDashboardNotificationIdIn(ids);
+        dashboardNotificationsRepository.deleteByDashboardNotificationIdIn(ids);
     }
 
     private DashboardNotificationsEntity copyNotification(DashboardNotificationsEntity notification) {

--- a/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardScenariosService.java
+++ b/src/main/java/uk/gov/hmcts/reform/dashboard/services/DashboardScenariosService.java
@@ -102,7 +102,6 @@ public class DashboardScenariosService {
 
         DashboardNotificationsEntity updated = new DashboardNotificationsEntity(
             existingNotification.getId(),
-            existingNotification.getNotificationAction(),
             existingNotification.getReference(),
             existingNotification.getName(),
             existingNotification.getCitizenRole(),
@@ -169,7 +168,6 @@ public class DashboardScenariosService {
 
                 DashboardNotificationsEntity notification = new DashboardNotificationsEntity(
                     UUID.randomUUID(),
-                    null,
                     uniqueCaseIdentifier,
                     template.getName(),
                     template.getRole(),

--- a/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.dashboard.data.Notification;
@@ -27,6 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -35,7 +37,8 @@ import static uk.gov.hmcts.reform.dashboard.utils.DashboardNotificationsTestUtil
 import static uk.gov.hmcts.reform.dashboard.utils.DashboardNotificationsTestUtils.getNotificationList;
 
 @ExtendWith(MockitoExtension.class)
-public class DashboardNotificationServiceTest {
+@SuppressWarnings("java:S1874")
+class DashboardNotificationServiceTest {
 
     @Mock
     private DashboardNotificationsRepository dashboardNotificationsRepository;
@@ -167,10 +170,12 @@ public class DashboardNotificationServiceTest {
     }
 
     @Test
-    public void saveOrUpdate() {
+    void saveOrUpdate() {
 
         DashboardNotificationsEntity notification1 = createDashboardNotificationsEntity();
+        notification1.setCreatedAt(OffsetDateTime.now());
         DashboardNotificationsEntity notification2 = createDashboardNotificationsEntity();
+        notification2.setCreatedAt(OffsetDateTime.now().minusDays(1));
         when(
             dashboardNotificationsRepository
                 .findByReferenceAndCitizenRoleAndName(
@@ -181,7 +186,7 @@ public class DashboardNotificationServiceTest {
         notification.setReference("reference");
         notification.setCitizenRole("CLAIMANT");
         dashboardNotificationService.saveOrUpdate(notification);
-        verify(notificationActionRepository, times(2)).deleteByDashboardNotificationAndActionPerformed(any(DashboardNotificationsEntity.class), any());
+        verify(notificationActionRepository, times(2)).deleteByDashboardNotificationIdAndActionPerformed(any(UUID.class), any());
         final ArgumentCaptor<DashboardNotificationsEntity> captor = ArgumentCaptor.forClass(DashboardNotificationsEntity.class);
         verify(dashboardNotificationsRepository).save(captor.capture());
         assertThat(captor.getValue()).isNotNull();
@@ -208,6 +213,7 @@ public class DashboardNotificationServiceTest {
     private DashboardNotificationsEntity createDashboardNotificationsEntity() {
         DashboardNotificationsEntity notification = new DashboardNotificationsEntity();
         notification.setId(UUID.randomUUID());
+        notification.setCreatedAt(OffsetDateTime.now());
         return notification;
     }
 
@@ -220,7 +226,8 @@ public class DashboardNotificationServiceTest {
 
             DashboardNotificationsEntity notification = getNotification(id);
             when(dashboardNotificationsRepository.findById(id)).thenReturn(Optional.of(notification));
-            when(dashboardNotificationsRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+            when(notificationActionRepository.findByDashboardNotificationIdIn(List.of(id)))
+                .thenReturn(List.of());
 
             UserDetails userDetails = Mockito.mock(UserDetails.class);
             when(userDetails.getFullName()).thenReturn("Claimant user");
@@ -228,9 +235,9 @@ public class DashboardNotificationServiceTest {
 
             dashboardNotificationService.recordClick(id, authToken);
 
-            ArgumentCaptor<DashboardNotificationsEntity> captor = ArgumentCaptor.forClass(DashboardNotificationsEntity.class);
-            verify(dashboardNotificationsRepository).save(captor.capture());
-            NotificationActionEntity action = captor.getValue().getNotificationAction();
+            ArgumentCaptor<NotificationActionEntity> captor = ArgumentCaptor.forClass(NotificationActionEntity.class);
+            verify(notificationActionRepository).save(captor.capture());
+            NotificationActionEntity action = captor.getValue();
             assertThat(action).isNotNull();
             assertThat(action.getActionPerformed()).isEqualTo("Click");
             assertThat(action.getCreatedBy()).isEqualTo("Claimant user");
@@ -245,10 +252,11 @@ public class DashboardNotificationServiceTest {
             existingAction.setId(99L);
             existingAction.setActionPerformed("Click");
             existingAction.setReference(notification.getReference());
-            notification.setNotificationAction(existingAction);
+            existingAction.setDashboardNotificationId(id);
 
             when(dashboardNotificationsRepository.findById(id)).thenReturn(Optional.of(notification));
-            when(dashboardNotificationsRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+            when(notificationActionRepository.findByDashboardNotificationIdIn(List.of(id)))
+                .thenReturn(List.of(existingAction));
 
             String authToken = "Auth-token";
             UserDetails userDetails = Mockito.mock(UserDetails.class);
@@ -257,9 +265,9 @@ public class DashboardNotificationServiceTest {
 
             dashboardNotificationService.recordClick(id, authToken);
 
-            ArgumentCaptor<DashboardNotificationsEntity> captor = ArgumentCaptor.forClass(DashboardNotificationsEntity.class);
-            verify(dashboardNotificationsRepository).save(captor.capture());
-            NotificationActionEntity action = captor.getValue().getNotificationAction();
+            ArgumentCaptor<NotificationActionEntity> captor = ArgumentCaptor.forClass(NotificationActionEntity.class);
+            verify(notificationActionRepository).save(captor.capture());
+            NotificationActionEntity action = captor.getValue();
             assertThat(action.getId()).isEqualTo(99L);
             assertThat(action.getCreatedBy()).isEqualTo("Claimant user");
             assertThat(action.getActionPerformed()).isEqualTo("Click");
@@ -333,5 +341,285 @@ public class DashboardNotificationServiceTest {
         assertThat(result)
             .extracting(Notification::getId)
             .containsExactly(id1, id2);
+    }
+
+    @Nested
+    class GetNotificationsWithActions {
+
+        @Test
+        void should_return_notification_with_latest_action_attached() {
+            UUID notifId = UUID.randomUUID();
+            DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+            entity.setId(notifId);
+            entity.setReference("ref");
+            entity.setCreatedAt(OffsetDateTime.now());
+
+            NotificationActionEntity action = new NotificationActionEntity(
+                1L, "ref", "Click", "User", OffsetDateTime.now(), notifId
+            );
+
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRole("ref", "role"))
+                .thenReturn(List.of(entity));
+            when(notificationActionRepository.findByDashboardNotificationIdIn(List.of(notifId)))
+                .thenReturn(List.of(action));
+
+            List<Notification> result = dashboardNotificationService.getNotifications("ref", "role");
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getNotificationAction()).isNotNull();
+            assertThat(result.get(0).getNotificationAction().getActionPerformed()).isEqualTo("Click");
+        }
+
+        @Test
+        void should_return_notification_without_action_when_none_exists() {
+            UUID notifId = UUID.randomUUID();
+            DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+            entity.setId(notifId);
+            entity.setCreatedAt(OffsetDateTime.now());
+
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRole("ref", "role"))
+                .thenReturn(List.of(entity));
+            when(notificationActionRepository.findByDashboardNotificationIdIn(List.of(notifId)))
+                .thenReturn(List.of());
+
+            List<Notification> result = dashboardNotificationService.getNotifications("ref", "role");
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getNotificationAction()).isNull();
+        }
+
+        @Test
+        void should_return_latest_action_when_duplicates_exist() {
+            UUID notifId = UUID.randomUUID();
+            DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+            entity.setId(notifId);
+            entity.setCreatedAt(OffsetDateTime.now());
+
+            NotificationActionEntity olderAction = new NotificationActionEntity(
+                1L, "ref", "Click", "OlderUser", OffsetDateTime.now().minusDays(1), notifId
+            );
+            NotificationActionEntity latestAction = new NotificationActionEntity(
+                2L, "ref", "Click", "LatestUser", OffsetDateTime.now(), notifId
+            );
+
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRole("ref", "role"))
+                .thenReturn(List.of(entity));
+            when(notificationActionRepository.findByDashboardNotificationIdIn(List.of(notifId)))
+                .thenReturn(List.of(olderAction, latestAction));
+
+            List<Notification> result = dashboardNotificationService.getNotifications("ref", "role");
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).getNotificationAction().getCreatedBy()).isEqualTo("LatestUser");
+            assertThat(result.get(0).getNotificationAction().getId()).isEqualTo(2L);
+        }
+    }
+
+    @Nested
+    class SaveOrUpdateTests {
+
+        @Test
+        void shouldCreateNewNotificationWhenNoExistingMatch() {
+            DashboardNotificationsEntity notification = new DashboardNotificationsEntity();
+            notification.setId(UUID.randomUUID());
+            notification.setName("template.name");
+            notification.setReference("reference");
+            notification.setCitizenRole("CLAIMANT");
+
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRoleAndName(
+                "reference", "CLAIMANT", "template.name"))
+                .thenReturn(List.of());
+            when(dashboardNotificationsRepository.save(notification)).thenReturn(notification);
+
+            DashboardNotificationsEntity saved = dashboardNotificationService.saveOrUpdate(notification);
+
+            assertThat(saved).isSameAs(notification);
+            verify(dashboardNotificationsRepository).save(notification);
+            verifyNoInteractions(notificationActionRepository);
+        }
+
+        @Test
+        void shouldDeleteActionsForAllExistingDuplicatesOnUpdate() {
+            UUID existingId1 = UUID.randomUUID();
+            UUID existingId2 = UUID.randomUUID();
+            UUID existingId3 = UUID.randomUUID();
+
+            DashboardNotificationsEntity existing1 = new DashboardNotificationsEntity();
+            existing1.setId(existingId1);
+            DashboardNotificationsEntity existing2 = new DashboardNotificationsEntity();
+            existing2.setId(existingId2);
+            DashboardNotificationsEntity existing3 = new DashboardNotificationsEntity();
+            existing3.setId(existingId3);
+
+            DashboardNotificationsEntity notification = new DashboardNotificationsEntity();
+            notification.setId(UUID.randomUUID());
+            notification.setName("template.name");
+            notification.setReference("reference");
+            notification.setCitizenRole("CLAIMANT");
+
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRoleAndName(any(), any(), any()))
+                .thenReturn(List.of(existing1, existing2, existing3));
+
+            dashboardNotificationService.saveOrUpdate(notification);
+
+            verify(notificationActionRepository).deleteByDashboardNotificationIdAndActionPerformed(existingId1, "Click");
+            verify(notificationActionRepository).deleteByDashboardNotificationIdAndActionPerformed(existingId2, "Click");
+            verify(notificationActionRepository).deleteByDashboardNotificationIdAndActionPerformed(existingId3, "Click");
+        }
+
+        @Test
+        void shouldUseFirstExistingNotificationIdOnUpdate() {
+            UUID firstExistingId = UUID.randomUUID();
+            DashboardNotificationsEntity existing = new DashboardNotificationsEntity();
+            existing.setId(firstExistingId);
+
+            DashboardNotificationsEntity notification = new DashboardNotificationsEntity();
+            notification.setId(UUID.randomUUID());
+            notification.setName("template.name");
+            notification.setReference("reference");
+            notification.setCitizenRole("CLAIMANT");
+            notification.setTitleEn("Updated Title");
+
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRoleAndName(any(), any(), any()))
+                .thenReturn(List.of(existing));
+
+            dashboardNotificationService.saveOrUpdate(notification);
+
+            ArgumentCaptor<DashboardNotificationsEntity> captor = ArgumentCaptor.forClass(DashboardNotificationsEntity.class);
+            verify(dashboardNotificationsRepository).save(captor.capture());
+            assertThat(captor.getValue().getId()).isEqualTo(firstExistingId);
+            assertThat(captor.getValue().getTitleEn()).isEqualTo("Updated Title");
+        }
+    }
+
+    @Nested
+    class DeleteNotificationTests {
+
+        @Test
+        void shouldDeleteNotificationById() {
+            UUID notifId = UUID.randomUUID();
+            dashboardNotificationService.deleteById(notifId);
+            InOrder inOrder = inOrder(notificationActionRepository, dashboardNotificationsRepository);
+            inOrder.verify(notificationActionRepository).deleteByDashboardNotificationId(notifId);
+            inOrder.verify(dashboardNotificationsRepository).deleteById(notifId);
+        }
+
+        @Test
+        void shouldDeleteByNameReferenceAndCitizenRole() {
+            DashboardNotificationsEntity notification = getNotification(UUID.randomUUID());
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRoleAndName("ref", "CLAIMANT", "name"))
+                .thenReturn(List.of(notification));
+            dashboardNotificationService.deleteByNameAndReferenceAndCitizenRole("name", "ref", "CLAIMANT");
+            verify(notificationActionRepository).deleteByDashboardNotificationId(notification.getId());
+            verify(dashboardNotificationsRepository).deleteByNameAndReferenceAndCitizenRole("name", "ref", "CLAIMANT");
+        }
+
+        @Test
+        void shouldDeleteByNameAndReference() {
+            DashboardNotificationsEntity notification = getNotification(UUID.randomUUID());
+            when(dashboardNotificationsRepository.findByReferenceAndName("ref", "name"))
+                .thenReturn(List.of(notification));
+            dashboardNotificationService.deleteByNameAndReference("name", "ref");
+            verify(notificationActionRepository).deleteByDashboardNotificationId(notification.getId());
+            verify(dashboardNotificationsRepository).deleteByNameAndReference("name", "ref");
+        }
+
+        @Test
+        void shouldDeleteByReferenceAndCitizenRole() {
+            DashboardNotificationsEntity notification = getNotification(UUID.randomUUID());
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRole("ref", "DEFENDANT"))
+                .thenReturn(List.of(notification));
+            dashboardNotificationService.deleteByReferenceAndCitizenRole("ref", "DEFENDANT");
+            verify(notificationActionRepository).deleteByDashboardNotificationId(notification.getId());
+            verify(dashboardNotificationsRepository).deleteByReferenceAndCitizenRole("ref", "DEFENDANT");
+        }
+    }
+
+    @Nested
+    class RecordClickTests {
+
+        @Test
+        void shouldCreateNewClickActionWhenNoExistingAction() {
+            String authToken = "Auth-token";
+            DashboardNotificationsEntity notification = getNotification(id);
+            when(dashboardNotificationsRepository.findById(id)).thenReturn(Optional.of(notification));
+            when(notificationActionRepository.findByDashboardNotificationIdIn(List.of(id)))
+                .thenReturn(List.of());
+
+            UserDetails userDetails = Mockito.mock(UserDetails.class);
+            when(userDetails.getFullName()).thenReturn("Test User");
+            when(idamApi.retrieveUserDetails(authToken)).thenReturn(userDetails);
+
+            dashboardNotificationService.recordClick(id, authToken);
+
+            ArgumentCaptor<NotificationActionEntity> captor = ArgumentCaptor.forClass(NotificationActionEntity.class);
+            verify(notificationActionRepository).save(captor.capture());
+            NotificationActionEntity action = captor.getValue();
+            assertThat(action.getId()).isNull();
+            assertThat(action.getActionPerformed()).isEqualTo("Click");
+            assertThat(action.getCreatedBy()).isEqualTo("Test User");
+            assertThat(action.getDashboardNotificationId()).isEqualTo(id);
+            assertThat(action.getReference()).isEqualTo(notification.getReference());
+        }
+
+        @Test
+        void shouldUpdateExistingClickAction() {
+            DashboardNotificationsEntity notification = getNotification(id);
+            NotificationActionEntity existingAction = new NotificationActionEntity(
+                42L, notification.getReference(), "Click", "Old User", OffsetDateTime.now().minusDays(1), id
+            );
+
+            when(dashboardNotificationsRepository.findById(id)).thenReturn(Optional.of(notification));
+            when(notificationActionRepository.findByDashboardNotificationIdIn(List.of(id)))
+                .thenReturn(List.of(existingAction));
+
+            String authToken = "Auth-token";
+            UserDetails userDetails = Mockito.mock(UserDetails.class);
+            when(userDetails.getFullName()).thenReturn("New User");
+            when(idamApi.retrieveUserDetails(authToken)).thenReturn(userDetails);
+
+            dashboardNotificationService.recordClick(id, authToken);
+
+            ArgumentCaptor<NotificationActionEntity> captor = ArgumentCaptor.forClass(NotificationActionEntity.class);
+            verify(notificationActionRepository).save(captor.capture());
+            NotificationActionEntity action = captor.getValue();
+            assertThat(action.getId()).isEqualTo(42L);
+            assertThat(action.getCreatedBy()).isEqualTo("New User");
+        }
+
+        @Test
+        void shouldCreateNewActionWhenExistingActionIsNotClick() {
+            DashboardNotificationsEntity notification = getNotification(id);
+            NotificationActionEntity existingAction = new NotificationActionEntity(
+                10L, notification.getReference(), "View", "Some User", OffsetDateTime.now(), id
+            );
+
+            when(dashboardNotificationsRepository.findById(id)).thenReturn(Optional.of(notification));
+            when(notificationActionRepository.findByDashboardNotificationIdIn(List.of(id)))
+                .thenReturn(List.of(existingAction));
+
+            String authToken = "Auth-token";
+            UserDetails userDetails = Mockito.mock(UserDetails.class);
+            when(userDetails.getFullName()).thenReturn("Click User");
+            when(idamApi.retrieveUserDetails(authToken)).thenReturn(userDetails);
+
+            dashboardNotificationService.recordClick(id, authToken);
+
+            ArgumentCaptor<NotificationActionEntity> captor = ArgumentCaptor.forClass(NotificationActionEntity.class);
+            verify(notificationActionRepository).save(captor.capture());
+            NotificationActionEntity action = captor.getValue();
+            assertThat(action.getId()).isNull();
+            assertThat(action.getActionPerformed()).isEqualTo("Click");
+        }
+
+        @Test
+        void shouldNotSaveActionWhenNotificationNotFound() {
+            when(dashboardNotificationsRepository.findById(id)).thenReturn(Optional.empty());
+
+            dashboardNotificationService.recordClick(id, "Auth-token");
+
+            verifyNoInteractions(notificationActionRepository);
+            verifyNoInteractions(idamApi);
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/dashboard/services/DashboardNotificationServiceTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.InOrder;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.dashboard.data.Notification;
@@ -28,7 +27,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -137,35 +135,54 @@ class DashboardNotificationServiceTest {
 
         @Test
         void shouldReturnOkWhenDeletingEntity() {
-            //when
             dashboardNotificationService.deleteById(id);
-
-            //then
-            verify(dashboardNotificationsRepository).deleteById(id);
+            verify(notificationActionRepository).deleteByDashboardNotificationIdIn(List.of(id));
+            verify(dashboardNotificationsRepository).deleteByDashboardNotificationIdIn(List.of(id));
         }
 
         @Test
         void deleteAllNotificationsToClaimant() {
             String reference = "reference";
             String claimant = "CLAIMANT";
+            DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+            entity.setId(id);
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRole(reference, claimant))
+                .thenReturn(List.of(entity));
+
             dashboardNotificationService.deleteByReferenceAndCitizenRole(reference, claimant);
-            Mockito.verify(dashboardNotificationsRepository).deleteByReferenceAndCitizenRole(reference, claimant);
+
+            verify(notificationActionRepository).deleteByDashboardNotificationIdIn(List.of(id));
+            verify(dashboardNotificationsRepository).deleteByDashboardNotificationIdIn(List.of(id));
         }
 
         @Test
         void deleteAllNotificationsToDefendant() {
             String reference = "reference";
             String defendant = "DEFENDANT";
+            DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+            entity.setId(id);
+            when(dashboardNotificationsRepository.findByReferenceAndCitizenRole(reference, defendant))
+                .thenReturn(List.of(entity));
+
             dashboardNotificationService.deleteByReferenceAndCitizenRole(reference, defendant);
-            Mockito.verify(dashboardNotificationsRepository).deleteByReferenceAndCitizenRole(reference, defendant);
+
+            verify(notificationActionRepository).deleteByDashboardNotificationIdIn(List.of(id));
+            verify(dashboardNotificationsRepository).deleteByDashboardNotificationIdIn(List.of(id));
         }
 
         @Test
         void deleteNotificationsByNameAndReference() {
             String templateName = "template.name";
             String reference = "reference";
+            DashboardNotificationsEntity entity = new DashboardNotificationsEntity();
+            entity.setId(id);
+            when(dashboardNotificationsRepository.findByReferenceAndName(reference, templateName))
+                .thenReturn(List.of(entity));
+
             dashboardNotificationService.deleteByNameAndReference(templateName, reference);
-            Mockito.verify(dashboardNotificationsRepository).deleteByNameAndReference(templateName, reference);
+
+            verify(notificationActionRepository).deleteByDashboardNotificationIdIn(List.of(id));
+            verify(dashboardNotificationsRepository).deleteByDashboardNotificationIdIn(List.of(id));
         }
     }
 
@@ -366,8 +383,8 @@ class DashboardNotificationServiceTest {
             List<Notification> result = dashboardNotificationService.getNotifications("ref", "role");
 
             assertThat(result).hasSize(1);
-            assertThat(result.get(0).getNotificationAction()).isNotNull();
-            assertThat(result.get(0).getNotificationAction().getActionPerformed()).isEqualTo("Click");
+            assertThat(result.getFirst().getNotificationAction()).isNotNull();
+            assertThat(result.getFirst().getNotificationAction().getActionPerformed()).isEqualTo("Click");
         }
 
         @Test
@@ -385,7 +402,7 @@ class DashboardNotificationServiceTest {
             List<Notification> result = dashboardNotificationService.getNotifications("ref", "role");
 
             assertThat(result).hasSize(1);
-            assertThat(result.get(0).getNotificationAction()).isNull();
+            assertThat(result.getFirst().getNotificationAction()).isNull();
         }
 
         @Test
@@ -410,8 +427,8 @@ class DashboardNotificationServiceTest {
             List<Notification> result = dashboardNotificationService.getNotifications("ref", "role");
 
             assertThat(result).hasSize(1);
-            assertThat(result.get(0).getNotificationAction().getCreatedBy()).isEqualTo("LatestUser");
-            assertThat(result.get(0).getNotificationAction().getId()).isEqualTo(2L);
+            assertThat(result.getFirst().getNotificationAction().getCreatedBy()).isEqualTo("LatestUser");
+            assertThat(result.getFirst().getNotificationAction().getId()).isEqualTo(2L);
         }
     }
 
@@ -498,10 +515,11 @@ class DashboardNotificationServiceTest {
         @Test
         void shouldDeleteNotificationById() {
             UUID notifId = UUID.randomUUID();
+
             dashboardNotificationService.deleteById(notifId);
-            InOrder inOrder = inOrder(notificationActionRepository, dashboardNotificationsRepository);
-            inOrder.verify(notificationActionRepository).deleteByDashboardNotificationId(notifId);
-            inOrder.verify(dashboardNotificationsRepository).deleteById(notifId);
+
+            verify(notificationActionRepository).deleteByDashboardNotificationIdIn(List.of(notifId));
+            verify(dashboardNotificationsRepository).deleteByDashboardNotificationIdIn(List.of(notifId));
         }
 
         @Test
@@ -509,9 +527,11 @@ class DashboardNotificationServiceTest {
             DashboardNotificationsEntity notification = getNotification(UUID.randomUUID());
             when(dashboardNotificationsRepository.findByReferenceAndCitizenRoleAndName("ref", "CLAIMANT", "name"))
                 .thenReturn(List.of(notification));
+
             dashboardNotificationService.deleteByNameAndReferenceAndCitizenRole("name", "ref", "CLAIMANT");
-            verify(notificationActionRepository).deleteByDashboardNotificationId(notification.getId());
-            verify(dashboardNotificationsRepository).deleteByNameAndReferenceAndCitizenRole("name", "ref", "CLAIMANT");
+
+            verify(notificationActionRepository).deleteByDashboardNotificationIdIn(List.of(notification.getId()));
+            verify(dashboardNotificationsRepository).deleteByDashboardNotificationIdIn(List.of(notification.getId()));
         }
 
         @Test
@@ -519,9 +539,11 @@ class DashboardNotificationServiceTest {
             DashboardNotificationsEntity notification = getNotification(UUID.randomUUID());
             when(dashboardNotificationsRepository.findByReferenceAndName("ref", "name"))
                 .thenReturn(List.of(notification));
+
             dashboardNotificationService.deleteByNameAndReference("name", "ref");
-            verify(notificationActionRepository).deleteByDashboardNotificationId(notification.getId());
-            verify(dashboardNotificationsRepository).deleteByNameAndReference("name", "ref");
+
+            verify(notificationActionRepository).deleteByDashboardNotificationIdIn(List.of(notification.getId()));
+            verify(dashboardNotificationsRepository).deleteByDashboardNotificationIdIn(List.of(notification.getId()));
         }
 
         @Test
@@ -529,9 +551,11 @@ class DashboardNotificationServiceTest {
             DashboardNotificationsEntity notification = getNotification(UUID.randomUUID());
             when(dashboardNotificationsRepository.findByReferenceAndCitizenRole("ref", "DEFENDANT"))
                 .thenReturn(List.of(notification));
+
             dashboardNotificationService.deleteByReferenceAndCitizenRole("ref", "DEFENDANT");
-            verify(notificationActionRepository).deleteByDashboardNotificationId(notification.getId());
-            verify(dashboardNotificationsRepository).deleteByReferenceAndCitizenRole("ref", "DEFENDANT");
+
+            verify(notificationActionRepository).deleteByDashboardNotificationIdIn(List.of(notification.getId()));
+            verify(dashboardNotificationsRepository).deleteByDashboardNotificationIdIn(List.of(notification.getId()));
         }
     }
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-3976


### Change description ###
Fix duplicate notification_action rows and one-to-one mapping mismatch causing Dashboard Notification query failures.  This PR addresses database exceptions and concurrency issues in the Dashboard Notification service. It resolves exceptions caused by a OneToOne mapping and StaleObjectStateException caused by concurrent deletions during high-load periods.

Changes: 
Decoupled entities, Bulk deletion, Updated 'recordClick', Performance optimisations, Deterministic matching

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
