### PR TITLE
Fix scheduler alert query in scheduler-alerts.tf to include abortReason

### DIFF
--- a/infrastructure/scheduler-alerts.tf
+++ b/infrastructure/scheduler-alerts.tf
@@ -43,7 +43,8 @@ module "scheduler-aborted-alerts" {
   app_insights_query = <<-AIQ
       customEvents
         | where name == "${each.key}JobAborted"
-        | project timestamp, name, properties.abortReason
+        | extend abortReason = tostring(column_ifexists('properties.abortReason', 'Unknown'))
+        | project timestamp, name, abortReason
       AIQ
 
   custom_email_subject       = "Warning: The scheduler ${each.key} in ${var.env} has aborted."


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5455


### Change description ###
Fix scheduler alert query to include correct syntax for abortReason


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
