### PR TITLE
Add scheduler alerts for demo and aat environments

### DIFF
--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -16,10 +16,4 @@ monitor_scheduler_alerts = {
     enabled                = true
     action_group           = "demo-civil-service-slack-alert"
   }
-  "DefendantResponseDeadline" = {
-    frequency_in_minutes   = 60
-    time_window_in_minutes = 60
-    enabled                = true
-    action_group           = "demo-civil-service-slack-alert"
-  }
 }

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,0 +1,23 @@
+#================================================================================================
+# Azure Monitor
+#================================================================================================
+civil_service_alert_slack_email_secret_name = "civil-service-alert-slack-group-email"
+
+monitor_action_group = {
+  "demo-civil-service-slack-alert" = {
+    short_name = "cvlsr-demo"
+  }
+}
+
+monitor_scheduler_alerts = {
+  "JudgementBuffer" = {
+    frequency_in_minutes   = 60
+    time_window_in_minutes = 60
+    enabled                = true
+  }
+  "DefendantResponseDeadline" = {
+    frequency_in_minutes   = 60
+    time_window_in_minutes = 60
+    enabled                = true
+  }
+}

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -14,10 +14,12 @@ monitor_scheduler_alerts = {
     frequency_in_minutes   = 60
     time_window_in_minutes = 60
     enabled                = true
+    action_group           = "demo-civil-service-slack-alert"
   }
   "DefendantResponseDeadline" = {
     frequency_in_minutes   = 60
     time_window_in_minutes = 60
     enabled                = true
+    action_group           = "demo-civil-service-slack-alert"
   }
 }

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -16,10 +16,4 @@ monitor_scheduler_alerts = {
     enabled                = true
     action_group           = "demo-civil-service-slack-alert"
   }
-  "DefendantResponseDeadline" = {
-    frequency_in_minutes   = 60
-    time_window_in_minutes = 60
-    enabled                = true
-    action_group           = "demo-civil-service-slack-alert"
-  }
 }

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,0 +1,23 @@
+#================================================================================================
+# Azure Monitor
+#================================================================================================
+civil_service_alert_slack_email_secret_name = "civil-service-alert-slack-group-email"
+
+monitor_action_group = {
+  "demo-civil-service-slack-alert" = {
+    short_name = "cvlsr-demo"
+  }
+}
+
+monitor_scheduler_alerts = {
+  "JudgementBuffer" = {
+    frequency_in_minutes   = 60
+    time_window_in_minutes = 60
+    enabled                = true
+  }
+  "DefendantResponseDeadline" = {
+    frequency_in_minutes   = 60
+    time_window_in_minutes = 60
+    enabled                = true
+  }
+}

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -14,10 +14,12 @@ monitor_scheduler_alerts = {
     frequency_in_minutes   = 60
     time_window_in_minutes = 60
     enabled                = true
+    action_group           = "demo-civil-service-slack-alert"
   }
   "DefendantResponseDeadline" = {
     frequency_in_minutes   = 60
     time_window_in_minutes = 60
     enabled                = true
+    action_group           = "demo-civil-service-slack-alert"
   }
 }

--- a/infrastructure/scheduler-alerts.tf
+++ b/infrastructure/scheduler-alerts.tf
@@ -1,0 +1,110 @@
+data "azurerm_key_vault_secret" "civil-service-alert-slack-email" {
+  count        = var.civil_service_alert_slack_email_secret_name != null ? 1 : 0
+  name         = var.civil_service_alert_slack_email_secret_name
+  key_vault_id = module.key-vault.key_vault_id
+}
+
+locals {
+  civil_service_alert_slack_email = length(data.azurerm_key_vault_secret.civil-service-alert-slack-email) > 0 ? data.azurerm_key_vault_secret.civil-service-alert-slack-email[0].value : null
+}
+
+resource "azurerm_monitor_action_group" "civil-service-action-group" {
+  for_each            = var.monitor_action_group
+  name                = each.key
+  resource_group_name = "civil-service-${var.env}"
+  short_name          = try(each.value.short_name, null)
+  tags                = var.common_tags
+
+  dynamic "email_receiver" {
+    for_each = local.civil_service_alert_slack_email != null ? [1] : []
+    content {
+      name                    = "slack-email"
+      email_address           = local.civil_service_alert_slack_email
+      use_common_alert_schema = true
+    }
+  }
+}
+
+module "scheduler-aborted-alerts" {
+  for_each = var.monitor_scheduler_alerts
+  source   = "git@github.com:hmcts/cnp-module-metric-alert"
+  location = var.location
+
+  app_insights_name  = module.application_insights.name
+  resourcegroup_name = "civil-service-${var.env}"
+
+  alert_name = "${each.key}JobAborted"
+  alert_desc = "Triggers when scheduler ${each.key} in ${var.env} has aborted."
+
+  app_insights_query = <<-AIQ
+      customEvents
+        | where name == "${each.key}JobAborted"
+        | project timestamp, name, properties.abortReason
+      AIQ
+
+  custom_email_subject       = "Warning: The scheduler ${each.key} in ${var.env} has aborted."
+  frequency_in_minutes       = try(each.value.frequency_in_minutes, 30)
+  time_window_in_minutes     = try(each.value.time_window_in_minutes, 30)
+  severity_level             = 3
+  action_group_name          = values(azurerm_monitor_action_group.civil-service-action-group)[0].name
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold          = 0
+  common_tags                = var.common_tags
+}
+
+module "scheduler-high-failure-rate-alerts" {
+  for_each = var.monitor_scheduler_alerts
+  source   = "git@github.com:hmcts/cnp-module-metric-alert"
+  location = var.location
+
+  app_insights_name  = module.application_insights.name
+  resourcegroup_name = "civil-service-${var.env}"
+
+  alert_name = "${each.key}HighFailureRate"
+  alert_desc = "Triggers when scheduler ${each.key} in ${var.env} has a high failure rate."
+
+  app_insights_query = <<-AIQ
+      customEvents
+        | where name in ("${each.key}JobCompleted", "${each.key}JobAborted")
+        | extend cases = toint(tostring(properties.totalCases))
+        | extend failed = toint(tostring(properties.failedCases))
+        | extend failureRate = failed * 1.0 / cases
+        | where failureRate > 0.2
+      AIQ
+
+  custom_email_subject       = "Warning: The scheduler ${each.key} in ${var.env} has a high failure rate."
+  frequency_in_minutes       = try(each.value.frequency_in_minutes, 30)
+  time_window_in_minutes     = try(each.value.time_window_in_minutes, 30)
+  severity_level             = 3
+  action_group_name          = values(azurerm_monitor_action_group.civil-service-action-group)[0].name
+  trigger_threshold_operator = "GreaterThan"
+  trigger_threshold          = 0
+  common_tags                = var.common_tags
+}
+
+module "scheduler-job-not-run-alerts" {
+  for_each = var.monitor_scheduler_alerts
+  source   = "git@github.com:hmcts/cnp-module-metric-alert"
+  location = var.location
+
+  app_insights_name  = module.application_insights.name
+  resourcegroup_name = "civil-service-${var.env}"
+
+  alert_name = "${each.key}JobNotRun"
+  alert_desc = "Triggers when scheduler ${each.key} in ${var.env} has not run in the last 26 hours."
+
+  app_insights_query = <<-AIQ
+      customEvents
+        | where name == "${each.key}JobStarted"
+        | where timestamp > ago(26h)
+      AIQ
+
+  custom_email_subject       = "Warning: The scheduler ${each.key} in ${var.env} has not run in the last 26 hours."
+  frequency_in_minutes       = try(each.value.frequency_in_minutes, 30)
+  time_window_in_minutes     = try(each.value.time_window_in_minutes, 30)
+  severity_level             = 3
+  action_group_name          = values(azurerm_monitor_action_group.civil-service-action-group)[0].name
+  trigger_threshold_operator = "LessThan"
+  trigger_threshold          = 1
+  common_tags                = var.common_tags
+}

--- a/infrastructure/scheduler-alerts.tf
+++ b/infrastructure/scheduler-alerts.tf
@@ -6,12 +6,14 @@ data "azurerm_key_vault_secret" "civil-service-alert-slack-email" {
 
 locals {
   civil_service_alert_slack_email = length(data.azurerm_key_vault_secret.civil-service-alert-slack-email) > 0 ? data.azurerm_key_vault_secret.civil-service-alert-slack-email[0].value : null
+  enabled_scheduler_alerts        = { for k, v in var.monitor_scheduler_alerts : k => v if try(v.enabled, true) }
+  resource_group_name             = "civil-service-${var.env}"
 }
 
 resource "azurerm_monitor_action_group" "civil-service-action-group" {
   for_each            = var.monitor_action_group
   name                = each.key
-  resource_group_name = "civil-service-${var.env}"
+  resource_group_name = local.resource_group_name
   short_name          = try(each.value.short_name, null)
   tags                = var.common_tags
 
@@ -26,12 +28,12 @@ resource "azurerm_monitor_action_group" "civil-service-action-group" {
 }
 
 module "scheduler-aborted-alerts" {
-  for_each = var.monitor_scheduler_alerts
+  for_each = local.enabled_scheduler_alerts
   source   = "git@github.com:hmcts/cnp-module-metric-alert"
   location = var.location
 
   app_insights_name  = module.application_insights.name
-  resourcegroup_name = "civil-service-${var.env}"
+  resourcegroup_name = local.resource_group_name
 
   alert_name = "${each.key}JobAborted"
   alert_desc = "Triggers when scheduler ${each.key} in ${var.env} has aborted."
@@ -46,19 +48,19 @@ module "scheduler-aborted-alerts" {
   frequency_in_minutes       = try(each.value.frequency_in_minutes, 30)
   time_window_in_minutes     = try(each.value.time_window_in_minutes, 30)
   severity_level             = 3
-  action_group_name          = values(azurerm_monitor_action_group.civil-service-action-group)[0].name
+  action_group_name          = azurerm_monitor_action_group.civil-service-action-group[each.value.action_group].name
   trigger_threshold_operator = "GreaterThan"
   trigger_threshold          = 0
   common_tags                = var.common_tags
 }
 
 module "scheduler-high-failure-rate-alerts" {
-  for_each = var.monitor_scheduler_alerts
+  for_each = local.enabled_scheduler_alerts
   source   = "git@github.com:hmcts/cnp-module-metric-alert"
   location = var.location
 
   app_insights_name  = module.application_insights.name
-  resourcegroup_name = "civil-service-${var.env}"
+  resourcegroup_name = local.resource_group_name
 
   alert_name = "${each.key}HighFailureRate"
   alert_desc = "Triggers when scheduler ${each.key} in ${var.env} has a high failure rate."
@@ -76,19 +78,19 @@ module "scheduler-high-failure-rate-alerts" {
   frequency_in_minutes       = try(each.value.frequency_in_minutes, 30)
   time_window_in_minutes     = try(each.value.time_window_in_minutes, 30)
   severity_level             = 3
-  action_group_name          = values(azurerm_monitor_action_group.civil-service-action-group)[0].name
+  action_group_name          = azurerm_monitor_action_group.civil-service-action-group[each.value.action_group].name
   trigger_threshold_operator = "GreaterThan"
   trigger_threshold          = 0
   common_tags                = var.common_tags
 }
 
 module "scheduler-job-not-run-alerts" {
-  for_each = var.monitor_scheduler_alerts
+  for_each = local.enabled_scheduler_alerts
   source   = "git@github.com:hmcts/cnp-module-metric-alert"
   location = var.location
 
   app_insights_name  = module.application_insights.name
-  resourcegroup_name = "civil-service-${var.env}"
+  resourcegroup_name = local.resource_group_name
 
   alert_name = "${each.key}JobNotRun"
   alert_desc = "Triggers when scheduler ${each.key} in ${var.env} has not run in the last 26 hours."
@@ -103,7 +105,7 @@ module "scheduler-job-not-run-alerts" {
   frequency_in_minutes       = try(each.value.frequency_in_minutes, 30)
   time_window_in_minutes     = try(each.value.time_window_in_minutes, 30)
   severity_level             = 3
-  action_group_name          = values(azurerm_monitor_action_group.civil-service-action-group)[0].name
+  action_group_name          = azurerm_monitor_action_group.civil-service-action-group[each.value.action_group].name
   trigger_threshold_operator = "LessThan"
   trigger_threshold          = 1
   common_tags                = var.common_tags

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -51,7 +51,7 @@ variable "ccd_service_bus_filter_rule" {
 # Monitor Variables
 #================================================================================================
 variable "monitor_action_group" {
-  type        = map(object({
+  type = map(object({
     short_name = optional(string)
   }))
   default     = {}
@@ -59,7 +59,7 @@ variable "monitor_action_group" {
 }
 
 variable "monitor_scheduler_alerts" {
-  type        = map(object({
+  type = map(object({
     frequency_in_minutes   = optional(number)
     time_window_in_minutes = optional(number)
     enabled                = optional(bool)

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -46,3 +46,20 @@ variable "ccd_service_bus_filter_rule" {
   default     = "jurisdiction_id IN ('CIVIL','civil')"
   description = "SQL filter rule for CCD Events Service Bus Subscription"
 }
+
+#================================================================================================
+# Monitor Variables
+#================================================================================================
+variable "monitor_action_group" {
+  default = {}
+}
+
+variable "monitor_scheduler_alerts" {
+  default = {}
+}
+
+variable "civil_service_alert_slack_email_secret_name" {
+  type        = string
+  description = "The name of the Key Vault secret containing the slack email group"
+  default     = null
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -51,11 +51,22 @@ variable "ccd_service_bus_filter_rule" {
 # Monitor Variables
 #================================================================================================
 variable "monitor_action_group" {
-  default = {}
+  type        = map(object({
+    short_name = optional(string)
+  }))
+  default     = {}
+  description = "Map of monitor action groups to create"
 }
 
 variable "monitor_scheduler_alerts" {
-  default = {}
+  type        = map(object({
+    frequency_in_minutes   = optional(number)
+    time_window_in_minutes = optional(number)
+    enabled                = optional(bool)
+    action_group           = string
+  }))
+  default     = {}
+  description = "Map of scheduler alerts to create, with action_group mapping"
 }
 
 variable "civil_service_alert_slack_email_secret_name" {


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-4392


### Change description ###
Add alerting for scheduled jobs within the civil-service infrastructure for the AAT and Demo environments.

- **Infrastructure Setup**: Added alerting configurations for scheduler jobs using `azurerm_monitor_action_group` and custom metric alert modules (`cnp-module-metric-alert`).
- **Alert Types**: Configured three critical types of alerts for each enabled scheduler:
  - `JobAborted`: Triggers when a job aborts.
  - `HighFailureRate`: Monitors for high failure rates (threshold > 20%).
  - `JobNotRun`: Detects if a job has not executed within the last 26 hours.
- **Slack Integration**: Enabled email-based Slack alerts by integrating with Azure Key Vault secrets for `civil_service_alert_slack_email_secret_name`.
- **Environment Configuration**: Updated `aat.tfvars` and `demo.tfvars` to include these alert definitions and set appropriate alert frequencies.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
