### PR TITLE
Create integration test for DEFAULT_JUDGEMENT_GRANTED_SPEC

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/workflow/ccd/DefaultJudgementGrantedSpecWorkflowTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/workflow/ccd/DefaultJudgementGrantedSpecWorkflowTest.java
@@ -1,0 +1,74 @@
+package uk.gov.hmcts.reform.civil.workflow.ccd;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.judgmentonline.JudgmentRTLStatus;
+import uk.gov.hmcts.reform.civil.model.judgmentonline.JudgmentState;
+import uk.gov.hmcts.reform.civil.workflow.WorkflowIntegrationTest;
+import uk.gov.hmcts.reform.civil.workflow.ccd.fixture.DefaultJudgementGrantedSpecFixtures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.hmcts.reform.civil.callback.CaseEvent.DEFAULT_JUDGEMENT_GRANTED_SPEC;
+import static uk.gov.hmcts.reform.civil.callback.CaseEvent.DEFAULT_JUDGEMENT_NON_DIVERGENT_SPEC;
+import static uk.gov.hmcts.reform.civil.enums.YesOrNo.YES;
+
+public class DefaultJudgementGrantedSpecWorkflowTest extends WorkflowIntegrationTest {
+
+    @Test
+    void shouldGrantDefaultJudgmentSuccessfully() throws Exception {
+        CaseData fixture = DefaultJudgementGrantedSpecFixtures.caseData();
+
+        startWorkflow(fixture)
+            .eventId(DEFAULT_JUDGEMENT_GRANTED_SPEC)
+            .aboutToSubmit()
+            .then(result -> {
+                assertThat(result.response().getErrors()).isNullOrEmpty();
+                assertThat(result.response().getState()).isEqualTo(CaseState.All_FINAL_ORDERS_ISSUED.name());
+
+                CaseData updatedCaseData = result.caseData();
+                assertThat(updatedCaseData.getActiveJudgment().getState()).isEqualTo(JudgmentState.ISSUED);
+                assertThat(updatedCaseData.getActiveJudgment().getIssueDate()).isNotNull();
+                assertThat(updatedCaseData.getActiveJudgment().getRtlState()).isEqualTo(JudgmentRTLStatus.ISSUED.getRtlState());
+                assertThat(updatedCaseData.getActiveJudgment().getIsRegisterWithRTL()).isEqualTo(YES);
+
+                assertThat(updatedCaseData.getBusinessProcess().getCamundaEvent()).isEqualTo(
+                    DEFAULT_JUDGEMENT_NON_DIVERGENT_SPEC.name());
+            })
+            .submitted()
+            .then(result -> assertThat(result.submittedResponse()).isNotNull());
+    }
+
+    @Test
+    void shouldReturnErrorWhenCaseNotInJudgmentRequestedState() throws Exception {
+        CaseData fixture = DefaultJudgementGrantedSpecFixtures.caseDataWithWrongState();
+
+        startWorkflow(fixture)
+            .eventId(DEFAULT_JUDGEMENT_GRANTED_SPEC)
+            .aboutToSubmit()
+            .then(result ->
+                      assertThat(result.response().getErrors()).contains(
+                          String.format(
+                              "Event DEFAULT_JUDGEMENT_GRANTED_SPEC: Cannot grant default judgment for case in state %s for caseId %d",
+                              CaseState.CASE_ISSUED,
+                              fixture.getCcdCaseReference()
+                          )
+                      ));
+    }
+
+    @Test
+    void shouldReturnErrorWhenActiveJudgmentIsNull() throws Exception {
+        CaseData fixture = DefaultJudgementGrantedSpecFixtures.caseDataWithNoActiveJudgment();
+
+        startWorkflow(fixture)
+            .eventId(DEFAULT_JUDGEMENT_GRANTED_SPEC)
+            .aboutToSubmit()
+            .then(result ->
+                      assertThat(result.response().getErrors()).contains(
+                          String.format(
+                              "Event DEFAULT_JUDGEMENT_GRANTED_SPEC: Active judgment is null for caseId %d",
+                              fixture.getCcdCaseReference()
+                          )
+                      ));
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/workflow/ccd/fixture/DefaultJudgementGrantedSpecFixtures.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/workflow/ccd/fixture/DefaultJudgementGrantedSpecFixtures.java
@@ -1,0 +1,39 @@
+package uk.gov.hmcts.reform.civil.workflow.ccd.fixture;
+
+import uk.gov.hmcts.reform.civil.enums.CaseState;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.judgmentonline.JudgmentDetails;
+import uk.gov.hmcts.reform.civil.model.judgmentonline.JudgmentState;
+import uk.gov.hmcts.reform.civil.workflow.helper.CaseDataTemplates;
+
+public final class DefaultJudgementGrantedSpecFixtures {
+
+    private static final String CLAIM_ISSUED_TEMPLATE = "claim-issued";
+
+    private DefaultJudgementGrantedSpecFixtures() {
+    }
+
+    public static CaseData caseData() {
+        return CaseDataTemplates.load(CLAIM_ISSUED_TEMPLATE, template -> {
+            CaseDataTemplates.set(template, "ccdState", CaseState.JUDGMENT_REQUESTED);
+            CaseDataTemplates.set(template, "activeJudgment", new JudgmentDetails().setState(JudgmentState.ISSUED));
+            CaseDataTemplates.set(template, "ccdCaseReference", 1234567890123456L);
+        });
+    }
+
+    public static CaseData caseDataWithNoActiveJudgment() {
+        return CaseDataTemplates.load(CLAIM_ISSUED_TEMPLATE, template -> {
+            CaseDataTemplates.set(template, "ccdState", CaseState.JUDGMENT_REQUESTED);
+            CaseDataTemplates.set(template, "activeJudgment", null);
+            CaseDataTemplates.set(template, "ccdCaseReference", 1234567890123456L);
+        });
+    }
+
+    public static CaseData caseDataWithWrongState() {
+        return CaseDataTemplates.load(CLAIM_ISSUED_TEMPLATE, template -> {
+            CaseDataTemplates.set(template, "ccdState", CaseState.CASE_ISSUED);
+            CaseDataTemplates.set(template, "activeJudgment", new JudgmentDetails().setState(JudgmentState.ISSUED));
+            CaseDataTemplates.set(template, "ccdCaseReference", 1234567890123456L);
+        });
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5217


### Change description ###
This PR adds a new integration test suite for `DefaultJudgementGrantedSpecCallbackHandler` to ensure the correct processing of default judgment grants in Specified claims.

### Key Modifications
*   **New Integration Test:** Implemented `DefaultJudgementGrantedSpecWorkflowTest.java` to cover the `DEFAULT_JUDGEMENT_GRANTED_SPEC` event.
    *   **Success Path:** Verifies `JudgmentDetails` updates (state, issue date, RTL status), case state transition to `All_FINAL_ORDERS_ISSUED`, and business process initiation.
    *   **Error Handling:** Added tests for invalid case states and null active judgments.
*   **Test Fixtures:** Created `DefaultJudgementGrantedSpecFixtures.java` to provide consistent `CaseData` for workflow testing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
