### PR TITLE
DTSCCI-5321: Expand support for additional video sub-channels

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtils.java
@@ -352,7 +352,9 @@ public class HmcDataUtils {
 
     private static boolean includesVideoHearing(HearingDaySchedule hearingDay) {
         return hearingDay.getAttendees().stream().anyMatch(attendee -> attendee.getHearingSubChannel() != null
-            && attendee.getHearingSubChannel().equals(VIDCVP));
+            && (attendee.getHearingSubChannel().equals(VIDCVP)
+            || attendee.getHearingSubChannel().equals(HearingSubChannel.VID)
+            || attendee.getHearingSubChannel().equals(HearingSubChannel.VIDTEAMS)));
     }
 
     private static boolean includesVideoHearing(List<HearingDaySchedule> schedule) {
@@ -363,15 +365,15 @@ public class HmcDataUtils {
         return includesVideoHearing(caseHearing.getHearingDaySchedule());
     }
 
-    private static List<Attendees> getAttendeesBySubChannel(HearingGetResponse hearing, HearingSubChannel subChannel) {
+    private static List<Attendees> getAttendeesBySubChannels(HearingGetResponse hearing, List<HearingSubChannel> subChannels) {
         HearingDaySchedule firstHearingDay = getHearingStartDay(hearing);
         return nonNull(firstHearingDay) && nonNull(firstHearingDay.getAttendees()) ? firstHearingDay.getAttendees().stream()
-                .filter(attendee -> nonNull(attendee.getHearingSubChannel()) && attendee.getHearingSubChannel().equals(subChannel)).toList()
+                .filter(attendee -> nonNull(attendee.getHearingSubChannel()) && subChannels.contains(attendee.getHearingSubChannel())).toList()
                 : new ArrayList<>();
     }
 
-    public static List<String> getHearingAttendeeNames(HearingGetResponse hearing, HearingSubChannel subChannel) {
-        return getAttendeesBySubChannel(hearing, subChannel).stream()
+    public static List<String> getHearingAttendeeNames(HearingGetResponse hearing, List<HearingSubChannel> subChannels) {
+        return getAttendeesBySubChannels(hearing, subChannels).stream()
                 .flatMap(attendee -> hearing.getPartyDetails().stream()
                         .filter(party -> party.getPartyID().equals(attendee.getPartyID()))
                         .filter(party -> party.getIndividualDetails() != null)
@@ -385,15 +387,15 @@ public class HmcDataUtils {
     }
 
     public static String getInPersonAttendeeNames(HearingGetResponse hearing) {
-        return concatenateNames(getHearingAttendeeNames(hearing, INTER));
+        return concatenateNames(getHearingAttendeeNames(hearing, List.of(INTER)));
     }
 
     public static String getPhoneAttendeeNames(HearingGetResponse hearing) {
-        return concatenateNames(getHearingAttendeeNames(hearing, TELCVP));
+        return concatenateNames(getHearingAttendeeNames(hearing, List.of(TELCVP)));
     }
 
     public static String getVideoAttendeesNames(HearingGetResponse hearing) {
-        return concatenateNames(getHearingAttendeeNames(hearing, VIDCVP));
+        return concatenateNames(getHearingAttendeeNames(hearing, List.of(VIDCVP, HearingSubChannel.VID, HearingSubChannel.VIDTEAMS)));
     }
 
     public static String getHearingTypeTitleText(CaseData caseData, HearingGetResponse hearing, boolean isWelsh) {

--- a/src/main/java/uk/gov/hmcts/reform/hmc/model/hearing/HearingSubChannel.java
+++ b/src/main/java/uk/gov/hmcts/reform/hmc/model/hearing/HearingSubChannel.java
@@ -4,5 +4,7 @@ public enum HearingSubChannel {
     INTER,
     NA,
     TELCVP,
-    VIDCVP
+    VIDCVP,
+    VID,
+    VIDTEAMS
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/HearingIndividual.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/HearingIndividual.java
@@ -13,7 +13,9 @@ import java.util.UUID;
 import static uk.gov.hmcts.reform.hmc.model.hearing.HearingSubChannel.INTER;
 import static uk.gov.hmcts.reform.hmc.model.hearing.HearingSubChannel.NA;
 import static uk.gov.hmcts.reform.hmc.model.hearing.HearingSubChannel.TELCVP;
+import static uk.gov.hmcts.reform.hmc.model.hearing.HearingSubChannel.VID;
 import static uk.gov.hmcts.reform.hmc.model.hearing.HearingSubChannel.VIDCVP;
+import static uk.gov.hmcts.reform.hmc.model.hearing.HearingSubChannel.VIDTEAMS;
 
 @NoArgsConstructor
 @Accessors(chain = true)
@@ -59,6 +61,14 @@ public class HearingIndividual {
 
     public static HearingIndividual attendingHearingByVideo(String firstName, String lastName) {
         return attendingHearingBy(firstName, lastName, VIDCVP);
+    }
+
+    public static HearingIndividual attendingHearingByVideoTeams(String firstName, String lastName) {
+        return attendingHearingBy(firstName, lastName, VIDTEAMS);
+    }
+
+    public static HearingIndividual attendingHearingByGenericVideo(String firstName, String lastName) {
+        return attendingHearingBy(firstName, lastName, VID);
     }
 
     public static HearingIndividual nonAttending(String firstName, String lastName) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
@@ -1575,14 +1575,34 @@ class HmcDataUtilsTest {
             HearingGetResponse hearing = buildHearing(
                 List.of(HearingIndividual.attendingHearingByVideo("Jason", "Wells"),
                         HearingIndividual.attendingHearingInPerson("Chloe", "Landale"),
-                        HearingIndividual.attendingHearingByVideo("Michael", "Carver"),
+                        HearingIndividual.attendingHearingByVideoTeams("Michael", "Carver"),
                         HearingIndividual.attendingHearingByPhone("Jenny", "Harper"),
-                        HearingIndividual.attendingHearingByVideo("Jack", "Crawley")
+                        HearingIndividual.attendingHearingByGenericVideo("Jack", "Crawley")
                 ));
 
             String actual = HmcDataUtils.getVideoAttendeesNames(hearing);
 
             assertEquals("Jason Wells\nMichael Carver\nJack Crawley", actual);
+        }
+
+        @Test
+        void shouldReturnVideoTeamsAttendee() {
+            HearingGetResponse hearing = buildHearing(
+                List.of(HearingIndividual.attendingHearingByVideoTeams("Jason", "Wells")));
+
+            String actual = HmcDataUtils.getVideoAttendeesNames(hearing);
+
+            assertEquals("Jason Wells", actual);
+        }
+
+        @Test
+        void shouldReturnGenericVideoAttendee() {
+            HearingGetResponse hearing = buildHearing(
+                List.of(HearingIndividual.attendingHearingByGenericVideo("Jason", "Wells")));
+
+            String actual = HmcDataUtils.getVideoAttendeesNames(hearing);
+
+            assertEquals("Jason Wells", actual);
         }
 
         @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5321


### Change description ###
Expand support for additional video sub-channels (VID, VIDTEAMS) in HMC data utilities and tests.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
