### PR TITLE
Dtscci 5622 paginated search

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
@@ -109,18 +109,6 @@ public class JudgementBufferSchedulerITest {
         coreCaseDataApiMockHelper.verifySubmitEvent(51);
     }
 
-    @Test
-    void shouldNotExecuteJudgementBufferSchedulerWhenDisabled() {
-        // Given
-        when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(false);
-
-        // When
-        scheduler.runScheduledTask();
-
-        // Then
-        verify(telemetryService, org.mockito.Mockito.never()).trackEvent(eq("JudgementBufferJobStarted"), anyMap());
-    }
-
     private List<CaseDetails> createCaseDetailsBatch(int size) {
         return rangeClosed(1, size)
             .mapToObj(i -> CaseDetailsBuilder.builder().id((long) i).data(Map.of()).build())

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.civil.scheduler;
 
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,11 +23,11 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.stream.IntStream.rangeClosed;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.civil.service.search.JudgementBufferExpiredSearchService.PAGE_SIZE;
 
 @ActiveProfiles("integration-test")
 @SpringBootTest(classes = {Application.class, TestIdamConfiguration.class, CoreCaseDataApiMockHelperConfiguration.class}, properties = {
@@ -38,7 +37,6 @@ import static org.mockito.Mockito.when;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class JudgementBufferSchedulerITest {
 
-    private static final int PAGE_SIZE = 50;
     private static final Long CASE_ID = 123L;
 
     @Autowired
@@ -63,7 +61,8 @@ public class JudgementBufferSchedulerITest {
     void shouldExecuteJudgementBufferScheduler() {
         // Given
         String caseIdString = CASE_ID.toString();
-        CaseDetails caseDetails = CaseDetailsBuilder.builder().atStateJudgmentRequested().id(CASE_ID).build();
+        CaseDetails caseDetails = CaseDetailsBuilder.builder().atStateJudgmentRequested().id(CASE_ID)
+            .build();
         SearchResult page1 = SearchResult.builder().total(1).cases(List.of(caseDetails)).build();
         StartEventResponse startEventResponse = StartEventResponse.builder().eventId(caseIdString).caseDetails(
             caseDetails).build();

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.scheduler;
 
+import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +21,10 @@ import uk.gov.hmcts.test.config.CoreCaseDataApiMockHelperConfiguration;
 import uk.gov.hmcts.test.helper.CoreCaseDataApiMockHelper;
 
 import java.util.List;
+import java.util.Map;
 
+import static java.util.stream.IntStream.rangeClosed;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -31,9 +35,10 @@ import static org.mockito.Mockito.when;
     "test.id=JudgementBufferSchedulerITest",
     "scheduler.judgementBuffer.enabled=true"
 })
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class JudgementBufferSchedulerITest {
 
+    private static final int PAGE_SIZE = 50;
     private static final Long CASE_ID = 123L;
 
     @Autowired
@@ -59,11 +64,11 @@ public class JudgementBufferSchedulerITest {
         // Given
         String caseIdString = CASE_ID.toString();
         CaseDetails caseDetails = CaseDetailsBuilder.builder().atStateJudgmentRequested().id(CASE_ID).build();
-        SearchResult searchResult = SearchResult.builder().total(1).cases(List.of(caseDetails)).build();
+        SearchResult page1 = SearchResult.builder().total(1).cases(List.of(caseDetails)).build();
         StartEventResponse startEventResponse = StartEventResponse.builder().eventId(caseIdString).caseDetails(
             caseDetails).build();
 
-        coreCaseDataApiMockHelper.mockElasticSearchResult(searchResult);
+        coreCaseDataApiMockHelper.mockElasticSearchResultPaginated(page1);
         coreCaseDataApiMockHelper.mockStartEvent(caseIdString, startEventResponse);
         coreCaseDataApiMockHelper.mockSubmitEvent(caseIdString, caseDetails);
 
@@ -73,6 +78,53 @@ public class JudgementBufferSchedulerITest {
         // Then
         verify(telemetryService).trackEvent(eq("JudgementBufferJobStarted"), anyMap());
         verify(telemetryService).trackEvent(eq("JudgementBufferJobCompleted"), anyMap());
-        coreCaseDataApiMockHelper.verifySubmitEvent();
+        coreCaseDataApiMockHelper.verifySubmitEvent(1);
+    }
+
+    @Test
+    void shouldExecuteJudgementBufferSchedulerWithPagination() {
+        // Given
+        // Create 50 cases for the first page to test pagination
+        List<CaseDetails> page1Cases = createCaseDetailsBatch(PAGE_SIZE);
+        CaseDetails case51 = CaseDetailsBuilder.builder().id(51L).data(Map.of()).build();
+
+        SearchResult page1 = SearchResult.builder().total(51).cases(page1Cases).build();
+        SearchResult page2 = SearchResult.builder().total(51).cases(List.of(case51)).build();
+
+        coreCaseDataApiMockHelper.mockElasticSearchResultPaginated(page1, page2);
+
+        StartEventResponse startEventResponse = StartEventResponse.builder()
+            .eventId("eventId")
+            .caseDetails(CaseDetails.builder().id(1L).data(Map.of()).build())
+            .build();
+        // Mock start and submit events for all 51 cases
+        coreCaseDataApiMockHelper.mockStartEventAnyCase(startEventResponse);
+        coreCaseDataApiMockHelper.mockSubmitEventAnyCase(CaseDetailsBuilder.builder().id(1L).data(Map.of()).build());
+
+        // When
+        scheduler.runScheduledTask();
+
+        // Then
+        verify(telemetryService).trackEvent(eq("JudgementBufferJobStarted"), anyMap());
+        verify(telemetryService).trackEvent(eq("JudgementBufferJobCompleted"), anyMap());
+        coreCaseDataApiMockHelper.verifySubmitEvent(51);
+    }
+
+    @Test
+    void shouldNotExecuteJudgementBufferSchedulerWhenDisabled() {
+        // Given
+        when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(false);
+
+        // When
+        scheduler.runScheduledTask();
+
+        // Then
+        verify(telemetryService, org.mockito.Mockito.never()).trackEvent(eq("JudgementBufferJobStarted"), anyMap());
+    }
+
+    private List<CaseDetails> createCaseDetailsBatch(int size) {
+        return rangeClosed(1, size)
+            .mapToObj(i -> CaseDetailsBuilder.builder().id((long) i).data(Map.of()).build())
+            .toList();
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
@@ -27,12 +27,12 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.hmcts.reform.civil.service.search.JudgementBufferExpiredSearchService.PAGE_SIZE;
 
 @ActiveProfiles("integration-test")
 @SpringBootTest(classes = {Application.class, TestIdamConfiguration.class, CoreCaseDataApiMockHelperConfiguration.class}, properties = {
     "test.id=JudgementBufferSchedulerITest",
-    "scheduler.judgementBuffer.enabled=true"
+    "scheduler.judgementBuffer.enabled=true",
+    "search.judgementbuffer.pageSize=50"
 })
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class JudgementBufferSchedulerITest {
@@ -84,7 +84,7 @@ public class JudgementBufferSchedulerITest {
     void shouldExecuteJudgementBufferSchedulerWithPagination() {
         // Given
         // Create 50 cases for the first page to test pagination
-        List<CaseDetails> page1Cases = createCaseDetailsBatch(PAGE_SIZE);
+        List<CaseDetails> page1Cases = createCaseDetailsBatch(50);
         CaseDetails case51 = CaseDetailsBuilder.builder().id(51L).data(Map.of()).build();
 
         SearchResult page1 = SearchResult.builder().total(51).cases(page1Cases).build();

--- a/src/integrationTest/java/uk/gov/hmcts/test/helper/CoreCaseDataApiMockHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/test/helper/CoreCaseDataApiMockHelper.java
@@ -13,6 +13,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.CaseDefinitionConstants.CASE_TYPE;
@@ -43,22 +44,36 @@ public class CoreCaseDataApiMockHelper {
         when(authTokenGenerator.generate()).thenReturn(GENERATED_TOKEN);
     }
 
-    public void mockElasticSearchResult(SearchResult searchResult) {
-        when(coreCaseDataApi.searchCases(eq(ACCESS_TOKEN), eq(GENERATED_TOKEN), eq(CASE_TYPE), any(String.class)))
-            .thenReturn(searchResult);
+
+    public void mockElasticSearchResultPaginated(SearchResult searchResult, SearchResult... nextSearchResults) {
+        when(coreCaseDataApi.searchCases(any(), any(), any(), any()))
+            .thenReturn(searchResult, nextSearchResults);
     }
 
     public void mockStartEvent(String caseIdString, StartEventResponse startEventResponse) {
         when(coreCaseDataApi.startEventForCaseWorker(
-            ACCESS_TOKEN,
-            GENERATED_TOKEN,
-            USER_ID,
-            JURISDICTION,
-            CASE_TYPE,
-            caseIdString,
-            DEFAULT_JUDGEMENT_GRANTED_SPEC.name()
+            eq(ACCESS_TOKEN),
+            eq(GENERATED_TOKEN),
+            eq(USER_ID),
+            eq(JURISDICTION),
+            eq(CASE_TYPE),
+            eq(caseIdString),
+            eq(DEFAULT_JUDGEMENT_GRANTED_SPEC.name())
         )).thenReturn(startEventResponse);
     }
+
+    public void mockStartEventAnyCase(StartEventResponse startEventResponse) {
+        when(coreCaseDataApi.startEventForCaseWorker(
+            eq(ACCESS_TOKEN),
+            eq(GENERATED_TOKEN),
+            eq(USER_ID),
+            eq(JURISDICTION),
+            eq(CASE_TYPE),
+            any(String.class),
+            eq(DEFAULT_JUDGEMENT_GRANTED_SPEC.name())
+        )).thenReturn(startEventResponse);
+    }
+
 
     public void mockSubmitEvent(String caseIdString, CaseDetails caseDetails) {
         when(coreCaseDataApi.submitEventForCaseWorker(
@@ -73,8 +88,8 @@ public class CoreCaseDataApiMockHelper {
         )).thenReturn(caseDetails);
     }
 
-    public void verifySubmitEvent() {
-        verify(coreCaseDataApi).submitEventForCaseWorker(
+    public void mockSubmitEventAnyCase(CaseDetails caseDetails) {
+        when(coreCaseDataApi.submitEventForCaseWorker(
             eq(ACCESS_TOKEN),
             eq(GENERATED_TOKEN),
             eq(USER_ID),
@@ -83,6 +98,24 @@ public class CoreCaseDataApiMockHelper {
             any(String.class),
             eq(true),
             any(CaseDataContent.class)
+        )).thenReturn(caseDetails);
+    }
+
+
+    public void verifySubmitEvent() {
+        verifySubmitEvent(1);
+    }
+
+    public void verifySubmitEvent(int expectedCount) {
+        verify(coreCaseDataApi, org.mockito.Mockito.times(expectedCount)).submitEventForCaseWorker(
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            any(),
+            org.mockito.ArgumentMatchers.anyBoolean(),
+            any()
         );
     }
 }

--- a/src/integrationTest/java/uk/gov/hmcts/test/helper/CoreCaseDataApiMockHelper.java
+++ b/src/integrationTest/java/uk/gov/hmcts/test/helper/CoreCaseDataApiMockHelper.java
@@ -13,7 +13,6 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.CaseDefinitionConstants.CASE_TYPE;
@@ -44,7 +43,6 @@ public class CoreCaseDataApiMockHelper {
         when(authTokenGenerator.generate()).thenReturn(GENERATED_TOKEN);
     }
 
-
     public void mockElasticSearchResultPaginated(SearchResult searchResult, SearchResult... nextSearchResults) {
         when(coreCaseDataApi.searchCases(any(), any(), any(), any()))
             .thenReturn(searchResult, nextSearchResults);
@@ -74,7 +72,6 @@ public class CoreCaseDataApiMockHelper {
         )).thenReturn(startEventResponse);
     }
 
-
     public void mockSubmitEvent(String caseIdString, CaseDetails caseDetails) {
         when(coreCaseDataApi.submitEventForCaseWorker(
             eq(ACCESS_TOKEN),
@@ -99,11 +96,6 @@ public class CoreCaseDataApiMockHelper {
             eq(true),
             any(CaseDataContent.class)
         )).thenReturn(caseDetails);
-    }
-
-
-    public void verifySubmitEvent() {
-        verifySubmitEvent(1);
     }
 
     public void verifySubmitEvent(int expectedCount) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/search/PaginatedQuery.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/search/PaginatedQuery.java
@@ -18,19 +18,14 @@ public class PaginatedQuery {
     private final String sortField;
 
     public PaginatedQuery(QueryBuilder queryBuilder, List<String> dataToReturn, int startIndex,
-                          boolean initialSearch, String searchAfterValue) {
-        this(queryBuilder, dataToReturn, startIndex, initialSearch, searchAfterValue, 10, "reference.keyword");
-    }
-
-    public PaginatedQuery(QueryBuilder queryBuilder, List<String> dataToReturn, int startIndex,
-                          boolean initialSearch, String searchAfterValue, int pageSize, String sortField) {
+                          boolean initialSearch, String searchAfterValue, int pageSize) {
         this.queryBuilder = queryBuilder;
         this.dataToReturn = dataToReturn;
         this.startIndex = startIndex;
         this.initialSearch = initialSearch;
         this.searchAfterValue = searchAfterValue;
         this.pageSize = pageSize;
-        this.sortField = sortField;
+        this.sortField = "reference.keyword";
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/search/PaginatedQuery.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/search/PaginatedQuery.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.civil.model.search;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import java.util.List;
+
+import static net.minidev.json.JSONValue.toJSONString;
+
+public class PaginatedQuery {
+
+    private final QueryBuilder queryBuilder;
+    private final List<String> dataToReturn;
+    private final int startIndex;
+    private final boolean initialSearch;
+    private final String searchAfterValue;
+
+    public PaginatedQuery(QueryBuilder queryBuilder, List<String> dataToReturn, int startIndex,
+                          boolean initialSearch, String searchAfterValue) {
+        this.queryBuilder = queryBuilder;
+        this.dataToReturn = dataToReturn;
+        this.startIndex = startIndex;
+        this.initialSearch = initialSearch;
+        this.searchAfterValue = searchAfterValue;
+    }
+
+    @Override
+    public String toString() {
+        if (initialSearch || (searchAfterValue == null && startIndex == 0)) {
+            return getInitialQuery();
+        } else {
+            return getSubsequentQuery();
+        }
+    }
+
+    private String getStartQuery() {
+        return "{"
+            + "\"query\": " + queryBuilder.toString() + ", "
+            + "\"_source\": " + toJSONString(dataToReturn) + ", "
+            + " \"size\": 10,"
+            + "\"from\": " + startIndex + ","
+            + "\"sort\": ["
+            + "{"
+            + "\"reference.keyword\": \"asc\""
+            + "            }"
+            + "          ]";
+    }
+
+    private String getInitialQuery() {
+        return getStartQuery() + END_QUERY;
+    }
+
+    private String getSubsequentQuery() {
+        return getStartQuery() + "," + String.format(SEARCH_AFTER, searchAfterValue) + END_QUERY;
+    }
+
+    private static final String END_QUERY = "\n}";
+    private static final String SEARCH_AFTER = "\"search_after\": [\"%s\"]";
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/search/PaginatedQuery.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/search/PaginatedQuery.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.civil.model.search;
 
+import lombok.Getter;
 import org.elasticsearch.index.query.QueryBuilder;
 import java.util.List;
 
 import static net.minidev.json.JSONValue.toJSONString;
 
+@Getter
 public class PaginatedQuery {
 
     private final QueryBuilder queryBuilder;
@@ -12,14 +14,23 @@ public class PaginatedQuery {
     private final int startIndex;
     private final boolean initialSearch;
     private final String searchAfterValue;
+    private final int pageSize;
+    private final String sortField;
 
     public PaginatedQuery(QueryBuilder queryBuilder, List<String> dataToReturn, int startIndex,
                           boolean initialSearch, String searchAfterValue) {
+        this(queryBuilder, dataToReturn, startIndex, initialSearch, searchAfterValue, 10, "reference.keyword");
+    }
+
+    public PaginatedQuery(QueryBuilder queryBuilder, List<String> dataToReturn, int startIndex,
+                          boolean initialSearch, String searchAfterValue, int pageSize, String sortField) {
         this.queryBuilder = queryBuilder;
         this.dataToReturn = dataToReturn;
         this.startIndex = startIndex;
         this.initialSearch = initialSearch;
         this.searchAfterValue = searchAfterValue;
+        this.pageSize = pageSize;
+        this.sortField = sortField;
     }
 
     @Override
@@ -35,11 +46,11 @@ public class PaginatedQuery {
         return "{"
             + "\"query\": " + queryBuilder.toString() + ", "
             + "\"_source\": " + toJSONString(dataToReturn) + ", "
-            + " \"size\": 10,"
-            + "\"from\": " + startIndex + ","
+            + " \"size\": " + pageSize + ","
+            + "\"from\": " + (searchAfterValue != null ? 0 : startIndex) + ","
             + "\"sort\": ["
             + "{"
-            + "\"reference.keyword\": \"asc\""
+            + "\"" + sortField + "\": \"asc\""
             + "            }"
             + "          ]";
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessor.java
@@ -7,9 +7,12 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 @Component
 @RequiredArgsConstructor
@@ -22,34 +25,34 @@ public class ScheduledTaskProcessor {
     private int circuitBreakerThreshold;
 
     public ScheduledTaskOutcome performProcessing(ScheduledTaskEventConfiguration eventConfig,
-                                                 Consumer<CaseDetails> scheduledTask,
-                                                 Set<CaseDetails> cases) {
-        List<Long> succeededCases = new ArrayList<>();
-        List<Long> failedCases = new ArrayList<>();
-        int consecutiveFailures = 0;
-        boolean abortedEarly = false;
-        String abortReason = "";
+                                                  Consumer<CaseDetails> scheduledTask,
+                                                  Stream<CaseDetails> cases) {
+        List<Long> succeededCases = Collections.synchronizedList(new ArrayList<>());
+        List<Long> failedCases = Collections.synchronizedList(new ArrayList<>());
+        AtomicInteger consecutiveFailures = new AtomicInteger(0);
+        StringBuilder abortReason = new StringBuilder();
 
-        for (CaseDetails caseDetails : cases) {
+        boolean completed = cases.sequential().allMatch(caseDetails -> {
             Long caseId = caseDetails.getId();
             try {
                 scheduledTask.accept(caseDetails);
                 eventTracker.caseProcessedEvent(eventConfig, caseId);
                 succeededCases.add(caseId);
-                consecutiveFailures = 0;
+                consecutiveFailures.set(0);
             } catch (Exception e) {
                 failedCases.add(caseId);
                 eventTracker.caseFailedEvent(eventConfig, caseId, e);
                 log.error("Error processing case {}: {}", caseId, e.getMessage(), e);
-                consecutiveFailures++;
+                int failures = consecutiveFailures.incrementAndGet();
 
-                if (consecutiveFailures >= circuitBreakerThreshold) {
-                    abortedEarly = true;
-                    abortReason = e.getMessage();
-                    break;
+                if (failures >= circuitBreakerThreshold) {
+                    abortReason.append(Objects.toString(e.getMessage(), e.getClass().getSimpleName()));
+                    return false;
                 }
             }
-        }
-        return new ScheduledTaskOutcome(succeededCases, failedCases, abortedEarly, abortReason);
+            return true;
+        });
+
+        return new ScheduledTaskOutcome(succeededCases, failedCases, !completed, abortReason.toString());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessor.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,13 +27,14 @@ public class ScheduledTaskProcessor {
 
     public ScheduledTaskOutcome performProcessing(ScheduledTaskEventConfiguration eventConfig,
                                                   Consumer<CaseDetails> scheduledTask,
-                                                  Stream<CaseDetails> cases) {
+                                                  ElasticSearchResult searchResult) {
         List<Long> succeededCases = Collections.synchronizedList(new ArrayList<>());
         List<Long> failedCases = Collections.synchronizedList(new ArrayList<>());
         AtomicInteger consecutiveFailures = new AtomicInteger(0);
         StringBuilder abortReason = new StringBuilder();
+        Stream<CaseDetails> sequentialStream = searchResult.caseDetailsStream().sequential();
 
-        boolean completed = cases.sequential().allMatch(caseDetails -> {
+        boolean completed = sequentialStream.allMatch(caseDetails -> {
             Long caseId = caseDetails.getId();
             try {
                 scheduledTask.accept(caseDetails);

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunner.java
@@ -6,11 +6,9 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
-import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 @Component
 @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -22,48 +20,68 @@ public class ScheduledTaskRunner {
     private final ScheduledTaskProcessor scheduledTaskProcessor;
 
     public void run(ScheduledTaskEventConfiguration eventConfig,
-                    Supplier<Stream<CaseDetails>> caseDetailsSupplier,
+                    ElasticSearchResult searchResult,
                     Consumer<CaseDetails> scheduledTask) {
 
-        final Stream<CaseDetails> cases;
-        try {
-            cases = Optional.ofNullable(caseDetailsSupplier.get()).orElse(Stream.empty());
-            processCaseDetails(eventConfig, scheduledTask, cases);
-        } catch (Exception e) {
-            eventTracker.jobAbortedEvent(eventConfig, e.getMessage());
+        if (searchResult == null) {
+            eventTracker.jobAbortedEvent(eventConfig, "SearchResult cannot be null");
             log.error(
-                "Scheduled task aborted due to error during case retrieval: {}",
-                eventConfig.getSchedulerName(),
-                e
+                "Scheduled task aborted due to SearchResult being null: {}",
+                eventConfig.getSchedulerName()
             );
+            return;
         }
+
+        if (searchResult.isEmpty()) {
+            eventTracker.jobStartedEvent(eventConfig, 0);
+            eventTracker.jobCompletedNoCasesEvent(eventConfig);
+            log.info("Scheduled task completed: {}, totalCases: 0", eventConfig.getSchedulerName());
+            return;
+        }
+
+        processCaseDetails(eventConfig, scheduledTask, searchResult);
     }
 
-    private void processCaseDetails(ScheduledTaskEventConfiguration eventConfig, Consumer<CaseDetails> scheduledTask, Stream<CaseDetails> cases) {
-        eventTracker.jobStartedEvent(eventConfig);
-        log.info("Running scheduled task: {}", eventConfig.getSchedulerName());
+    private void processCaseDetails(ScheduledTaskEventConfiguration eventConfig,
+                                    Consumer<CaseDetails> scheduledTask,
+                                    ElasticSearchResult searchResult) {
+        int totalCases = searchResult.totalResults();
+        eventTracker.jobStartedEvent(eventConfig, totalCases);
+        log.info("Running scheduled task: {}, totalCases: {}", eventConfig.getSchedulerName(), totalCases);
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, cases);
+        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(
+            eventConfig,
+            scheduledTask,
+            searchResult
+        );
 
         if (outcome.abortedEarly()) {
             eventTracker.jobAbortedEvent(
                 eventConfig,
+                totalCases,
                 outcome.succeededCases().size(),
                 outcome.failedCases().size(),
                 outcome.abortReason()
             );
             log.info(
-                "Scheduled task aborted: {}, succeededCases: {}, failedCases: {}, abortReason: {}",
+                "Scheduled task aborted: {}, totalCases: {}, succeededCases: {}, failedCases: {}, abortReason: {}",
                 eventConfig.getSchedulerName(),
+                totalCases,
                 outcome.succeededCases().size(),
                 outcome.failedCases().size(),
                 outcome.abortReason()
             );
         } else {
-            eventTracker.jobCompletedEvent(eventConfig, outcome.succeededCases().size(), outcome.failedCases().size());
+            eventTracker.jobCompletedEvent(
+                eventConfig,
+                totalCases,
+                outcome.succeededCases().size(),
+                outcome.failedCases().size()
+            );
             log.info(
-                "Scheduled task completed: {}, succeededCases: {}, failedCases: {}",
+                "Scheduled task completed: {}, totalCases: {}, succeededCases: {}, failedCases: {}",
                 eventConfig.getSchedulerName(),
+                totalCases,
                 outcome.succeededCases().size(),
                 outcome.failedCases().size()
             );

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunner.java
@@ -7,11 +7,10 @@ import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 
-import java.util.Collections;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 @Component
 @Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
@@ -23,50 +22,48 @@ public class ScheduledTaskRunner {
     private final ScheduledTaskProcessor scheduledTaskProcessor;
 
     public void run(ScheduledTaskEventConfiguration eventConfig,
-                    Supplier<Set<CaseDetails>> caseDetailsSupplier,
+                    Supplier<Stream<CaseDetails>> caseDetailsSupplier,
                     Consumer<CaseDetails> scheduledTask) {
 
-        final Set<CaseDetails> cases;
+        final Stream<CaseDetails> cases;
         try {
-            cases = Optional.ofNullable(caseDetailsSupplier.get())
-                .orElse(Collections.emptySet());
+            cases = Optional.ofNullable(caseDetailsSupplier.get()).orElse(Stream.empty());
+            processCaseDetails(eventConfig, scheduledTask, cases);
         } catch (Exception e) {
             eventTracker.jobAbortedEvent(eventConfig, e.getMessage());
-            log.error("Scheduled task aborted due to error during case retrieval: {}", eventConfig.getSchedulerName(), e);
-            return;
-        }
-
-        if (cases.isEmpty()) {
-            eventTracker.jobStartedEvent(eventConfig, 0);
-            eventTracker.jobCompletedNoCasesEvent(eventConfig);
-            log.info("Scheduled task completed: {}, totalCases: 0", eventConfig.getSchedulerName());
-        } else {
-            processCaseDetails(eventConfig, scheduledTask, cases);
+            log.error(
+                "Scheduled task aborted due to error during case retrieval: {}",
+                eventConfig.getSchedulerName(),
+                e
+            );
         }
     }
 
-    private void processCaseDetails(ScheduledTaskEventConfiguration eventConfig, Consumer<CaseDetails> scheduledTask, Set<CaseDetails> cases) {
-        eventTracker.jobStartedEvent(eventConfig, cases.size());
-        log.info("Running scheduled task: {}, totalCases: {}", eventConfig.getSchedulerName(), cases.size());
+    private void processCaseDetails(ScheduledTaskEventConfiguration eventConfig, Consumer<CaseDetails> scheduledTask, Stream<CaseDetails> cases) {
+        eventTracker.jobStartedEvent(eventConfig);
+        log.info("Running scheduled task: {}", eventConfig.getSchedulerName());
 
         ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, cases);
 
         if (outcome.abortedEarly()) {
-            eventTracker.jobAbortedEvent(eventConfig, cases.size(), outcome.succeededCases().size(), outcome.failedCases().size(), outcome.abortReason());
+            eventTracker.jobAbortedEvent(
+                eventConfig,
+                outcome.succeededCases().size(),
+                outcome.failedCases().size(),
+                outcome.abortReason()
+            );
             log.info(
-                "Scheduled task aborted: {}, totalCases: {}, succeededCases: {}, failedCases: {}, abortReason: {}",
+                "Scheduled task aborted: {}, succeededCases: {}, failedCases: {}, abortReason: {}",
                 eventConfig.getSchedulerName(),
-                cases.size(),
                 outcome.succeededCases().size(),
                 outcome.failedCases().size(),
                 outcome.abortReason()
             );
         } else {
-            eventTracker.jobCompletedEvent(eventConfig, cases.size(), outcome.succeededCases().size(), outcome.failedCases().size());
+            eventTracker.jobCompletedEvent(eventConfig, outcome.succeededCases().size(), outcome.failedCases().size());
             log.info(
-                "Scheduled task completed: {}, totalCases: {}, succeededCases: {}, failedCases: {}",
+                "Scheduled task completed: {}, succeededCases: {}, failedCases: {}",
                 eventConfig.getSchedulerName(),
-                cases.size(),
                 outcome.succeededCases().size(),
                 outcome.failedCases().size()
             );

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineScheduler.java
@@ -6,10 +6,14 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.scheduler.common.CivilScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskEventConfiguration;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.search.DefendantResponseDeadlineCheckSearchService;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
+
+import java.util.Set;
 
 @Component
 @RequiredArgsConstructor
@@ -37,8 +41,12 @@ public class DefendantResponseDeadlineScheduler implements CivilScheduler {
         log.info("Running {} scheduler", SCHEDULER_NAME);
         scheduledTaskRunner.run(
             new ScheduledTaskEventConfiguration(SCHEDULER_NAME),
-            () -> searchService.getCases().stream(),
+            resultsFrom(searchService.getCases()),
             defendantResponseDeadlineTask
         );
+    }
+
+    private ElasticSearchResult resultsFrom(Set<CaseDetails> caseDetails) {
+        return new ElasticSearchResult(caseDetails.size(), caseDetails.stream());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineScheduler.java
@@ -37,7 +37,7 @@ public class DefendantResponseDeadlineScheduler implements CivilScheduler {
         log.info("Running {} scheduler", SCHEDULER_NAME);
         scheduledTaskRunner.run(
             new ScheduledTaskEventConfiguration(SCHEDULER_NAME),
-            searchService::getCases,
+            () -> searchService.getCases().stream(),
             defendantResponseDeadlineTask
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
@@ -12,8 +12,6 @@ import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.service.search.JudgementBufferExpiredSearchService;
 
-import java.util.stream.Collectors;
-
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -42,7 +40,7 @@ public class JudgementBufferScheduler implements CivilScheduler {
             log.info("Running {} scheduler", SCHEDULER_NAME);
             scheduledTaskRunner.run(
                 new ScheduledTaskEventConfiguration(SCHEDULER_NAME),
-                () -> searchService.getCases(),
+                searchService::getCasesStream,
                 judgementBufferScheduledTask
             );
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
@@ -40,7 +40,7 @@ public class JudgementBufferScheduler implements CivilScheduler {
             log.info("Running {} scheduler", SCHEDULER_NAME);
             scheduledTaskRunner.run(
                 new ScheduledTaskEventConfiguration(SCHEDULER_NAME),
-                searchService::getCasesStream,
+                searchService.getSearchResults(),
                 judgementBufferScheduledTask
             );
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
@@ -12,6 +12,8 @@ import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.service.search.JudgementBufferExpiredSearchService;
 
+import java.util.stream.Collectors;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -40,7 +42,7 @@ public class JudgementBufferScheduler implements CivilScheduler {
             log.info("Running {} scheduler", SCHEDULER_NAME);
             scheduledTaskRunner.run(
                 new ScheduledTaskEventConfiguration(SCHEDULER_NAME),
-                searchService::getCases,
+                () -> searchService.getCases(),
                 judgementBufferScheduledTask
             );
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/CoreCaseDataService.java
@@ -21,6 +21,7 @@ import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.common.DynamicList;
 import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
+import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
 import uk.gov.hmcts.reform.civil.model.search.Query;
 import uk.gov.hmcts.reform.civil.referencedata.model.LocationRefData;
 import uk.gov.hmcts.reform.civil.service.data.UserAuthContent;
@@ -194,6 +195,13 @@ public class CoreCaseDataService {
         String userToken = userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         String searchString = query.toString();
         log.info("Searching Elasticsearch with query: " + searchString);
+        return coreCaseDataApi.searchCases(userToken, authTokenGenerator.generate(), CASE_TYPE, searchString);
+    }
+
+    public SearchResult searchCasesPaginated(PaginatedQuery paginatedQuery) {
+        String userToken = userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+        String searchString = paginatedQuery.toString();
+        log.info("Searching Elasticsearch with paginated query: " + searchString);
         return coreCaseDataApi.searchCases(userToken, authTokenGenerator.generate(), CASE_TYPE, searchString);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/ElasticSearchPaginatedStreamProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/ElasticSearchPaginatedStreamProvider.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.civil.service.search;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
+import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
+import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
+
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+@Component
+@RequiredArgsConstructor
+public class ElasticSearchPaginatedStreamProvider {
+
+    private static final int ES_DEFAULT_SEARCH_LIMIT = 10;
+    private final CoreCaseDataService coreCaseDataService;
+
+    public Stream<CaseDetails> getPaginatedStream(Function<String, PaginatedQuery> queryFunction) {
+        return StreamSupport.stream(
+            new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
+                private String searchAfterValue;
+                private int currentCaseIndex = 0;
+                private SearchResult currentSearchResult;
+
+                @Override
+                public boolean tryAdvance(Consumer<? super CaseDetails> action) {
+                    if (currentSearchResult == null || currentCaseIndex >= currentSearchResult.getCases().size()) {
+                        if (currentSearchResult != null && currentSearchResult.getCases().size() < ES_DEFAULT_SEARCH_LIMIT) {
+                            return false;
+                        }
+                        fetchNextPage();
+                    }
+
+                    if (currentSearchResult.getCases().isEmpty() || currentCaseIndex >= currentSearchResult.getCases().size()) {
+                        return false;
+                    }
+
+                    CaseDetails caseDetails = currentSearchResult.getCases().get(currentCaseIndex++);
+                    searchAfterValue = caseDetails.getId().toString();
+                    action.accept(caseDetails);
+                    return true;
+                }
+
+                private void fetchNextPage() {
+                    currentSearchResult = coreCaseDataService.searchCasesPaginated(queryFunction.apply(searchAfterValue));
+                    currentCaseIndex = 0;
+                }
+            }, false
+        );
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/ElasticSearchPaginatedStreamProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/ElasticSearchPaginatedStreamProvider.java
@@ -7,6 +7,8 @@ import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
 import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Spliterator;
 import java.util.Spliterators;
 import java.util.function.Consumer;
@@ -18,38 +20,46 @@ import java.util.stream.StreamSupport;
 @RequiredArgsConstructor
 public class ElasticSearchPaginatedStreamProvider {
 
-    private static final int ES_DEFAULT_SEARCH_LIMIT = 10;
     private final CoreCaseDataService coreCaseDataService;
 
     public Stream<CaseDetails> getPaginatedStream(Function<String, PaginatedQuery> queryFunction) {
+        return getPaginatedStream(queryFunction, caseDetails -> caseDetails.getId().toString());
+    }
+
+    public Stream<CaseDetails> getPaginatedStream(Function<String, PaginatedQuery> queryFunction,
+                                                  Function<CaseDetails, String> sortKeyExtractor) {
         return StreamSupport.stream(
             new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
                 private String searchAfterValue;
+                private List<CaseDetails> currentCases = Collections.emptyList();
                 private int currentCaseIndex = 0;
-                private SearchResult currentSearchResult;
 
                 @Override
                 public boolean tryAdvance(Consumer<? super CaseDetails> action) {
-                    if (currentSearchResult == null || currentCaseIndex >= currentSearchResult.getCases().size()) {
-                        if (currentSearchResult != null && currentSearchResult.getCases().size() < ES_DEFAULT_SEARCH_LIMIT) {
+                    if (currentCaseIndex >= currentCases.size()) {
+                        if (!fetchNextPage()) {
                             return false;
                         }
-                        fetchNextPage();
                     }
 
-                    if (currentSearchResult.getCases().isEmpty() || currentCaseIndex >= currentSearchResult.getCases().size()) {
-                        return false;
-                    }
-
-                    CaseDetails caseDetails = currentSearchResult.getCases().get(currentCaseIndex++);
-                    searchAfterValue = caseDetails.getId().toString();
+                    CaseDetails caseDetails = currentCases.get(currentCaseIndex++);
+                    searchAfterValue = sortKeyExtractor.apply(caseDetails);
                     action.accept(caseDetails);
                     return true;
                 }
 
-                private void fetchNextPage() {
-                    currentSearchResult = coreCaseDataService.searchCasesPaginated(queryFunction.apply(searchAfterValue));
+                private boolean fetchNextPage() {
+                    SearchResult searchResult = coreCaseDataService.searchCasesPaginated(queryFunction.apply(searchAfterValue));
+                    currentCases = searchResult != null && searchResult.getCases() != null
+                        ? searchResult.getCases()
+                        : Collections.emptyList();
                     currentCaseIndex = 0;
+                    if (currentCases.isEmpty()) {
+                        return false;
+                    }
+
+                    String nextSearchAfterValue = sortKeyExtractor.apply(currentCases.getLast());
+                    return nextSearchAfterValue != null && !nextSearchAfterValue.equals(searchAfterValue);
                 }
             }, false
         );

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/ElasticSearchPaginatedStreamProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/ElasticSearchPaginatedStreamProvider.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.civil.service.search;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
@@ -18,6 +19,7 @@ import java.util.stream.StreamSupport;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ElasticSearchPaginatedStreamProvider {
 
     private final CoreCaseDataService coreCaseDataService;
@@ -28,40 +30,65 @@ public class ElasticSearchPaginatedStreamProvider {
 
     public Stream<CaseDetails> getPaginatedStream(Function<String, PaginatedQuery> queryFunction,
                                                   Function<CaseDetails, String> sortKeyExtractor) {
-        return StreamSupport.stream(
-            new Spliterators.AbstractSpliterator<>(Long.MAX_VALUE, Spliterator.ORDERED) {
-                private String searchAfterValue;
-                private List<CaseDetails> currentCases = Collections.emptyList();
-                private int currentCaseIndex = 0;
+        return StreamSupport.stream(new ElasticSearchSpliterator(queryFunction, sortKeyExtractor), false);
+    }
 
-                @Override
-                public boolean tryAdvance(Consumer<? super CaseDetails> action) {
-                    if (currentCaseIndex >= currentCases.size()) {
-                        if (!fetchNextPage()) {
-                            return false;
-                        }
-                    }
+    private class ElasticSearchSpliterator extends Spliterators.AbstractSpliterator<CaseDetails> {
+        private final Function<String, PaginatedQuery> queryFunction;
+        private final Function<CaseDetails, String> sortKeyExtractor;
+        private String searchAfterValue;
+        private List<CaseDetails> currentCases = Collections.emptyList();
+        private int currentCaseIndex = 0;
+        private boolean hasMorePages = true;
 
-                    CaseDetails caseDetails = currentCases.get(currentCaseIndex++);
-                    searchAfterValue = sortKeyExtractor.apply(caseDetails);
-                    action.accept(caseDetails);
-                    return true;
+        protected ElasticSearchSpliterator(Function<String, PaginatedQuery> queryFunction,
+                                         Function<CaseDetails, String> sortKeyExtractor) {
+            super(Long.MAX_VALUE, Spliterator.ORDERED);
+            this.queryFunction = queryFunction;
+            this.sortKeyExtractor = sortKeyExtractor;
+        }
+
+        @Override
+        public boolean tryAdvance(Consumer<? super CaseDetails> action) {
+            if (currentCaseIndex >= currentCases.size()) {
+                if (!hasMorePages || !fetchNextPage()) {
+                    return false;
                 }
+            }
 
-                private boolean fetchNextPage() {
-                    SearchResult searchResult = coreCaseDataService.searchCasesPaginated(queryFunction.apply(searchAfterValue));
-                    currentCases = searchResult != null && searchResult.getCases() != null
-                        ? searchResult.getCases()
-                        : Collections.emptyList();
-                    currentCaseIndex = 0;
-                    if (currentCases.isEmpty()) {
-                        return false;
-                    }
+            CaseDetails caseDetails = currentCases.get(currentCaseIndex++);
+            searchAfterValue = sortKeyExtractor.apply(caseDetails);
+            action.accept(caseDetails);
+            return true;
+        }
 
-                    String nextSearchAfterValue = sortKeyExtractor.apply(currentCases.getLast());
-                    return nextSearchAfterValue != null && !nextSearchAfterValue.equals(searchAfterValue);
-                }
-            }, false
-        );
+        private boolean fetchNextPage() {
+            log.debug("Fetching next page of cases with searchAfterValue: {}", searchAfterValue);
+            PaginatedQuery paginatedQuery = queryFunction.apply(searchAfterValue);
+            SearchResult searchResult = coreCaseDataService.searchCasesPaginated(paginatedQuery);
+
+            currentCases = searchResult != null && searchResult.getCases() != null
+                ? searchResult.getCases()
+                : Collections.emptyList();
+            currentCaseIndex = 0;
+            hasMorePages = currentCases.size() == paginatedQuery.getPageSize();
+
+            if (currentCases.isEmpty()) {
+                log.debug("No more cases found, stopping pagination.");
+                return false;
+            }
+
+            String nextSearchAfterValue = sortKeyExtractor.apply(currentCases.getLast());
+            boolean hasProgressed = nextSearchAfterValue != null && !nextSearchAfterValue.equals(searchAfterValue);
+
+            if (!hasProgressed) {
+                log.warn("Pagination did not progress. Stopping to avoid infinite loop. searchAfterValue: {}", searchAfterValue);
+                hasMorePages = false;
+                return false;
+            }
+
+            log.debug("Fetched {} cases. More pages available: {}", currentCases.size(), hasMorePages);
+            return true;
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/ElasticSearchPaginatedStreamProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/ElasticSearchPaginatedStreamProvider.java
@@ -70,6 +70,13 @@ public class ElasticSearchPaginatedStreamProvider {
             currentCases = searchResult != null && searchResult.getCases() != null
                 ? searchResult.getCases()
                 : Collections.emptyList();
+
+            if (searchResult != null && currentCases.size() > searchResult.getTotal()) {
+                log.warn("Search result total ({}) is less than the number of cases returned ({}). "
+                             + "This may indicate an inconsistency in the search results.",
+                         searchResult.getTotal(), currentCases.size());
+            }
+
             currentCaseIndex = 0;
             hasMorePages = currentCases.size() == paginatedQuery.getPageSize();
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
@@ -24,6 +24,8 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 @RequiredArgsConstructor
 public class JudgementBufferExpiredSearchService {
 
+    public static final int PAGE_SIZE = 50;
+
     private final ElasticSearchPaginatedStreamProvider elasticSearchPaginatedStreamProvider;
 
     public Set<CaseDetails> getCases() {
@@ -47,8 +49,7 @@ public class JudgementBufferExpiredSearchService {
             0,
             searchAfterValue == null,
             searchAfterValue,
-            50,
-            "id"
+            PAGE_SIZE
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
@@ -3,16 +3,15 @@ package uk.gov.hmcts.reform.civil.service.search;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchPaginatedStreamProvider;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Stream;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
@@ -28,14 +27,10 @@ public class JudgementBufferExpiredSearchService {
 
     private final ElasticSearchPaginatedStreamProvider elasticSearchPaginatedStreamProvider;
 
-    public Set<CaseDetails> getCases() {
-        return getCasesStream().collect(java.util.stream.Collectors.toSet());
-    }
-
-    public Stream<CaseDetails> getCasesStream() {
+    public ElasticSearchResult getSearchResults() {
         String timeNow = ZonedDateTime.now(ZoneOffset.UTC).toString();
 
-        return elasticSearchPaginatedStreamProvider.getPaginatedStream(
+        return elasticSearchPaginatedStreamProvider.getPaginatedSearchResult(
             searchAfterValue -> query(timeNow, searchAfterValue)
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.civil.service.search;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
@@ -23,9 +24,10 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 @RequiredArgsConstructor
 public class JudgementBufferExpiredSearchService {
 
-    public static final int PAGE_SIZE = 50;
-
     private final ElasticSearchPaginatedStreamProvider elasticSearchPaginatedStreamProvider;
+
+    @Value("${search.judgementBuffer.pageSize:50}")
+    private int pageSize;
 
     public ElasticSearchResult getSearchResults() {
         String timeNow = ZonedDateTime.now(ZoneOffset.UTC).toString();
@@ -44,7 +46,7 @@ public class JudgementBufferExpiredSearchService {
             0,
             searchAfterValue == null,
             searchAfterValue,
-            PAGE_SIZE
+            pageSize
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
@@ -1,17 +1,17 @@
 package uk.gov.hmcts.reform.civil.service.search;
 
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
-import uk.gov.hmcts.reform.civil.model.search.Query;
 
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
@@ -21,28 +21,34 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 
 @Service
 @Slf4j
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class JudgementBufferExpiredSearchService {
-
-    protected static final int START_INDEX = 0;
 
     private final ElasticSearchPaginatedStreamProvider elasticSearchPaginatedStreamProvider;
 
-    public Stream<CaseDetails> getCases() {
-        String timeNow = ZonedDateTime.now(ZoneOffset.UTC).toString();
-
-        return elasticSearchPaginatedStreamProvider.getPaginatedStream(searchAfterValue -> query(START_INDEX, timeNow, searchAfterValue));
+    public Set<CaseDetails> getCases() {
+        return getCasesStream().collect(java.util.stream.Collectors.toSet());
     }
 
-    private PaginatedQuery query(int startIndex, String timeNow, String searchAfterValue) {
-        log.info("Call to JudgementBufferExpiredSearchService query with index {} and timeNow {}", startIndex, timeNow);
+    public Stream<CaseDetails> getCasesStream() {
+        String timeNow = ZonedDateTime.now(ZoneOffset.UTC).toString();
+
+        return elasticSearchPaginatedStreamProvider.getPaginatedStream(
+            searchAfterValue -> query(timeNow, searchAfterValue)
+        );
+    }
+
+    private PaginatedQuery query(String timeNow, String searchAfterValue) {
+        log.info("Call to JudgementBufferExpiredSearchService query with timeNow {}", timeNow);
         ZonedDateTime timeMinus48Hours = ZonedDateTime.parse(timeNow).minusHours(48);
         return new PaginatedQuery(
             generateSearchForExpiredJudgments(timeMinus48Hours),
             List.of("reference"),
-            startIndex,
-            startIndex == 0 && searchAfterValue == null,
-            searchAfterValue
+            0,
+            searchAfterValue == null,
+            searchAfterValue,
+            50,
+            "id"
         );
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchService.java
@@ -1,14 +1,18 @@
 package uk.gov.hmcts.reform.civil.service.search;
 
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.elasticsearch.index.query.BoolQueryBuilder;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
 import uk.gov.hmcts.reform.civil.model.search.Query;
-import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
@@ -17,28 +21,39 @@ import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 
 @Service
 @Slf4j
-public class JudgementBufferExpiredSearchService extends ElasticSearchService {
+@AllArgsConstructor
+public class JudgementBufferExpiredSearchService {
 
-    public JudgementBufferExpiredSearchService(CoreCaseDataService coreCaseDataService) {
-        super(coreCaseDataService);
+    protected static final int START_INDEX = 0;
+
+    private final ElasticSearchPaginatedStreamProvider elasticSearchPaginatedStreamProvider;
+
+    public Stream<CaseDetails> getCases() {
+        String timeNow = ZonedDateTime.now(ZoneOffset.UTC).toString();
+
+        return elasticSearchPaginatedStreamProvider.getPaginatedStream(searchAfterValue -> query(START_INDEX, timeNow, searchAfterValue));
     }
 
-    @Override
-    public Query query(int startIndex, String timeNow) {
+    private PaginatedQuery query(int startIndex, String timeNow, String searchAfterValue) {
         log.info("Call to JudgementBufferExpiredSearchService query with index {} and timeNow {}", startIndex, timeNow);
         ZonedDateTime timeMinus48Hours = ZonedDateTime.parse(timeNow).minusHours(48);
-        return new Query(
-            boolQuery()
-                .minimumShouldMatch(1)
-                .should(boolQuery()
-                            .must(rangeQuery("data.joDJCreatedDate").lte(timeMinus48Hours))
-                            .must(beState(CaseState.JUDGMENT_REQUESTED))
-                            .must(haveNoOngoingBusinessProcess())
-                ),
+        return new PaginatedQuery(
+            generateSearchForExpiredJudgments(timeMinus48Hours),
             List.of("reference"),
             startIndex,
-            true
+            startIndex == 0 && searchAfterValue == null,
+            searchAfterValue
         );
+    }
+
+    private BoolQueryBuilder generateSearchForExpiredJudgments(ZonedDateTime timeMinus48Hours) {
+        return boolQuery()
+            .minimumShouldMatch(1)
+            .should(boolQuery()
+                        .must(rangeQuery("data.joDJCreatedDate").lte(timeMinus48Hours))
+                        .must(beState(CaseState.JUDGMENT_REQUESTED))
+                        .must(haveNoOngoingBusinessProcess())
+            );
     }
 
     public BoolQueryBuilder beState(CaseState state) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchPaginatedStreamProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchPaginatedStreamProvider.java
@@ -1,10 +1,9 @@
-package uk.gov.hmcts.reform.civil.service.search;
+package uk.gov.hmcts.reform.civil.service.search.common;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
 import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 
@@ -30,7 +29,25 @@ public class ElasticSearchPaginatedStreamProvider {
 
     public Stream<CaseDetails> getPaginatedStream(Function<String, PaginatedQuery> queryFunction,
                                                   Function<CaseDetails, String> sortKeyExtractor) {
-        return StreamSupport.stream(new ElasticSearchSpliterator(queryFunction, sortKeyExtractor), false);
+        return StreamSupport.stream(new ElasticSearchSpliterator(queryFunction, sortKeyExtractor, null), false);
+    }
+
+    public ElasticSearchResult getPaginatedSearchResult(Function<String, PaginatedQuery> queryFunction) {
+        return getPaginatedSearchResult(queryFunction, caseDetails -> caseDetails.getId().toString());
+    }
+
+    public ElasticSearchResult getPaginatedSearchResult(Function<String, PaginatedQuery> queryFunction,
+                                                        Function<CaseDetails, String> sortKeyExtractor) {
+        PaginatedQuery initialQuery = queryFunction.apply(null);
+        uk.gov.hmcts.reform.ccd.client.model.SearchResult searchResult = coreCaseDataService.searchCasesPaginated(initialQuery);
+
+        int total = searchResult != null ? searchResult.getTotal() : 0;
+        Stream<CaseDetails> stream = StreamSupport.stream(
+            new ElasticSearchSpliterator(queryFunction, sortKeyExtractor, searchResult),
+            false
+        );
+
+        return new ElasticSearchResult(total, stream);
     }
 
     private class ElasticSearchSpliterator extends Spliterators.AbstractSpliterator<CaseDetails> {
@@ -42,10 +59,24 @@ public class ElasticSearchPaginatedStreamProvider {
         private boolean hasMorePages = true;
 
         protected ElasticSearchSpliterator(Function<String, PaginatedQuery> queryFunction,
-                                         Function<CaseDetails, String> sortKeyExtractor) {
+                                           Function<CaseDetails, String> sortKeyExtractor,
+                                           uk.gov.hmcts.reform.ccd.client.model.SearchResult initialSearchResult) {
             super(Long.MAX_VALUE, Spliterator.ORDERED);
             this.queryFunction = queryFunction;
             this.sortKeyExtractor = sortKeyExtractor;
+
+            if (initialSearchResult != null) {
+                currentCases = initialSearchResult.getCases() != null
+                    ? initialSearchResult.getCases()
+                    : Collections.emptyList();
+
+                if (!currentCases.isEmpty()) {
+                    searchAfterValue = sortKeyExtractor.apply(currentCases.getLast());
+                }
+
+                PaginatedQuery paginatedQuery = queryFunction.apply(null);
+                hasMorePages = currentCases.size() >= paginatedQuery.getPageSize();
+            }
         }
 
         @Override
@@ -57,7 +88,6 @@ public class ElasticSearchPaginatedStreamProvider {
             }
 
             CaseDetails caseDetails = currentCases.get(currentCaseIndex++);
-            searchAfterValue = sortKeyExtractor.apply(caseDetails);
             action.accept(caseDetails);
             return true;
         }
@@ -65,7 +95,7 @@ public class ElasticSearchPaginatedStreamProvider {
         private boolean fetchNextPage() {
             log.debug("Fetching next page of cases with searchAfterValue: {}", searchAfterValue);
             PaginatedQuery paginatedQuery = queryFunction.apply(searchAfterValue);
-            SearchResult searchResult = coreCaseDataService.searchCasesPaginated(paginatedQuery);
+            uk.gov.hmcts.reform.ccd.client.model.SearchResult searchResult = coreCaseDataService.searchCasesPaginated(paginatedQuery);
 
             currentCases = searchResult != null && searchResult.getCases() != null
                 ? searchResult.getCases()
@@ -78,7 +108,7 @@ public class ElasticSearchPaginatedStreamProvider {
             }
 
             currentCaseIndex = 0;
-            hasMorePages = currentCases.size() == paginatedQuery.getPageSize();
+            hasMorePages = currentCases.size() >= paginatedQuery.getPageSize();
 
             if (currentCases.isEmpty()) {
                 log.debug("No more cases found, stopping pagination.");

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchPaginatedStreamProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchPaginatedStreamProvider.java
@@ -72,10 +72,11 @@ public class ElasticSearchPaginatedStreamProvider {
 
                 if (!currentCases.isEmpty()) {
                     searchAfterValue = sortKeyExtractor.apply(currentCases.getLast());
+                    PaginatedQuery paginatedQuery = queryFunction.apply(null);
+                    hasMorePages = currentCases.size() >= paginatedQuery.getPageSize();
+                } else {
+                    hasMorePages = false;
                 }
-
-                PaginatedQuery paginatedQuery = queryFunction.apply(null);
-                hasMorePages = currentCases.size() >= paginatedQuery.getPageSize();
             }
         }
 
@@ -124,6 +125,7 @@ public class ElasticSearchPaginatedStreamProvider {
                 return false;
             }
 
+            this.searchAfterValue = nextSearchAfterValue;
             log.debug("Fetched {} cases. More pages available: {}", currentCases.size(), hasMorePages);
             return true;
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchResult.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.civil.service.search.common;
+
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+
+import java.util.stream.Stream;
+
+/**
+ * Result of an ElasticSearch paginated search.
+ * Contains the total number of results and a stream to consume them.
+ * Note: the stream should be consumed only once.
+ */
+public record ElasticSearchResult(int totalResults, Stream<CaseDetails> caseDetailsStream) {
+
+    public boolean isEmpty() {
+        return totalResults == 0;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,6 +68,10 @@ scheduler:
     cronExpression: ${CRON_EXPRESSION_DEFENDANT_RESPONSE:0 1 16 * * ?}
     enabled: ${SCHEDULER_ENABLED_DEFENDANT_RESPONSE:false}
 
+search:
+  judgementBuffer:
+    pageSize: ${SEARCH_PAGE_SIZE_JUDGEMENT_BUFFER:50}
+
 oidc:
   issuer: ${OIDC_ISSUER:http://fr-am:8080/openam/oauth2/hmcts}
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessorTest.java
@@ -12,10 +12,12 @@ import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
@@ -39,7 +41,7 @@ class ScheduledTaskProcessorTest {
         CaseDetails case3 = CaseDetailsBuilder.builder().id(3L).build();
         Set<CaseDetails> cases = new LinkedHashSet<>(List.of(case1, case2, case3));
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, cases);
+        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, cases.stream());
 
         assertThat(outcome).isNotNull();
         assertThat(outcome.succeededCases().size()).isEqualTo(3);
@@ -54,6 +56,20 @@ class ScheduledTaskProcessorTest {
         verify(scheduledEventTracker).caseProcessedEvent(eventConfig, case2.getId());
         verify(scheduledEventTracker).caseProcessedEvent(eventConfig, case3.getId());
         verifyNoMoreInteractions(scheduledEventTracker);
+    }
+
+    @Test
+    void shouldNotProcess_whenNoCases() {
+        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+
+        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, Stream.empty());
+
+        assertThat(outcome).isNotNull();
+        assertThat(outcome.succeededCases().size()).isEqualTo(0);
+        assertThat(outcome.failedCases().size()).isEqualTo(0);
+
+        verifyNoInteractions(scheduledTask);
+        verifyNoInteractions(scheduledEventTracker);
     }
 
     @Test
@@ -74,7 +90,7 @@ class ScheduledTaskProcessorTest {
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, cases);
+        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, cases.stream());
 
         assertThat(outcome.abortedEarly()).isTrue();
         assertThat(outcome.abortReason()).isEqualTo("Error 2");

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessorTest.java
@@ -9,6 +9,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
 
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
+
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -40,8 +42,9 @@ class ScheduledTaskProcessorTest {
         CaseDetails case2 = CaseDetailsBuilder.builder().id(2L).build();
         CaseDetails case3 = CaseDetailsBuilder.builder().id(3L).build();
         Set<CaseDetails> cases = new LinkedHashSet<>(List.of(case1, case2, case3));
+        ElasticSearchResult searchResult = new ElasticSearchResult(3, cases.stream());
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, cases.stream());
+        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
 
         assertThat(outcome).isNotNull();
         assertThat(outcome.succeededCases().size()).isEqualTo(3);
@@ -62,7 +65,7 @@ class ScheduledTaskProcessorTest {
     void shouldNotProcess_whenNoCases() {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, Stream.empty());
+        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, new ElasticSearchResult(0, Stream.empty()));
 
         assertThat(outcome).isNotNull();
         assertThat(outcome.succeededCases().size()).isEqualTo(0);
@@ -89,8 +92,9 @@ class ScheduledTaskProcessorTest {
         doThrow(error2).when(scheduledTask).accept(case2);
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+        ElasticSearchResult searchResult = new ElasticSearchResult(4, cases.stream());
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, cases.stream());
+        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
 
         assertThat(outcome.abortedEarly()).isTrue();
         assertThat(outcome.abortReason()).isEqualTo("Error 2");

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunnerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunnerTest.java
@@ -14,12 +14,15 @@ import uk.gov.hmcts.reform.civil.service.search.ElasticSearchService;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+@SuppressWarnings("unchecked")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ScheduledTaskRunnerTest {
@@ -45,7 +48,7 @@ class ScheduledTaskRunnerTest {
         RuntimeException exception = new RuntimeException("Search failed");
         when(searchService.getCases()).thenThrow(exception);
 
-        scheduledTaskRunner.run(eventConfig, searchService::getCases, scheduledTask);
+        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases() != null ? searchService.getCases().stream() : null, scheduledTask);
 
         verify(scheduledEventTracker).jobAbortedEvent(eq(eventConfig), eq("Search failed"));
         verifyNoMoreInteractions(scheduledTask);
@@ -56,11 +59,10 @@ class ScheduledTaskRunnerTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         when(searchService.getCases()).thenReturn(null);
 
-        scheduledTaskRunner.run(eventConfig, searchService::getCases, scheduledTask);
+        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases() != null ? searchService.getCases().stream() : null, scheduledTask);
 
-        verify(scheduledEventTracker).jobStartedEvent(eq(eventConfig), eq(0));
-        verify(scheduledEventTracker).jobCompletedNoCasesEvent(eq(eventConfig));
-        verifyNoMoreInteractions(scheduledTask);
+        verify(scheduledEventTracker).jobStartedEvent(eq(eventConfig));
+        verify(scheduledTaskProcessor).performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class));
     }
 
     @Test
@@ -72,14 +74,12 @@ class ScheduledTaskRunnerTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(1L), List.of(), false, "");
 
-        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), eq(cases)))
+        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class)))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, searchService::getCases, scheduledTask);
+        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases().stream(), scheduledTask);
 
-        verify(scheduledEventTracker).jobStartedEvent(eq(eventConfig), eq(1));
-        verify(scheduledTaskProcessor).performProcessing(eq(eventConfig), eq(scheduledTask), eq(cases));
-        verify(scheduledEventTracker).jobCompletedEvent(eq(eventConfig), eq(cases.size()), eq(1), eq(0));
+        verify(scheduledTaskProcessor).performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class));
     }
 
     @Test
@@ -94,12 +94,12 @@ class ScheduledTaskRunnerTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(), List.of(1L, 2L), true, "Error 2");
 
-        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), eq(cases)))
+        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class)))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, searchService::getCases, scheduledTask);
+        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases().stream(), scheduledTask);
 
-        verify(scheduledEventTracker).jobAbortedEvent(eq(eventConfig), eq(cases.size()), eq(0), eq(2), eq("Error 2"));
+        verify(scheduledEventTracker).jobAbortedEvent(eq(eventConfig), eq(0), eq(2), eq("Error 2"));
     }
 
     @Test
@@ -113,11 +113,11 @@ class ScheduledTaskRunnerTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(2L), List.of(1L, 3L), false, "");
 
-        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), eq(cases)))
+        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class)))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, searchService::getCases, scheduledTask);
+        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases().stream(), scheduledTask);
 
-        verify(scheduledEventTracker).jobCompletedEvent(eq(eventConfig), eq(cases.size()), eq(1), eq(2));
+        verify(scheduledEventTracker).jobCompletedEvent(eq(eventConfig), eq(1), eq(2));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunnerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunnerTest.java
@@ -10,10 +10,9 @@ import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
 import uk.gov.hmcts.reform.civil.service.search.ElasticSearchService;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -22,7 +21,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@SuppressWarnings("unchecked")
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ScheduledTaskRunnerTest {
@@ -45,79 +43,89 @@ class ScheduledTaskRunnerTest {
     @Test
     void shouldAbort_whenCaseRetrievalFails() {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
-        RuntimeException exception = new RuntimeException("Search failed");
-        when(searchService.getCases()).thenThrow(exception);
 
-        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases() != null ? searchService.getCases().stream() : null, scheduledTask);
+        scheduledTaskRunner.run(eventConfig, null, scheduledTask);
 
-        verify(scheduledEventTracker).jobAbortedEvent(eq(eventConfig), eq("Search failed"));
+        verify(scheduledEventTracker).jobAbortedEvent(eq(eventConfig), eq("SearchResult cannot be null"));
         verifyNoMoreInteractions(scheduledTask);
     }
 
     @Test
-    void shouldHandleNullCases_whenCaseRetrievalReturnsNull() {
+    void shouldHandleZeroCases_whenTotalResultsIsZero() {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
-        when(searchService.getCases()).thenReturn(null);
+        ElasticSearchResult searchResult = new ElasticSearchResult(0, Stream.empty());
 
-        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases() != null ? searchService.getCases().stream() : null, scheduledTask);
+        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
 
-        verify(scheduledEventTracker).jobStartedEvent(eq(eventConfig));
-        verify(scheduledTaskProcessor).performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class));
+        verify(scheduledEventTracker).jobStartedEvent(eq(eventConfig), eq(0));
+        verify(scheduledEventTracker).jobCompletedNoCasesEvent(eq(eventConfig));
+        verifyNoMoreInteractions(scheduledTaskProcessor);
+    }
+
+    @Test
+    void shouldHandleCases_whenCaseRetrievalIsSuccessful() {
+        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+        CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
+        ElasticSearchResult searchResult = new ElasticSearchResult(1, Stream.of(case1));
+        ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(1L), List.of(), false, "");
+
+        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), eq(searchResult)))
+            .thenReturn(outcome);
+
+        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
+
+        verify(scheduledEventTracker).jobStartedEvent(eq(eventConfig), eq(1));
+        verify(scheduledTaskProcessor).performProcessing(eq(eventConfig), eq(scheduledTask), eq(searchResult));
+        verify(scheduledEventTracker).jobCompletedEvent(eq(eventConfig), eq(1), eq(1), eq(0));
     }
 
     @Test
     void shouldRunProcessor_whenCasesPresent() {
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
-        Set<CaseDetails> cases = new LinkedHashSet<>(List.of(case1));
-        when(searchService.getCases()).thenReturn(cases);
+        ElasticSearchResult searchResult = new ElasticSearchResult(1, Stream.of(case1));
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(1L), List.of(), false, "");
 
-        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class)))
+        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(ElasticSearchResult.class)))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases().stream(), scheduledTask);
+        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
 
-        verify(scheduledTaskProcessor).performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class));
+        verify(scheduledTaskProcessor).performProcessing(eq(eventConfig), eq(scheduledTask), any(ElasticSearchResult.class));
     }
 
     @Test
     void shouldAbortEarly_whenConsecutiveFailuresThresholdReached() {
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
         CaseDetails case2 = CaseDetailsBuilder.builder().id(2L).build();
-        CaseDetails case3 = CaseDetailsBuilder.builder().id(3L).build();
-        CaseDetails case4 = CaseDetailsBuilder.builder().id(4L).build();
-        Set<CaseDetails> cases = new LinkedHashSet<>(List.of(case1, case2, case3, case4));
-        when(searchService.getCases()).thenReturn(cases);
+        ElasticSearchResult searchResult = new ElasticSearchResult(2, Stream.of(case1, case2));
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(), List.of(1L, 2L), true, "Error 2");
 
-        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class)))
+        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(ElasticSearchResult.class)))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases().stream(), scheduledTask);
+        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
 
-        verify(scheduledEventTracker).jobAbortedEvent(eq(eventConfig), eq(0), eq(2), eq("Error 2"));
+        verify(scheduledEventTracker).jobAbortedEvent(eq(eventConfig), eq(2), eq(0), eq(2), eq("Error 2"));
     }
 
     @Test
     void shouldNotAbortEarly_whenFailuresAreNotConsecutive() {
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
         CaseDetails case2 = CaseDetailsBuilder.builder().id(2L).build();
-        CaseDetails case3 = CaseDetailsBuilder.builder().id(3L).build();
-        Set<CaseDetails> cases = new LinkedHashSet<>(List.of(case1, case2, case3));
-        when(searchService.getCases()).thenReturn(cases);
+        ElasticSearchResult searchResult = new ElasticSearchResult(2, Stream.of(case1, case2));
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
-        ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(2L), List.of(1L, 3L), false, "");
+        ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(1L), List.of(2L), false, "");
 
-        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(Stream.class)))
+        when(scheduledTaskProcessor.performProcessing(eq(eventConfig), eq(scheduledTask), any(ElasticSearchResult.class)))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, () -> searchService.getCases().stream(), scheduledTask);
+        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
 
-        verify(scheduledEventTracker).jobCompletedEvent(eq(eventConfig), eq(1), eq(2));
+        verify(scheduledEventTracker).jobCompletedEvent(eq(eventConfig), eq(2), eq(1), eq(1));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineSchedulerTest.java
@@ -5,15 +5,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskEventConfiguration;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.search.DefendantResponseDeadlineCheckSearchService;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
-import java.util.function.Supplier;
+import java.util.Set;
 
+import static java.util.Collections.emptySet;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DefendantResponseDeadlineSchedulerTest {
@@ -30,16 +34,18 @@ class DefendantResponseDeadlineSchedulerTest {
     @InjectMocks
     private DefendantResponseDeadlineScheduler scheduler;
 
-    @SuppressWarnings("unchecked")
     @Test
     void shouldRunTaskRunner_whenDeadlineCheckIsCalled() {
         ScheduledTaskEventConfiguration expectedConfig = new ScheduledTaskEventConfiguration(scheduler.getName());
+
+        Set<CaseDetails> caseDetails = emptySet();
+        when(searchService.getCases()).thenReturn(caseDetails);
 
         scheduler.runScheduledTask();
 
         verify(scheduledTaskRunner).run(
             eq(expectedConfig),
-            any(Supplier.class),
+            any(ElasticSearchResult.class),
             eq(defendantResponseDeadlineTask)
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferSchedulerTest.java
@@ -10,8 +10,9 @@ import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskEventConfiguratio
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.service.search.JudgementBufferExpiredSearchService;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
-import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -40,17 +41,17 @@ class JudgementBufferSchedulerTest {
     @Nested
     class Execute {
 
-        @SuppressWarnings("unchecked")
         @Test
         void shouldRunTaskRunner_whenSchedulerIsEnabledAndFeatureToggleIsEnabled() {
-            ScheduledTaskEventConfiguration expectedConfig = new ScheduledTaskEventConfiguration(scheduler.getName());
             when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(true);
+            when(searchService.getSearchResults()).thenReturn(new ElasticSearchResult(0, Stream.empty()));
 
             scheduler.runScheduledTask();
 
+            ScheduledTaskEventConfiguration expectedConfig = new ScheduledTaskEventConfiguration(scheduler.getName());
             verify(scheduledTaskRunner).run(
                 eq(expectedConfig),
-                any(Supplier.class),
+                any(ElasticSearchResult.class),
                 eq(judgementBufferScheduledTask)
             );
         }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
@@ -42,8 +42,12 @@ class JudgementBufferExpiredSearchServiceTest {
     @Test
     void shouldStopPaginatingIfPageIsNotFull() {
         // Given
-        CaseDetails case1 = CaseDetails.builder().id(1L).build();
-        CaseDetails case2 = CaseDetails.builder().id(2L).build();
+        CaseDetails case1 = CaseDetails.builder()
+            .id(1L)
+            .build();
+        CaseDetails case2 = CaseDetails.builder()
+            .id(2L)
+            .build();
 
         // Page size is 50, but we return 2 cases. This should be the last page.
         SearchResult page1 = SearchResult.builder().total(2).cases(List.of(case1, case2)).build();
@@ -92,9 +96,13 @@ class JudgementBufferExpiredSearchServiceTest {
 
         // Let's create 50 cases for the first page.
         List<CaseDetails> fiftyCases = java.util.stream.IntStream.rangeClosed(1, 50)
-            .mapToObj(i -> CaseDetails.builder().id((long) i).build())
+            .mapToObj(i -> CaseDetails.builder()
+                .id((long) i)
+                .build())
             .toList();
-        CaseDetails case51 = CaseDetails.builder().id(51L).build();
+        CaseDetails case51 = CaseDetails.builder()
+            .id(51L)
+            .build();
 
         SearchResult page1 = SearchResult.builder()
             .total(51)
@@ -120,5 +128,30 @@ class JudgementBufferExpiredSearchServiceTest {
 
         assertThat(capturedQueries.get(0).toString()).contains("\"size\": 50");
         assertThat(capturedQueries.get(1).toString()).contains("\"search_after\": [\"50\"]");
+    }
+
+    @Test
+    void shouldLogWarningIfTotalIsLessThanCasesReturned() {
+        // Given
+        CaseDetails case1 = CaseDetails.builder()
+            .id(1L)
+            .build();
+        CaseDetails case2 = CaseDetails.builder()
+            .id(2L)
+            .build();
+
+        // Page size is 50, but we return 2 cases. Total is reported as 1 (inconsistent).
+        SearchResult page1 = SearchResult.builder().total(1).cases(List.of(case1, case2)).build();
+
+        when(coreCaseDataService.searchCasesPaginated(any())).thenReturn(page1);
+
+        // When
+        Stream<CaseDetails> casesStream = searchService.getCasesStream();
+        List<CaseDetails> allCases = casesStream.toList();
+
+        // Then
+        assertThat(allCases).hasSize(2);
+        // Warning is logged internally, we verify the execution finishes correctly.
+        verify(coreCaseDataService, times(1)).searchCasesPaginated(any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
 import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchPaginatedStreamProvider;
+import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -55,7 +57,8 @@ class JudgementBufferExpiredSearchServiceTest {
         when(coreCaseDataService.searchCasesPaginated(any())).thenReturn(page1);
 
         // When
-        Stream<CaseDetails> casesStream = searchService.getCasesStream();
+        ElasticSearchResult searchResult = searchService.getSearchResults();
+        Stream<CaseDetails> casesStream = searchResult.caseDetailsStream();
         List<CaseDetails> allCases = casesStream.toList();
 
         // Then
@@ -118,7 +121,8 @@ class JudgementBufferExpiredSearchServiceTest {
             .thenReturn(page2);
 
         // When
-        Stream<CaseDetails> casesStream = searchService.getCasesStream();
+        ElasticSearchResult searchResult = searchService.getSearchResults();
+        Stream<CaseDetails> casesStream = searchResult.caseDetailsStream();
         List<CaseDetails> allCases = casesStream.toList();
 
         // Then
@@ -146,7 +150,8 @@ class JudgementBufferExpiredSearchServiceTest {
         when(coreCaseDataService.searchCasesPaginated(any())).thenReturn(page1);
 
         // When
-        Stream<CaseDetails> casesStream = searchService.getCasesStream();
+        ElasticSearchResult searchResult = searchService.getSearchResults();
+        Stream<CaseDetails> casesStream = searchResult.caseDetailsStream();
         List<CaseDetails> allCases = casesStream.toList();
 
         // Then

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
@@ -40,6 +40,27 @@ class JudgementBufferExpiredSearchServiceTest {
     }
 
     @Test
+    void shouldStopPaginatingIfPageIsNotFull() {
+        // Given
+        CaseDetails case1 = CaseDetails.builder().id(1L).build();
+        CaseDetails case2 = CaseDetails.builder().id(2L).build();
+
+        // Page size is 50, but we return 2 cases. This should be the last page.
+        SearchResult page1 = SearchResult.builder().total(2).cases(List.of(case1, case2)).build();
+
+        when(coreCaseDataService.searchCasesPaginated(any())).thenReturn(page1);
+
+        // When
+        Stream<CaseDetails> casesStream = searchService.getCasesStream();
+        List<CaseDetails> allCases = casesStream.toList();
+
+        // Then
+        assertThat(allCases).hasSize(2);
+        // Should only call once because the first page was not full
+        verify(coreCaseDataService, times(1)).searchCasesPaginated(any());
+    }
+
+    @Test
     void shouldReturnStreamThatPaginatesCorrectly() {
         // Given
         CaseDetails case1 = CaseDetails.builder().id(1L).build();
@@ -54,39 +75,50 @@ class JudgementBufferExpiredSearchServiceTest {
         CaseDetails case10 = CaseDetails.builder().id(10L).build();
         CaseDetails case11 = CaseDetails.builder().id(11L).build();
 
-        // Page 1
+        // Page 1 - returning full page (size 50 by default in JudgementBufferExpiredSearchService)
+        // For testing we will return 10 cases but the test logic in ElasticSearchPaginatedStreamProvider
+        // will think it's full IF we set the page size to 10 in the query.
+        // Wait, JudgementBufferExpiredSearchService sets page size to 50.
+        // If I want to test pagination with a full page, I should either:
+        // 1. Mock the first page to have 50 cases.
+        // 2. Or, acknowledge that if I return 10 cases, and page size is 50, it will stop.
+
+        // Let's modify the test to reflect the new behavior:
+        // If the first page has 10 cases and page size is 50, it SHOULD stop.
+        // To test pagination, I need the first page to be full (50 cases).
+
+        // Alternatively, I can change the test to use a smaller page size if I could control it,
+        // but it's hardcoded to 50 in JudgementBufferExpiredSearchService.
+
+        // Let's create 50 cases for the first page.
+        List<CaseDetails> fiftyCases = java.util.stream.IntStream.rangeClosed(1, 50)
+            .mapToObj(i -> CaseDetails.builder().id((long) i).build())
+            .toList();
+        CaseDetails case51 = CaseDetails.builder().id(51L).build();
+
         SearchResult page1 = SearchResult.builder()
-            .total(11)
-            .cases(List.of(case1, case2, case3, case4, case5, case6, case7, case8, case9, case10))
+            .total(51)
+            .cases(fiftyCases)
             .build();
-        // Page 2
         SearchResult page2 = SearchResult.builder()
-            .total(11)
-            .cases(List.of(case11))
+            .total(51)
+            .cases(List.of(case51))
             .build();
 
         when(coreCaseDataService.searchCasesPaginated(any(PaginatedQuery.class)))
             .thenReturn(page1)
-            .thenReturn(page2)
-            .thenReturn(SearchResult.builder().cases(List.of()).build());
+            .thenReturn(page2);
 
         // When
         Stream<CaseDetails> casesStream = searchService.getCasesStream();
         List<CaseDetails> allCases = casesStream.toList();
 
         // Then
-        assertThat(allCases).hasSize(11);
-        assertThat(allCases).containsExactly(case1, case2, case3, case4, case5, case6, case7, case8, case9, case10, case11);
-
-        verify(coreCaseDataService, times(3)).searchCasesPaginated(queryCaptor.capture());
+        assertThat(allCases).hasSize(51);
+        verify(coreCaseDataService, times(2)).searchCasesPaginated(queryCaptor.capture());
         List<PaginatedQuery> capturedQueries = queryCaptor.getAllValues();
 
-        assertThat(capturedQueries.get(0).toString()).contains("\"from\": 0");
         assertThat(capturedQueries.get(0).toString()).contains("\"size\": 50");
-        assertThat(capturedQueries.get(0).toString()).contains("\"id\": \"asc\"");
-        assertThat(capturedQueries.get(1).toString()).contains("\"search_after\": [\"10\"]");
-        assertThat(capturedQueries.get(1).toString()).contains("\"from\": 0");
-        assertThat(capturedQueries.get(1).toString()).contains("\"size\": 50");
-        assertThat(capturedQueries.get(1).toString()).contains("\"id\": \"asc\"");
+        assertThat(capturedQueries.get(1).toString()).contains("\"search_after\": [\"50\"]");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
@@ -1,48 +1,87 @@
 package uk.gov.hmcts.reform.civil.service.search;
 
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.mockito.MockedStatic;
-import uk.gov.hmcts.reform.civil.enums.CaseState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
+import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
 import uk.gov.hmcts.reform.civil.model.search.Query;
+import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.stream.Stream;
 
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
-import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.mockStatic;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-class JudgementBufferExpiredSearchServiceTest extends ElasticSearchServiceTest {
+@ExtendWith(MockitoExtension.class)
+class JudgementBufferExpiredSearchServiceTest {
 
-    private static final ZonedDateTime FIXED_NOW = ZonedDateTime.of(2025, 7, 8, 10, 0, 0, 0, ZoneOffset.UTC);
-    private MockedStatic<ZonedDateTime> zonedDateTimeMock;
+    @Mock
+    private CoreCaseDataService coreCaseDataService;
+
+    private ElasticSearchPaginatedStreamProvider elasticSearchPaginatedStreamProvider;
+    private JudgementBufferExpiredSearchService searchService;
+
+    @Captor
+    private ArgumentCaptor<PaginatedQuery> queryCaptor;
 
     @BeforeEach
     void setup() {
-        searchService = new JudgementBufferExpiredSearchService(coreCaseDataService);
-        zonedDateTimeMock = mockStatic(ZonedDateTime.class, CALLS_REAL_METHODS);
-        zonedDateTimeMock.when(() -> ZonedDateTime.now(ZoneOffset.UTC)).thenReturn(FIXED_NOW);
+        elasticSearchPaginatedStreamProvider = new ElasticSearchPaginatedStreamProvider(coreCaseDataService);
+        searchService = new JudgementBufferExpiredSearchService(elasticSearchPaginatedStreamProvider);
     }
 
-    @AfterEach
-    void tearDown() {
-        zonedDateTimeMock.close();
-    }
+    @Test
+    void shouldReturnStreamThatPaginatesCorrectly() {
+        // Given
+        CaseDetails case1 = CaseDetails.builder().id(1L).build();
+        CaseDetails case2 = CaseDetails.builder().id(2L).build();
+        CaseDetails case3 = CaseDetails.builder().id(3L).build();
+        CaseDetails case4 = CaseDetails.builder().id(4L).build();
+        CaseDetails case5 = CaseDetails.builder().id(5L).build();
+        CaseDetails case6 = CaseDetails.builder().id(6L).build();
+        CaseDetails case7 = CaseDetails.builder().id(7L).build();
+        CaseDetails case8 = CaseDetails.builder().id(8L).build();
+        CaseDetails case9 = CaseDetails.builder().id(9L).build();
+        CaseDetails case10 = CaseDetails.builder().id(10L).build();
+        CaseDetails case11 = CaseDetails.builder().id(11L).build();
 
-    @Override
-    protected Query buildQuery(int fromValue) {
-        ZonedDateTime timeMinus48Hours = FIXED_NOW.minusHours(48);
-        BoolQueryBuilder query = boolQuery()
-            .minimumShouldMatch(1)
-            .should(boolQuery()
-                        .must(rangeQuery("data.joDJCreatedDate").lte(timeMinus48Hours))
-                        .must(boolQuery().must(matchQuery("state", CaseState.JUDGMENT_REQUESTED.toString())))
-                        .must(((JudgementBufferExpiredSearchService) searchService).haveNoOngoingBusinessProcess()));
-        return new Query(query, List.of("reference"), fromValue, true);
+        // Page 1
+        SearchResult page1 = SearchResult.builder()
+            .total(11)
+            .cases(List.of(case1, case2, case3, case4, case5, case6, case7, case8, case9, case10))
+            .build();
+        // Page 2
+        SearchResult page2 = SearchResult.builder()
+            .total(11)
+            .cases(List.of(case11))
+            .build();
+
+        when(coreCaseDataService.searchCasesPaginated(any(PaginatedQuery.class)))
+            .thenReturn(page1)
+            .thenReturn(page2);
+
+        // When
+        Stream<CaseDetails> casesStream = searchService.getCases();
+        List<CaseDetails> allCases = casesStream.toList();
+
+        // Then
+        assertThat(allCases).hasSize(11);
+        assertThat(allCases).containsExactly(case1, case2, case3, case4, case5, case6, case7, case8, case9, case10, case11);
+
+        verify(coreCaseDataService, times(2)).searchCasesPaginated(queryCaptor.capture());
+        List<PaginatedQuery> capturedQueries = queryCaptor.getAllValues();
+
+        assertThat(capturedQueries.get(0).toString()).contains("\"from\": 0");
+        assertThat(capturedQueries.get(1).toString()).contains("\"search_after\": [\"10\"]");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
 import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
-import uk.gov.hmcts.reform.civil.model.search.Query;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 
 import java.util.List;
@@ -68,20 +67,26 @@ class JudgementBufferExpiredSearchServiceTest {
 
         when(coreCaseDataService.searchCasesPaginated(any(PaginatedQuery.class)))
             .thenReturn(page1)
-            .thenReturn(page2);
+            .thenReturn(page2)
+            .thenReturn(SearchResult.builder().cases(List.of()).build());
 
         // When
-        Stream<CaseDetails> casesStream = searchService.getCases();
+        Stream<CaseDetails> casesStream = searchService.getCasesStream();
         List<CaseDetails> allCases = casesStream.toList();
 
         // Then
         assertThat(allCases).hasSize(11);
         assertThat(allCases).containsExactly(case1, case2, case3, case4, case5, case6, case7, case8, case9, case10, case11);
 
-        verify(coreCaseDataService, times(2)).searchCasesPaginated(queryCaptor.capture());
+        verify(coreCaseDataService, times(3)).searchCasesPaginated(queryCaptor.capture());
         List<PaginatedQuery> capturedQueries = queryCaptor.getAllValues();
 
         assertThat(capturedQueries.get(0).toString()).contains("\"from\": 0");
+        assertThat(capturedQueries.get(0).toString()).contains("\"size\": 50");
+        assertThat(capturedQueries.get(0).toString()).contains("\"id\": \"asc\"");
         assertThat(capturedQueries.get(1).toString()).contains("\"search_after\": [\"10\"]");
+        assertThat(capturedQueries.get(1).toString()).contains("\"from\": 0");
+        assertThat(capturedQueries.get(1).toString()).contains("\"size\": 50");
+        assertThat(capturedQueries.get(1).toString()).contains("\"id\": \"asc\"");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/search/JudgementBufferExpiredSearchServiceTest.java
@@ -39,6 +39,7 @@ class JudgementBufferExpiredSearchServiceTest {
     void setup() {
         elasticSearchPaginatedStreamProvider = new ElasticSearchPaginatedStreamProvider(coreCaseDataService);
         searchService = new JudgementBufferExpiredSearchService(elasticSearchPaginatedStreamProvider);
+        org.springframework.test.util.ReflectionTestUtils.setField(searchService, "pageSize", 50);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchPaginatedStreamProviderTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchPaginatedStreamProviderTest.java
@@ -1,0 +1,198 @@
+package uk.gov.hmcts.reform.civil.service.search.common;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
+import uk.gov.hmcts.reform.civil.model.search.PaginatedQuery;
+import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ElasticSearchPaginatedStreamProviderTest {
+
+    @Mock
+    private CoreCaseDataService coreCaseDataService;
+
+    private ElasticSearchPaginatedStreamProvider provider;
+
+    @BeforeEach
+    void setup() {
+        provider = new ElasticSearchPaginatedStreamProvider(coreCaseDataService);
+    }
+
+    @Test
+    void shouldPaginateCorrectlyForThreePagesUsingGetPaginatedSearchResult() {
+        CaseDetails case1 = CaseDetails.builder().id(1L).build();
+        CaseDetails case2 = CaseDetails.builder().id(2L).build();
+        CaseDetails case3 = CaseDetails.builder().id(3L).build();
+
+        SearchResult page1 = SearchResult.builder().total(3).cases(List.of(case1)).build();
+        SearchResult page2 = SearchResult.builder().total(3).cases(List.of(case2)).build();
+        SearchResult page3 = SearchResult.builder().total(3).cases(List.of(case3)).build();
+
+        when(coreCaseDataService.searchCasesPaginated(any(PaginatedQuery.class)))
+            .thenAnswer(invocation -> {
+                PaginatedQuery query = invocation.getArgument(0);
+                if (query.getSearchAfterValue() == null) {
+                    return page1;
+                } else if (query.getSearchAfterValue().equals("1")) {
+                    return page2;
+                } else if (query.getSearchAfterValue().equals("2")) {
+                    return page3;
+                }
+                return SearchResult.builder().total(0).cases(List.of()).build();
+            });
+
+        ElasticSearchResult result = provider.getPaginatedSearchResult(
+            searchAfter -> new PaginatedQuery(null, null, 0, searchAfter == null, searchAfter, 1)
+        );
+
+        assertThat(result.totalResults()).isEqualTo(3);
+        List<CaseDetails> cases = result.caseDetailsStream().toList();
+
+        assertThat(cases).hasSize(3);
+        assertThat(cases.get(0).getId()).isEqualTo(1L);
+        assertThat(cases.get(1).getId()).isEqualTo(2L);
+        assertThat(cases.get(2).getId()).isEqualTo(3L);
+
+        verify(coreCaseDataService, times(4)).searchCasesPaginated(any());
+    }
+
+    @Test
+    void shouldPaginateCorrectlyUsingGetPaginatedStream() {
+        CaseDetails case1 = CaseDetails.builder().id(1L).build();
+        CaseDetails case2 = CaseDetails.builder().id(2L).build();
+
+        SearchResult page1 = SearchResult.builder().total(2).cases(List.of(case1)).build();
+        SearchResult page2 = SearchResult.builder().total(2).cases(List.of(case2)).build();
+
+        when(coreCaseDataService.searchCasesPaginated(any(PaginatedQuery.class)))
+            .thenAnswer(invocation -> {
+                PaginatedQuery query = invocation.getArgument(0);
+                if (query.getSearchAfterValue() == null) {
+                    return page1;
+                } else if (query.getSearchAfterValue().equals("1")) {
+                    return page2;
+                }
+                return SearchResult.builder().total(0).cases(List.of()).build();
+            });
+
+        Stream<CaseDetails> stream = provider.getPaginatedStream(
+            searchAfter -> new PaginatedQuery(null, null, 0, searchAfter == null, searchAfter, 1)
+        );
+
+        List<CaseDetails> cases = stream.toList();
+
+        assertThat(cases).hasSize(2);
+        assertThat(cases.get(0).getId()).isEqualTo(1L);
+        assertThat(cases.get(1).getId()).isEqualTo(2L);
+    }
+
+    @Test
+    void shouldHandleEmptyResults() {
+        SearchResult emptyResult = SearchResult.builder().total(0).cases(Collections.emptyList()).build();
+        when(coreCaseDataService.searchCasesPaginated(any())).thenReturn(emptyResult);
+
+        ElasticSearchResult result = provider.getPaginatedSearchResult(
+            searchAfter -> new PaginatedQuery(null, null, 0, searchAfter == null, searchAfter, 10)
+        );
+
+        assertThat(result.totalResults()).isEqualTo(0);
+        assertThat(result.caseDetailsStream().toList()).isEmpty();
+    }
+
+    @Test
+    void shouldHandleNullSearchResult() {
+        when(coreCaseDataService.searchCasesPaginated(any())).thenReturn(null);
+
+        ElasticSearchResult result = provider.getPaginatedSearchResult(
+            searchAfter -> new PaginatedQuery(null, null, 0, searchAfter == null, searchAfter, 10)
+        );
+
+        assertThat(result.totalResults()).isEqualTo(0);
+        assertThat(result.caseDetailsStream().toList()).isEmpty();
+    }
+
+    @Test
+    void shouldHandleNullCasesInSearchResult() {
+        SearchResult searchResult = SearchResult.builder().total(10).cases(null).build();
+        when(coreCaseDataService.searchCasesPaginated(any())).thenReturn(searchResult);
+
+        ElasticSearchResult result = provider.getPaginatedSearchResult(
+            searchAfter -> new PaginatedQuery(null, null, 0, searchAfter == null, searchAfter, 10)
+        );
+
+        assertThat(result.totalResults()).isEqualTo(10);
+        assertThat(result.caseDetailsStream().toList()).isEmpty();
+    }
+
+    @Test
+    void shouldStopIfPaginationStallsToAvoidInfiniteLoop() {
+        CaseDetails case1 = CaseDetails.builder().id(1L).build();
+        // Return same case twice, so sortKey doesn't change
+        SearchResult page = SearchResult.builder().total(10).cases(List.of(case1)).build();
+
+        when(coreCaseDataService.searchCasesPaginated(any())).thenReturn(page);
+
+        ElasticSearchResult result = provider.getPaginatedSearchResult(
+            searchAfter -> new PaginatedQuery(null, null, 0, searchAfter == null, searchAfter, 1)
+        );
+
+        List<CaseDetails> cases = result.caseDetailsStream().toList();
+
+        // Should only have 1 case because pagination stalled
+        assertThat(cases).hasSize(1);
+        verify(coreCaseDataService, times(2)).searchCasesPaginated(any());
+    }
+
+    @Test
+    void shouldHandleCustomSortKeyExtractor() {
+        Map<String, Object> data1 = new HashMap<>();
+        data1.put("customKey", "AAA");
+        CaseDetails case1 = CaseDetails.builder().id(1L).data(data1).build();
+
+        Map<String, Object> data2 = new HashMap<>();
+        data2.put("customKey", "BBB");
+        CaseDetails case2 = CaseDetails.builder().id(2L).data(data2).build();
+
+        SearchResult page1 = SearchResult.builder().total(2).cases(List.of(case1)).build();
+        SearchResult page2 = SearchResult.builder().total(2).cases(List.of(case2)).build();
+
+        when(coreCaseDataService.searchCasesPaginated(any(PaginatedQuery.class)))
+            .thenAnswer(invocation -> {
+                PaginatedQuery query = invocation.getArgument(0);
+                if (query.getSearchAfterValue() == null) {
+                    return page1;
+                } else if (query.getSearchAfterValue().equals("AAA")) {
+                    return page2;
+                }
+                return SearchResult.builder().total(0).cases(List.of()).build();
+            });
+
+        ElasticSearchResult result = provider.getPaginatedSearchResult(
+            searchAfter -> new PaginatedQuery(null, null, 0, searchAfter == null, searchAfter, 1),
+            caseDetails -> (String) caseDetails.getData().get("customKey")
+        );
+
+        List<CaseDetails> cases = result.caseDetailsStream().toList();
+
+        assertThat(cases).hasSize(2);
+        assertThat(cases.get(0).getId()).isEqualTo(1L);
+        assertThat(cases.get(1).getId()).isEqualTo(2L);
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5622


### Change description ###
This PR introduces a robust and memory-efficient paginated search mechanism for scheduled tasks, specifically refactoring the `JudgementBufferScheduler` to use this new approach.

### Key Changes

#### 1. Paginated Search Infrastructure
- **`ElasticSearchPaginatedStreamProvider`**: A new component that leverages a custom `Spliterator` to provide a `Stream<CaseDetails>` that lazily fetches pages from ElasticSearch. This ensures the application remains memory-efficient even when processing large volumes of cases.
- **`PaginatedQuery`**: A new model to support `search_after` pagination in ElasticSearch, replacing the previous `from/size` approach which has a 10k record limit.
- **`ElasticSearchResult`**: A record that encapsulates both the total count of results and the stream of cases, allowing schedulers to report total progress before processing begins.

#### 2. Scheduler Refactoring
- **`ScheduledTaskRunner` & `ScheduledTaskProcessor`**: Refactored to accept `ElasticSearchResult` instead of a `Set<CaseDetails>`. The processor now handles cases sequentially through the stream, which is particularly beneficial for high-volume tasks.
- **Concurrency & Safety**: Updated `ScheduledTaskProcessor` to use thread-safe collections (`Collections.synchronizedList`) and atomic counters (`AtomicInteger`) for tracking successes and failures, ensuring stability during stream processing.
- **Circuit Breaker**: Retained the circuit breaker logic within the stream-based processing to abort early if the consecutive failure threshold is reached.

#### 3. Service Implementations
- **`JudgementBufferExpiredSearchService`**: Completely refactored to use the new paginated search. It now uses a page size of 50 and handles high-volume case retrieval gracefully.
- **`DefendantResponseDeadlineScheduler`**: Updated with a compatibility wrapper (`resultsFrom`) to align with the new `ScheduledTaskRunner` API while maintaining its existing search logic.

#### 4. Testing & Verification
- **Integration Tests**: Updated `JudgementBufferSchedulerITest` and `CoreCaseDataApiMockHelper` to simulate and verify paginated API responses.
- **Unit Tests**: Enhanced test coverage for `ScheduledTaskProcessor`, `ScheduledTaskRunner`, and `JudgementBufferExpiredSearchService` to cover edge cases such as empty results, partial pages, and circuit breaker triggers.

### Technical Details
- **Pagination Strategy**: Uses `search_after` with a sort key (defaulting to case ID) to ensure reliable traversal of the entire result set.
- **Efficiency**: Pagination only makes subsequent requests if the previous page was full, minimizing unnecessary API calls.
- **Logging**: Added detailed debug logging for pagination progress and warnings for potential infinite loops or data inconsistencies.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
