### PR TITLE
Use 4.x branch for service bus subscription module

### DIFF
--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -4,7 +4,6 @@ module "servicebus-subscription" {
   name                = "hmc-to-civil-subscription-${var.env}"
   namespace_id        = "hmc-servicebus-${var.env}"
   topic_name          = "hmc-to-cft-${var.env}"
-  resource_group_name = "hmc-shared-${var.env}"
 }
 
 resource "azurerm_servicebus_subscription_rule" "topic_filter_rule_civil" {

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -1,6 +1,6 @@
 #HMC to Hearings API
 module "servicebus-subscription" {
-  source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-18682"
+  source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x"
   name                = "hmc-to-civil-subscription-${var.env}"
   namespace_name      = "hmc-servicebus-${var.env}"
   topic_name          = "hmc-to-cft-${var.env}"

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -2,7 +2,7 @@
 module "servicebus-subscription" {
   source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x"
   name                = "hmc-to-civil-subscription-${var.env}"
-  namespace_name      = "hmc-servicebus-${var.env}"
+  namespace_id      = "hmc-servicebus-${var.env}"
   topic_name          = "hmc-to-cft-${var.env}"
   resource_group_name = "hmc-shared-${var.env}"
 }

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -1,8 +1,13 @@
 #HMC to Hearings API
+data "azurerm_servicebus_namespace" "hmc_servicebus_namespace" {
+  name                = "hmc-servicebus-${var.env}"
+  resource_group_name = "hmc-shared-${var.env}"
+}
+
 module "servicebus-subscription" {
   source       = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x"
   name         = "hmc-to-civil-subscription-${var.env}"
-  namespace_id = "hmc-servicebus-${var.env}"
+  namespace_id = data.azurerm_servicebus_namespace.hmc_servicebus_namespace.id
   topic_name   = "hmc-to-cft-${var.env}"
 }
 

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -1,9 +1,9 @@
 #HMC to Hearings API
 module "servicebus-subscription" {
-  source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x"
-  name                = "hmc-to-civil-subscription-${var.env}"
-  namespace_id        = "hmc-servicebus-${var.env}"
-  topic_name          = "hmc-to-cft-${var.env}"
+  source       = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x"
+  name         = "hmc-to-civil-subscription-${var.env}"
+  namespace_id = "hmc-servicebus-${var.env}"
+  topic_name   = "hmc-to-cft-${var.env}"
 }
 
 resource "azurerm_servicebus_subscription_rule" "topic_filter_rule_civil" {

--- a/infrastructure/service-bus.tf
+++ b/infrastructure/service-bus.tf
@@ -2,7 +2,7 @@
 module "servicebus-subscription" {
   source              = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=4.x"
   name                = "hmc-to-civil-subscription-${var.env}"
-  namespace_id      = "hmc-servicebus-${var.env}"
+  namespace_id        = "hmc-servicebus-${var.env}"
   topic_name          = "hmc-to-cft-${var.env}"
   resource_group_name = "hmc-shared-${var.env}"
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Use 4.x branch for service bus subscription module as DTSPO-18682 has been deleted


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
