### PR TITLE
DTSCCI-5316: NPE in Hearing Notice Scheduler for disallowed state

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/event/HearingNoticeSchedulerEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/event/HearingNoticeSchedulerEventHandler.java
@@ -75,28 +75,28 @@ public class HearingNoticeSchedulerEventHandler {
         int requestedHearingVersion = hearing.getRequestDetails().getVersionNumber().intValue();
         log.info("Processing hearing id: [{}] status: [{}] and requested version: [{}]", hearingId, hearingStatus, requestedHearingVersion);
 
+        PartiesNotifiedResponse partiesNotified = null;
         if (hearingStatus.equals(ListAssistCaseStatus.LISTED)) {
-            PartiesNotifiedResponse partiesNotified = getLatestPartiesNotifiedResponse(hearingId);
+
             String caseReference = hearing.getCaseDetails().getCaseRef();
             CaseDetails caseDetails = coreCaseDataService.getCase(Long.parseLong(caseReference));
+            partiesNotified = getLatestPartiesNotifiedResponse(hearingId);
 
             boolean stateNotAllowedToGenerateHearingNotice = isNotAllowedState(caseDetails.getState(), caseReference);
-
-            if (!stateNotAllowedToGenerateHearingNotice
-                && HmcDataUtils.hearingDataChanged(partiesNotified, hearing)) {
-                log.info("Dispatching hearing notice task for hearing [{}].",
-                        hearingId);
+            if (!stateNotAllowedToGenerateHearingNotice && HmcDataUtils.hearingDataChanged(partiesNotified, hearing)) {
+                log.info("Dispatching hearing notice task for hearing [{}].", hearingId);
                 triggerHearingNoticeEvent(new HearingNoticeMessageVars()
                         .setHearingId(hearingId)
                         .setCaseId(caseReference)
                         .setTriggeredViaScheduler(true));
-
-            } else {
-                notifyHmc(hearingId, hearing, partiesNotified.getServiceData());
+                return;
             }
-        } else {
-            notifyHmc(hearingId, hearing, new PartiesNotifiedServiceData());
         }
+
+        PartiesNotifiedServiceData serviceData = (partiesNotified != null && partiesNotified.getServiceData() != null)
+            ? partiesNotified.getServiceData()
+            : new PartiesNotifiedServiceData();
+        notifyHmc(hearingId, hearing, serviceData);
     }
 
     private static boolean isNotAllowedState(String state, String caseReferene) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtils.java
@@ -30,7 +30,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.getContentText;
@@ -201,8 +200,8 @@ public class HmcDataUtils {
      */
     public static Integer getTotalHearingDurationInMinutes(HearingGetResponse hearing) {
         return hearing.getHearingResponse().getHearingDaySchedule().stream()
-            .map(day -> getHearingDayMinutesDuration(day))
-            .reduce((aac, day) -> aac + day).orElse(null);
+            .map(HmcDataUtils::getHearingDayMinutesDuration)
+            .reduce(Integer::sum).orElse(null);
     }
 
     /**
@@ -241,7 +240,7 @@ public class HmcDataUtils {
      */
     private static String concatWithAnd(List<String> strings) {
         return strings.stream()
-            .filter(string -> string != null && !string.equals(""))
+            .filter(string -> string != null && !string.isEmpty())
             .reduce((acc, displayText) -> String.format("%s and %s", acc, displayText))
             .orElse("");
     }
@@ -256,7 +255,7 @@ public class HmcDataUtils {
     private static String concatWithWelshAnd(List<String> strings, Boolean vowelStart) {
         String andText = vowelStart ? "ac" : "a";
         return strings.stream()
-            .filter(string -> string != null && !string.equals(""))
+            .filter(string -> string != null && !string.isEmpty())
             .reduce((acc, displayText) -> String.format("%s %s %s", acc, andText, displayText))
             .orElse("");
     }
@@ -348,18 +347,16 @@ public class HmcDataUtils {
 
     public static boolean includesVideoHearing(HearingsResponse hearings) {
         return hasHearings(hearings)
-                && hearings.getCaseHearings().stream()
-                .filter(HmcDataUtils::includesVideoHearing).count() > 0;
+                && hearings.getCaseHearings().stream().anyMatch(HmcDataUtils::includesVideoHearing);
     }
 
     private static boolean includesVideoHearing(HearingDaySchedule hearingDay) {
-        return hearingDay.getAttendees().stream().filter(
-            attendee -> attendee.getHearingSubChannel() != null
-                && attendee.getHearingSubChannel().equals(VIDCVP)).count() > 0;
+        return hearingDay.getAttendees().stream().anyMatch(attendee -> attendee.getHearingSubChannel() != null
+            && attendee.getHearingSubChannel().equals(VIDCVP));
     }
 
     private static boolean includesVideoHearing(List<HearingDaySchedule> schedule) {
-        return schedule.stream().filter(HmcDataUtils::includesVideoHearing).count() > 0;
+        return schedule.stream().anyMatch(HmcDataUtils::includesVideoHearing);
     }
 
     private static boolean includesVideoHearing(CaseHearing caseHearing) {
@@ -380,11 +377,11 @@ public class HmcDataUtils {
                         .filter(party -> party.getIndividualDetails() != null)
                         .map(party -> StringUtils.joinNonNull(" ", party.getIndividualDetails().getFirstName(),
                                 party.getIndividualDetails().getLastName()))
-                ).collect(Collectors.toList());
+                ).toList();
     }
 
     private static String concatenateNames(List<String> names) {
-        return nonNull(names) && names.size() > 0 ? org.apache.commons.lang.StringUtils.join(names, "\n") : null;
+        return nonNull(names) && !names.isEmpty() ? org.apache.commons.lang.StringUtils.join(names, "\n") : null;
     }
 
     public static String getInPersonAttendeeNames(HearingGetResponse hearing) {
@@ -417,7 +414,7 @@ public class HmcDataUtils {
         List<LocationRefData> locations = locationRefDataService.getHearingCourtLocations(bearerToken);
         var matchedLocations =  locations.stream().filter(loc -> loc.getEpimmsId().equals(venueId)).toList();
         if (!matchedLocations.isEmpty()) {
-            return matchedLocations.get(0);
+            return matchedLocations.getFirst();
         } else {
             throw new IllegalArgumentException("Hearing location data not available for hearing " + hearingId + " venueId " + venueId);
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtils.java
@@ -28,6 +28,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -113,7 +114,7 @@ public class HmcDataUtils {
                     HearingDay datesFromHearingDay = new HearingDay()
                         .setHearingStartDateTime(convertFromUTC(hearingDay.getHearingStartDateTime()))
                         .setHearingEndDateTime(convertFromUTC(hearingDay.getHearingEndDateTime()));
-                    if (!serviceData.getHearingLocation().equals(hearingDay.getHearingVenueId())
+                    if (!Objects.equals(serviceData.getHearingLocation(), hearingDay.getHearingVenueId())
                         || !serviceData.getDays().contains(datesFromHearingDay)) {
                         return true;
                     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/event/HearingNoticeSchedulerEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/event/HearingNoticeSchedulerEventHandlerTest.java
@@ -39,7 +39,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -336,11 +335,11 @@ class HearingNoticeSchedulerEventHandlerTest {
         handler.handle(new HearingNoticeSchedulerTaskEvent(HEARING_ID));
 
         verify(hearingsService, times(1)).updatePartiesNotifiedResponse(
-            eq(AUTH_TOKEN),
-            eq(HEARING_ID),
-            eq(VERSION),
-            eq(RECEIVED_DATETIME),
-            eq(new PartiesNotified().setServiceData(new PartiesNotifiedServiceData()))
+            AUTH_TOKEN,
+            HEARING_ID,
+            VERSION,
+            RECEIVED_DATETIME,
+            new PartiesNotified().setServiceData(new PartiesNotifiedServiceData())
         );
         verify(runtimeService, times(0)).createMessageCorrelation(MESSAGE_ID);
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/event/HearingNoticeSchedulerEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/event/HearingNoticeSchedulerEventHandlerTest.java
@@ -39,6 +39,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -316,6 +317,32 @@ class HearingNoticeSchedulerEventHandlerTest {
         );
         verify(runtimeService, times(0)).createMessageCorrelation(MESSAGE_ID);
         verifyNoInteractions(messageCorrelationBuilder);
+    }
+
+    @Test
+    void shouldAcknowledgeHearingWithoutNotice_whenHearingIsListedAndPartiesNotifiedIsNullAndCaseStateIsDisallowed() {
+        when(hearingsService.getHearingResponse(anyString(), anyString())).thenReturn(
+            createHearing(ListAssistCaseStatus.LISTED));
+        when(hearingsService.getPartiesNotifiedResponses(anyString(), anyString())).thenReturn(
+            new PartiesNotifiedResponses());
+
+        CaseDetails mockCaseDetails = CaseDetails.builder()
+            .id(Long.parseLong(CASE_ID))
+            .state("CLOSED")
+            .build();
+
+        when(coreCaseDataService.getCase(Long.parseLong(CASE_ID))).thenReturn(mockCaseDetails);
+
+        handler.handle(new HearingNoticeSchedulerTaskEvent(HEARING_ID));
+
+        verify(hearingsService, times(1)).updatePartiesNotifiedResponse(
+            eq(AUTH_TOKEN),
+            eq(HEARING_ID),
+            eq(VERSION),
+            eq(RECEIVED_DATETIME),
+            eq(new PartiesNotified().setServiceData(new PartiesNotifiedServiceData()))
+        );
+        verify(runtimeService, times(0)).createMessageCorrelation(MESSAGE_ID);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
@@ -208,6 +208,26 @@ class HmcDataUtilsTest {
         assertTrue(result);
     }
 
+    @Test
+    void hearingDataChanged_WhenHearingLocationIsNull_ReturnsTrue() {
+        HearingGetResponse hearing = new HearingGetResponse()
+            .setHearingResponse(new uk.gov.hmcts.reform.hmc.model.hearing.HearingResponse()
+                                 .setHearingDaySchedule(List.of(new uk.gov.hmcts.reform.hmc.model.hearing.HearingDaySchedule()
+                                                                   .setHearingVenueId("Venue A")
+                                                                   .setHearingStartDateTime(LocalDateTime.now())
+                                                                   .setHearingEndDateTime(LocalDateTime.now().plusHours(1)))));
+        PartiesNotifiedResponse partiesNotified = new PartiesNotifiedResponse()
+            .setServiceData(new PartiesNotifiedServiceData()
+                             .setDays(List.of(new HearingDay()
+                                               .setHearingStartDateTime(LocalDateTime.now())
+                                               .setHearingEndDateTime(LocalDateTime.now().plusHours(1))))
+                             .setHearingLocation(null)); // NULL location
+
+        boolean result = HmcDataUtils.hearingDataChanged(partiesNotified, hearing);
+
+        assertTrue(result);
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void getHearingDaysText(Boolean isWelsh) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
@@ -38,7 +38,6 @@ import uk.gov.hmcts.reform.hmc.model.unnotifiedhearings.PartiesNotifiedServiceDa
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -874,15 +873,19 @@ class HmcDataUtilsTest {
     void getTotalHearingDurationText_whenDuration1Day5Hours(Boolean isWelsh) {
         var hearingDay1 = new HearingDaySchedule()
             .setHearingStartDateTime(LocalDateTime.of(2023, 10, 23, 10, 0))
-            .setHearingEndDateTime(LocalDateTime.of(2023, 10, 23, 15, 0));
+            .setHearingEndDateTime(LocalDateTime.of(2023, 10, 23, 16, 0));
+
+        var hearingDay2 = new HearingDaySchedule()
+            .setHearingStartDateTime(LocalDateTime.of(2023, 10, 24, 10, 0))
+            .setHearingEndDateTime(LocalDateTime.of(2023, 10, 24, 15, 0));
 
         HearingGetResponse hearing = new HearingGetResponse()
             .setHearingResponse(new HearingResponse().setHearingDaySchedule(
-                List.of(hearingDay1)));
+                List.of(hearingDay1, hearingDay2)));
 
         var result = HmcDataUtils.getTotalHearingDurationText(hearing, isWelsh);
 
-        assertEquals(result, isWelsh ? "5 awr" : "5 hours");
+        assertEquals(result, isWelsh ? "1 diwrnod a 5 awr" : "1 day and 5 hours");
     }
 
     @ParameterizedTest
@@ -1627,9 +1630,11 @@ class HmcDataUtilsTest {
         return new CaseHearing()
             .setHearingId(Long.valueOf(hearingId))
             .setHearingRequestDateTime(hearingRequestTime)
-            .setHearingDaySchedule(startTimes.stream().map(startTime -> new HearingDaySchedule().setHearingStartDateTime(
-                startTime)).collect(
-                Collectors.toList()));
+            .setHearingDaySchedule(
+                startTimes.stream()
+                    .map(startTime -> new HearingDaySchedule().setHearingStartDateTime(startTime))
+                    .toList()
+            );
     }
 
     @Nested


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5316


### Change description ###
Fixed handling for LISTED hearings without prior notification history in disallowed case states and added null-safety to HmcDataUtils.hearingDataChanged.
Updates various Sonar code smells.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
