### PR TITLE
DTSCCI-5427: Feign-based error handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -349,6 +349,7 @@ def sonarExclusions = [
   "**/config/HttpClientRestConfiguration.java",
   "**/config/HttpClientFeignConfiguration.java",
   "**/config/HttpClientFeignConfigurationTest.java",
+  "**/config/feign/GlobalFeignConfiguration.java",
   "**/aspect/ErrorDecoderTelemetryAspect.java",
   "**/handler/callback/camunda/dashboardnotifications/claimant/CCJRequestedDashboardNotificationHandler.java",
   "**/handler/callback/camunda/dashboardnotifications/claimant/ClaimantCCJResponseNotificationHandler.java",

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/aspect/ErrorDecoderTelemetryAspectIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/aspect/ErrorDecoderTelemetryAspectIntegrationTest.java
@@ -62,7 +62,7 @@ class ErrorDecoderTelemetryAspectIntegrationTest {
                 && "GET".equals(properties.get("httpMethod"))
                 && "504".equals(properties.get("status"))
                 && "true".equals(properties.get("retryable"))
-                && "none".equals(properties.get("retryAfter"))
+                && "0".equals(properties.get("retryAfter"))
                 && "IllegalStateException".equals(properties.get("defaultException"))),
             isNull()
         );

--- a/src/main/java/uk/gov/hmcts/reform/civil/Application.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/Application.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import uk.gov.hmcts.reform.civil.config.feign.GlobalFeignConfiguration;
 
 @SpringBootApplication
 @EnableCamundaRestClient
@@ -21,7 +22,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
     "uk.gov.hmcts.reform.ccd.client",
     "uk.gov.hmcts.reform.cmc",
     "uk.gov.hmcts.reform.hmc"
-})
+}, defaultConfiguration =  GlobalFeignConfiguration.class)
 @SuppressWarnings("HideUtilityClassConstructor") // Spring needs a constructor, its not a utility class
 public class Application {
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/aspect/ErrorDecoderTelemetryAspect.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/aspect/ErrorDecoderTelemetryAspect.java
@@ -11,16 +11,13 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.stereotype.Component;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import static feign.Util.checkNotNull;
-import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.hc.core5.http.Method.isIdempotent;
+import static uk.gov.hmcts.reform.civil.utils.FeignRetryUtils.getRetryAfter;
+import static uk.gov.hmcts.reform.civil.utils.FeignRetryUtils.isRetryable;
+import static uk.gov.hmcts.reform.civil.utils.FeignRetryUtils.isRetryableNonIdempotentMethod;
 
 @Aspect
 @Component
@@ -30,7 +27,6 @@ public class ErrorDecoderTelemetryAspect {
 
     private static final String FEIGN_ERROR_CLASSIFIED_EVENT = "httpclient.feign.error.classified";
     private static final String UNKNOWN = "unknown";
-    public static final String RETRY_AFTER = "Retry-After";
 
     private final TelemetryClient telemetryClient;
 
@@ -55,7 +51,6 @@ public class ErrorDecoderTelemetryAspect {
     private void trackClassification(String methodKey, Response response, Throwable throwable) {
         try {
             Map<String, String> properties = buildClassification(methodKey, response, throwable);
-            log.info("Feign error decoder classification: {}", properties);
             telemetryClient.trackEvent(
                 FEIGN_ERROR_CLASSIFIED_EVENT,
                 properties,
@@ -67,101 +62,26 @@ public class ErrorDecoderTelemetryAspect {
     }
 
     private static Map<String, String> buildClassification(String methodKey, Response response, Throwable throwable) {
-        Request.HttpMethod method = response != null && response.request() != null ? response.request().httpMethod() : null;
+        Request request = response != null ? response.request() : null;
+        Request.HttpMethod method = request != null ? request.httpMethod() : null;
         int status = response != null ? response.status() : -1;
-        boolean idempotent = isIdempotent(method);
-        String retryAfterHeader = getFirstHeader(response, RETRY_AFTER);
-        Long retryAfterEpoch = new RetryAfterDecoder().apply(retryAfterHeader.isBlank() ? null : retryAfterHeader);
-        boolean retryable = throwable instanceof RetryableException || isRetryable(status, idempotent, retryAfterEpoch);
+        long retryAfterEpoch = getRetryAfter(response);
+        boolean idempotent = isIdempotent(method != null ? method.name() : null);
+        boolean retryableNonIdempotent = isRetryableNonIdempotentMethod(methodKey);
+
+        boolean retryable = throwable instanceof RetryableException
+            || isRetryable(status, retryAfterEpoch, idempotent || retryableNonIdempotent);
 
         Map<String, String> properties = new HashMap<>();
         properties.put("methodKey", methodKey != null ? methodKey : UNKNOWN);
         properties.put("httpMethod", method != null ? method.name() : UNKNOWN);
         properties.put("status", status >= 0 ? String.valueOf(status) : UNKNOWN);
-        properties.put("retryAfter", retryAfterEpoch != null ? String.valueOf(retryAfterEpoch) : "none");
+        properties.put("retryAfter", String.valueOf(retryAfterEpoch));
         properties.put("idempotent", String.valueOf(idempotent));
         properties.put("retryable", String.valueOf(retryable));
         properties.put("defaultException", throwable != null ? throwable.getClass().getSimpleName() : UNKNOWN);
 
-        if (throwable instanceof feign.FeignException feignException) {
-            properties.put("feignStatus", String.valueOf(feignException.status()));
-        }
         return properties;
     }
 
-    private static boolean isIdempotent(Request.HttpMethod method) {
-        if (method == null) {
-            return false;
-        }
-        return method == Request.HttpMethod.GET
-            || method == Request.HttpMethod.HEAD
-            || method == Request.HttpMethod.PUT
-            || method == Request.HttpMethod.DELETE
-            || method == Request.HttpMethod.OPTIONS
-            || method == Request.HttpMethod.TRACE;
-    }
-
-    private static boolean isRetryable(int status, boolean idempotent, Long retryAfter) {
-        if (status == 429 || status == 503) {
-            return retryAfter != null || idempotent;
-        }
-        if (status == 408 || status == 502 || status == 504) {
-            return idempotent;
-        }
-
-        return false;
-    }
-
-    private static String getFirstHeader(Response response, String name) {
-        if (response == null || response.headers() == null) {
-            return "";
-        }
-        for (Map.Entry<String, Collection<String>> header : response.headers().entrySet()) {
-            if (header.getKey() != null && header.getKey().equalsIgnoreCase(name) && header.getValue() != null
-                && !header.getValue().isEmpty()) {
-                return header.getValue().iterator().next();
-            }
-        }
-        return "";
-    }
-
-    static class RetryAfterDecoder {
-
-        private final DateTimeFormatter dateTimeFormatter;
-
-        RetryAfterDecoder() {
-            this(RFC_1123_DATE_TIME);
-        }
-
-        RetryAfterDecoder(DateTimeFormatter dateTimeFormatter) {
-            this.dateTimeFormatter = checkNotNull(dateTimeFormatter, "dateTimeFormatter");
-        }
-
-        protected long currentTimeMillis() {
-            return System.currentTimeMillis();
-        }
-
-        /**
-         * returns an epoch millisecond that corresponds to the first time a request can be retried.
-         *
-         * @param retryAfter String in <a href="https://tools.ietf.org/html/rfc2616#section-14.37"
-         *     >Retry-After format</a>
-         */
-        @SuppressWarnings("java:S6353")
-        public Long apply(String retryAfter) {
-            if (retryAfter == null) {
-                return null;
-            }
-            if (retryAfter.matches("^[0-9]+\\.?0*$")) {
-                retryAfter = retryAfter.replaceAll("\\.0*$", "");
-                long deltaMillis = SECONDS.toMillis(Long.parseLong(retryAfter));
-                return currentTimeMillis() + deltaMillis;
-            }
-            try {
-                return ZonedDateTime.parse(retryAfter, dateTimeFormatter).toInstant().toEpochMilli();
-            } catch (NullPointerException | DateTimeParseException ignored) {
-                return null;
-            }
-        }
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/config/feign/GlobalErrorDecoder.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/feign/GlobalErrorDecoder.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.civil.config.feign;
+
+import feign.Request;
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
+
+import static org.apache.hc.core5.http.Method.isIdempotent;
+import static uk.gov.hmcts.reform.civil.utils.FeignRetryUtils.isRetryable;
+import static uk.gov.hmcts.reform.civil.utils.FeignRetryUtils.isRetryableNonIdempotentMethod;
+
+public class GlobalErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder delegate;
+
+    public GlobalErrorDecoder() {
+        this(new Default());
+    }
+
+    public GlobalErrorDecoder(ErrorDecoder errorDecoder) {
+        this.delegate = errorDecoder;
+    }
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+        Exception exception = delegate.decode(methodKey, response);
+        return mapToRetryableExceptionIfEligible(methodKey, response, exception);
+    }
+
+    private static Exception mapToRetryableExceptionIfEligible(String methodKey, Response response, Exception ex) {
+        if (ex instanceof RetryableException) {
+            return ex;
+        }
+
+        Request request = response != null ? response.request() : null;
+        if (request == null) {
+            return ex;
+        }
+
+        Request.HttpMethod method =  request.httpMethod();
+        int status = response.status();
+        boolean idempotent = isIdempotent(method != null ? method.name() : null);
+        boolean retryableNonIdempotent = isRetryableNonIdempotentMethod(methodKey);
+        if (!isRetryable(status, 0, idempotent || retryableNonIdempotent)) {
+            return ex;
+        }
+
+        String message = ex != null && ex.getMessage() != null ? ex.getMessage() : "Retryable Feign exception";
+        return new RetryableException(status, message, method, ex, (Long) null, request);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/config/feign/GlobalFeignConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/feign/GlobalFeignConfiguration.java
@@ -1,0 +1,35 @@
+package uk.gov.hmcts.reform.civil.config.feign;
+
+import feign.ExceptionPropagationPolicy;
+import feign.Retryer;
+import feign.codec.ErrorDecoder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GlobalFeignConfiguration {
+
+    @Value("${feign.initialBackoff:500}")
+    private int initialBackoff;
+    @Value("${feign.maxBackoff:5000}")
+    private int maxBackoff;
+    @Value("${feign.maxAttempts:3}")
+    private int maxAttempts;
+
+    @Bean
+    public ErrorDecoder feignErrorDecoder() {
+        return new GlobalErrorDecoder();
+    }
+
+    @Bean
+    public Retryer feignRetryer() {
+        return new Retryer.Default(initialBackoff, maxBackoff, maxAttempts);
+    }
+
+    @Bean
+    public ExceptionPropagationPolicy exceptionPropagationPolicy() {
+        return ExceptionPropagationPolicy.UNWRAP;
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/FeignRetryUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/FeignRetryUtils.java
@@ -1,0 +1,91 @@
+package uk.gov.hmcts.reform.civil.utils;
+
+import feign.Response;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Collection;
+import java.util.Set;
+
+import static feign.Util.checkNotNull;
+import static java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class FeignRetryUtils {
+
+    public static final String RETRY_AFTER = "Retry-After";
+
+    private static final Set<String> RETRYABLE_NON_IDEMPOTENT_METHOD_KEYS = Set.of(
+        "CoreCaseDataApi#searchCases(String,String,String,String)"
+    );
+
+    private FeignRetryUtils() {
+        //Utility class
+    }
+
+    public static boolean isRetryable(int status, long retryAfter, boolean idempotent) {
+        if (status == 429 || status == 503) {
+            return idempotent || retryAfter > 0;
+        }
+        if (status == 408 || status == 502 || status == 504) {
+            return idempotent;
+        }
+        return false;
+    }
+
+    public static boolean isRetryableNonIdempotentMethod(String methodKey) {
+        return methodKey != null && RETRYABLE_NON_IDEMPOTENT_METHOD_KEYS.contains(methodKey);
+    }
+
+    public static long getRetryAfter(Response response) {
+        if (response == null || response.headers() == null) {
+            return 0L;
+        }
+        Collection<String> values = response.headers().get(RETRY_AFTER);
+        if (values == null || values.isEmpty()) {
+            return 0L;
+        }
+        return new RetryAfterDecoder().apply(values.iterator().next());
+    }
+
+    static class RetryAfterDecoder {
+
+        private final DateTimeFormatter dateTimeFormatter;
+
+        RetryAfterDecoder() {
+            this(RFC_1123_DATE_TIME);
+        }
+
+        RetryAfterDecoder(DateTimeFormatter dateTimeFormatter) {
+            this.dateTimeFormatter = checkNotNull(dateTimeFormatter, "dateTimeFormatter");
+        }
+
+        protected long currentTimeMillis() {
+            return System.currentTimeMillis();
+        }
+
+        /**
+         * returns an epoch millisecond that corresponds to the first time a request can be retried.
+         *
+         * @param retryAfter String in <a href="https://tools.ietf.org/html/rfc2616#section-14.37"
+         *     >Retry-After format</a>
+         */
+        @SuppressWarnings("java:S6353")
+        public long apply(String retryAfter) {
+            if (retryAfter == null || retryAfter.isBlank()) {
+                return 0L;
+            }
+            if (retryAfter.matches("^[0-9]+\\.?0*$")) {
+                retryAfter = retryAfter.replaceAll("\\.0*$", "");
+                long deltaMillis = SECONDS.toMillis(Long.parseLong(retryAfter));
+                return currentTimeMillis() + deltaMillis;
+            }
+            try {
+                return ZonedDateTime.parse(retryAfter, dateTimeFormatter).toInstant().toEpochMilli();
+            } catch (NullPointerException | DateTimeParseException ignored) {
+                return 0L;
+            }
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/config/feign/GlobalErrorDecoderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/config/feign/GlobalErrorDecoderTest.java
@@ -1,0 +1,212 @@
+package uk.gov.hmcts.reform.civil.config.feign;
+
+import feign.Request;
+import feign.Response;
+import feign.RetryableException;
+import feign.codec.ErrorDecoder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class GlobalErrorDecoderTest {
+
+    private GlobalErrorDecoder globalErrorDecoder;
+
+    @Mock
+    private ErrorDecoder delegate;
+
+    @BeforeEach
+    void setUp() {
+        globalErrorDecoder = new GlobalErrorDecoder(delegate);
+    }
+
+    @Test
+    void shouldCallDelegateDecode() {
+        Response response = Response.builder()
+            .status(400)
+            .reason("Bad Request")
+            .request(mock(Request.class))
+            .build();
+        String methodKey = "someMethod";
+        Exception expectedException = new Exception("Delegate Exception");
+        when(delegate.decode(methodKey, response)).thenReturn(expectedException);
+
+        Exception result = globalErrorDecoder.decode(methodKey, response);
+
+        assertThat(result).isEqualTo(expectedException);
+        verify(delegate).decode(methodKey, response);
+    }
+
+    @Test
+    void shouldReturnOriginalExceptionIfAlreadyRetryable() {
+        RetryableException retryableException = mock(RetryableException.class);
+        when(delegate.decode(anyString(), any())).thenReturn(retryableException);
+
+        Exception result = globalErrorDecoder.decode("method", mock(Response.class));
+
+        assertThat(result).isEqualTo(retryableException);
+    }
+
+    @Test
+    void shouldReturnOriginalExceptionIfResponseIsNull() {
+        Exception originalException = new Exception("error");
+        when(delegate.decode(anyString(), any())).thenReturn(originalException);
+
+        Exception result = globalErrorDecoder.decode("method", null);
+
+        assertThat(result).isEqualTo(originalException);
+    }
+
+    @Test
+    void shouldReturnOriginalExceptionIfRequestIsNull() {
+        Response response = mock(Response.class);
+        when(response.request()).thenReturn(null);
+        Exception originalException = new Exception("error");
+        when(delegate.decode(anyString(), any())).thenReturn(originalException);
+
+        Exception result = globalErrorDecoder.decode("method", response);
+
+        assertThat(result).isEqualTo(originalException);
+    }
+
+    @Test
+    void shouldMapToRetryableExceptionForIdempotentMethodAndRetryableStatus() {
+        Request request = Request.create(Request.HttpMethod.GET, "url", Collections.emptyMap(), null, null, null);
+        Response response = Response.builder()
+            .status(503)
+            .request(request)
+            .build();
+        Exception originalException = new Exception("original error");
+        when(delegate.decode(anyString(), any())).thenReturn(originalException);
+
+        Exception result = globalErrorDecoder.decode("method", response);
+
+        assertThat(result).isInstanceOf(RetryableException.class);
+        RetryableException retryableException = (RetryableException) result;
+        assertThat(retryableException.status()).isEqualTo(503);
+        assertThat(retryableException.getMessage()).isEqualTo("original error");
+        assertThat(retryableException.getCause()).isEqualTo(originalException);
+        assertThat(retryableException.method()).isEqualTo(Request.HttpMethod.GET);
+    }
+
+    @Test
+    void shouldMapToRetryableExceptionForNonIdempotentButAllowedMethod() {
+        // CoreCaseDataApi#searchCases(String,String,String,String) is allowed in FeignRetryUtils
+        String methodKey = "CoreCaseDataApi#searchCases(String,String,String,String)";
+        Request request = Request.create(Request.HttpMethod.POST, "url", Collections.emptyMap(), null, null, null);
+        Response response = Response.builder()
+            .status(429)
+            .request(request)
+            .build();
+        when(delegate.decode(anyString(), any())).thenReturn(new Exception("too many requests"));
+
+        Exception result = globalErrorDecoder.decode(methodKey, response);
+
+        assertThat(result).isInstanceOf(RetryableException.class);
+        assertThat(((RetryableException) result).status()).isEqualTo(429);
+    }
+
+    @Test
+    void shouldNotMapToRetryableExceptionForNonIdempotentMethodAndNotAllowedMethod() {
+        String methodKey = "Other#method";
+        Request request = Request.create(Request.HttpMethod.POST, "url", Collections.emptyMap(), null, null, null);
+        Response response = Response.builder()
+            .status(503)
+            .request(request)
+            .build();
+        Exception originalException = new Exception("error");
+        when(delegate.decode(anyString(), any())).thenReturn(originalException);
+
+        Exception result = globalErrorDecoder.decode(methodKey, response);
+
+        assertThat(result).isEqualTo(originalException);
+    }
+
+    @Test
+    void shouldNotMapToRetryableExceptionForNonRetryableStatus() {
+        Request request = Request.create(Request.HttpMethod.GET, "url", Collections.emptyMap(), null, null, null);
+        Response response = Response.builder()
+            .status(400)
+            .request(request)
+            .build();
+        Exception originalException = new Exception("error");
+        when(delegate.decode(anyString(), any())).thenReturn(originalException);
+
+        Exception result = globalErrorDecoder.decode("method", response);
+
+        assertThat(result).isEqualTo(originalException);
+    }
+
+    @Test
+    void shouldUseDefaultMessageIfExceptionOrMessageIsNull() {
+        Request request = Request.create(Request.HttpMethod.GET, "url", Collections.emptyMap(), null, null, null);
+        Response response = Response.builder()
+            .status(503)
+            .request(request)
+            .build();
+        when(delegate.decode(anyString(), any())).thenReturn(null);
+
+        Exception result = globalErrorDecoder.decode("method", response);
+
+        assertThat(result).isInstanceOf(RetryableException.class);
+        assertThat(result.getMessage()).isEqualTo("Retryable Feign exception");
+    }
+
+    @Test
+    void shouldHandleNullHttpMethod() {
+        Request request = mock(Request.class);
+        when(request.httpMethod()).thenReturn(null);
+        Response response = Response.builder()
+            .status(503)
+            .request(request)
+            .build();
+        Exception originalException = new Exception("error");
+        when(delegate.decode(anyString(), any())).thenReturn(originalException);
+
+        Exception result = globalErrorDecoder.decode("methodKey", response);
+
+        // if method is null, idempotent will be false (HC Method.isIdempotent(null) is false)
+        // unless methodKey is retryableNonIdempotent
+        assertThat(result).isEqualTo(originalException);
+    }
+
+    @Test
+    void shouldHandleNullHttpMethodButAllowedMethodKey() {
+        String methodKey = "CoreCaseDataApi#searchCases(String,String,String,String)";
+        Request request = mock(Request.class);
+        when(request.httpMethod()).thenReturn(null);
+        Response response = Response.builder()
+            .status(429)
+            .request(request)
+            .build();
+        when(delegate.decode(anyString(), any())).thenReturn(new Exception("error"));
+
+        Exception result = globalErrorDecoder.decode(methodKey, response);
+
+        assertThat(result).isInstanceOf(RetryableException.class);
+    }
+
+    @Test
+    void shouldWorkWithDefaultConstructor() {
+        GlobalErrorDecoder decoder = new GlobalErrorDecoder();
+        Response response = Response.builder()
+            .status(404)
+            .request(Request.create(Request.HttpMethod.GET, "url", Collections.emptyMap(), null, null, null))
+            .build();
+        
+        Exception result = decoder.decode("method", response);
+        assertThat(result).isNotNull();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/config/feign/GlobalFeignConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/config/feign/GlobalFeignConfigurationTest.java
@@ -1,0 +1,59 @@
+package uk.gov.hmcts.reform.civil.config.feign;
+
+import feign.ExceptionPropagationPolicy;
+import feign.Retryer;
+import feign.codec.ErrorDecoder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GlobalFeignConfigurationTest {
+
+    private GlobalFeignConfiguration configuration;
+
+    @BeforeEach
+    void setUp() {
+        configuration = new GlobalFeignConfiguration();
+        ReflectionTestUtils.setField(configuration, "initialBackoff", 500);
+        ReflectionTestUtils.setField(configuration, "maxBackoff", 5000);
+        ReflectionTestUtils.setField(configuration, "maxAttempts", 3);
+    }
+
+    @Test
+    void shouldReturnFeignErrorDecoder() {
+        ErrorDecoder decoder = configuration.feignErrorDecoder();
+        assertThat(decoder).isInstanceOf(GlobalErrorDecoder.class);
+    }
+
+    @Test
+    void shouldReturnFeignRetryer() {
+        Retryer retryer = configuration.feignRetryer();
+        assertThat(retryer).isInstanceOf(Retryer.Default.class);
+        
+        assertThat(ReflectionTestUtils.getField(retryer, "period")).isEqualTo(500L);
+        assertThat(ReflectionTestUtils.getField(retryer, "maxPeriod")).isEqualTo(5000L);
+        assertThat(ReflectionTestUtils.getField(retryer, "maxAttempts")).isEqualTo(3);
+    }
+
+    @Test
+    void shouldReturnFeignRetryerWithCustomValues() {
+        ReflectionTestUtils.setField(configuration, "initialBackoff", 1000);
+        ReflectionTestUtils.setField(configuration, "maxBackoff", 10000);
+        ReflectionTestUtils.setField(configuration, "maxAttempts", 5);
+
+        Retryer retryer = configuration.feignRetryer();
+        assertThat(retryer).isInstanceOf(Retryer.Default.class);
+
+        assertThat(ReflectionTestUtils.getField(retryer, "period")).isEqualTo(1000L);
+        assertThat(ReflectionTestUtils.getField(retryer, "maxPeriod")).isEqualTo(10000L);
+        assertThat(ReflectionTestUtils.getField(retryer, "maxAttempts")).isEqualTo(5);
+    }
+
+    @Test
+    void shouldReturnExceptionPropagationPolicy() {
+        ExceptionPropagationPolicy policy = configuration.exceptionPropagationPolicy();
+        assertThat(policy).isEqualTo(ExceptionPropagationPolicy.UNWRAP);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/FeignRetryUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/FeignRetryUtilsTest.java
@@ -1,0 +1,156 @@
+package uk.gov.hmcts.reform.civil.utils;
+
+import feign.Response;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FeignRetryUtilsTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "429, 0, true, true",
+        "429, 100, false, true",
+        "429, 0, false, false",
+        "503, 0, true, true",
+        "503, 100, false, true",
+        "503, 0, false, false",
+        "408, 0, true, true",
+        "408, 0, false, false",
+        "502, 0, true, true",
+        "502, 0, false, false",
+        "504, 0, true, true",
+        "504, 0, false, false",
+        "400, 100, true, false",
+        "500, 100, true, false"
+    })
+    void shouldReturnCorrectRetryableStatus(int status, long retryAfter, boolean idempotent, boolean expected) {
+        assertThat(FeignRetryUtils.isRetryable(status, retryAfter, idempotent)).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnTrueForRetryableNonIdempotentMethod() {
+        assertThat(FeignRetryUtils.isRetryableNonIdempotentMethod("CoreCaseDataApi#searchCases(String,String,String,String)"))
+            .isTrue();
+    }
+
+    @Test
+    void shouldReturnFalseForOtherMethods() {
+        assertThat(FeignRetryUtils.isRetryableNonIdempotentMethod("OtherApi#method()"))
+            .isFalse();
+        assertThat(FeignRetryUtils.isRetryableNonIdempotentMethod(null))
+            .isFalse();
+    }
+
+    @Nested
+    class GetRetryAfter {
+        @Test
+        void shouldReturnZeroWhenResponseIsNull() {
+            assertThat(FeignRetryUtils.getRetryAfter(null)).isZero();
+        }
+
+        @Test
+        void shouldReturnZeroWhenHeadersAreNull() {
+            Response response = mock(Response.class);
+            when(response.headers()).thenReturn(null);
+            assertThat(FeignRetryUtils.getRetryAfter(response)).isZero();
+        }
+
+        @Test
+        void shouldReturnZeroWhenRetryAfterHeaderIsMissing() {
+            Response response = mock(Response.class);
+            when(response.headers()).thenReturn(Collections.emptyMap());
+            assertThat(FeignRetryUtils.getRetryAfter(response)).isZero();
+        }
+
+        @Test
+        void shouldReturnRetryAfterValueInSeconds() {
+            Response response = mock(Response.class);
+            Map<String, Collection<String>> headers = Map.of(FeignRetryUtils.RETRY_AFTER, Collections.singletonList("30"));
+            when(response.headers()).thenReturn(headers);
+
+            long result = FeignRetryUtils.getRetryAfter(response);
+            // It should be roughly currentTime + 30s
+            assertThat(result).isGreaterThan(System.currentTimeMillis());
+        }
+
+        @Test
+        void shouldReturnRetryAfterValueInDateTime() {
+            Response response = mock(Response.class);
+            String dateStr = "Fri, 31 Dec 2021 23:59:59 GMT";
+            Map<String, Collection<String>> headers = Map.of(FeignRetryUtils.RETRY_AFTER, Collections.singletonList(dateStr));
+            when(response.headers()).thenReturn(headers);
+
+            long expectedEpoch = ZonedDateTime.parse(dateStr, DateTimeFormatter.RFC_1123_DATE_TIME).toInstant().toEpochMilli();
+            assertThat(FeignRetryUtils.getRetryAfter(response)).isEqualTo(expectedEpoch);
+        }
+
+        @Test
+        void shouldReturnFirstValueWhenMultipleHeadersPresent() {
+            Response response = mock(Response.class);
+            Map<String, Collection<String>> headers = Map.of(FeignRetryUtils.RETRY_AFTER, List.of("30", "60"));
+            when(response.headers()).thenReturn(headers);
+
+            long result = FeignRetryUtils.getRetryAfter(response);
+            assertThat(result).isGreaterThan(System.currentTimeMillis());
+        }
+    }
+
+    @Nested
+    class RetryAfterDecoderTest {
+        @Test
+        void shouldHandleNullOrBlank() {
+            FeignRetryUtils.RetryAfterDecoder decoder = new FeignRetryUtils.RetryAfterDecoder();
+            assertThat(decoder.apply(null)).isZero();
+            assertThat(decoder.apply("")).isZero();
+            assertThat(decoder.apply("  ")).isZero();
+        }
+
+        @Test
+        void shouldHandleInvalidFormat() {
+            FeignRetryUtils.RetryAfterDecoder decoder = new FeignRetryUtils.RetryAfterDecoder();
+            assertThat(decoder.apply("invalid")).isZero();
+        }
+
+        static class TestDecoder extends FeignRetryUtils.RetryAfterDecoder {
+            @Override
+            protected long currentTimeMillis() {
+                return 1000L;
+            }
+        }
+
+        @Test
+        void shouldHandleDecimalSeconds() {
+            FeignRetryUtils.RetryAfterDecoder decoder = new TestDecoder();
+            assertThat(decoder.apply("30.0")).isEqualTo(31000L);
+            assertThat(decoder.apply("30")).isEqualTo(31000L);
+        }
+
+        @Test
+        void shouldHandleMalformedDecimal() {
+            FeignRetryUtils.RetryAfterDecoder decoder = new FeignRetryUtils.RetryAfterDecoder();
+            assertThat(decoder.apply("30.0.0")).isZero();
+        }
+
+        @Test
+        void shouldHandleCustomDateTimeFormatter() {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z");
+            FeignRetryUtils.RetryAfterDecoder decoder = new FeignRetryUtils.RetryAfterDecoder(formatter);
+            String dateStr = "2021-12-31 23:59:59 GMT";
+            long expectedEpoch = ZonedDateTime.parse(dateStr, formatter).toInstant().toEpochMilli();
+            assertThat(decoder.apply(dateStr)).isEqualTo(expectedEpoch);
+        }
+    }
+}


### PR DESCRIPTION
…hods, configure global retryer, and enhance error decoder

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5427
https://tools.hmcts.net/jira/browse/DTSCCI-5556

### Change description ###
Added GlobalFeignConfiguration to register shared Feign components.
Added GlobalErrorDecoder to convert eligible Feign exceptions into RetryableException.
Enabled ExceptionPropagationPolicy.UNWRAP so Feign exceptions are propagated in the expected form for downstream handling.
Added support for retrying approved non-idempotent method keys where the operation is safe to retry

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
