### PR TITLE
DTSPO-30107: grant preview Jenkins MI civil vault access

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -23,6 +23,12 @@ provider "azurerm" {
 }
 
 provider "azurerm" {
+  alias           = "cnp_dev"
+  subscription_id = "1c4f0704-a29e-403d-b719-b90c34ef14c9"
+  features {}
+}
+
+provider "azurerm" {
   features {}
 }
 

--- a/infrastructure/tf-kv-main.tf
+++ b/infrastructure/tf-kv-main.tf
@@ -8,6 +8,16 @@ data "azurerm_user_assigned_identity" "jenkins" {
   resource_group_name = "managed-identities-${var.env}-rg"
 }
 
+data "azurerm_user_assigned_identity" "jenkins-preview" {
+  provider = azurerm.cnp_dev
+
+  # Temporary exception for DTSPO-30107: Civil preview deploys currently read
+  # AAT team secrets because the Jenkins library maps preview vaults to AAT.
+  # Remove once preview secret loading no longer requires AAT vault access.
+  name                = "jenkins-preview-mi"
+  resource_group_name = "managed-identities-preview-rg"
+}
+
 module "key-vault" {
   source                  = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
   name                    = "${var.product}-${var.env}"
@@ -20,4 +30,7 @@ module "key-vault" {
   jenkins_object_id       = data.azurerm_user_assigned_identity.jenkins.principal_id
   common_tags             = var.common_tags
   create_managed_identity = true
+  managed_identity_object_ids = [
+    data.azurerm_user_assigned_identity.jenkins-preview.principal_id
+  ]
 }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

See [DTSPO-30108](https://tools.hmcts.net/jira/browse/DTSPO-30108)

### Change description ###
Jenkins preview deploys currently load AAT team secrets because Jenkins maps preview -> aat; this grants jenkins-preview-mi read-only access until preview secret loading is redesigned.

#### If you're adding a new secret then do the following ####
Run the script in `./bin/set-secret-in-all-vaults <microservice-name>` and paste the output below
This will ensure the secret is in all the vaults it needs to be

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
