### PR TITLE
DTSCCI-5640: Update build.gradle to set default Docker API version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -698,6 +698,8 @@ tasks.withType(Test).configureEach { t ->
   jvmArgs '-XX:ReservedCodeCacheSize=512m'
   // Temurin 21.0.7 occasionally crashes in C2 (BoolNode::Ideal SIGSEGV); stay on C1 until upstream fix.
   jvmArgs "-XX:TieredStopAtLevel=1"
+  // Docker Desktop 29 (Engine API 1.54) rejects docker-java's older default API version.
+  systemProperty 'api.version', System.getProperty('api.version', '1.40')
 
   testLogging {
     exceptionFormat = 'full'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5640


### Change description ###
Set the Docker API version for Gradle test JVMs to 1.40 in build.gradle: 
`systemProperty 'api.version', System.getProperty('api.version', '1.40')` 
This allows Testcontainers to connect to Docker Desktop successfully while still allowing the value to be overridden if needed.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
