### PR TITLE
DTSCCI-5678: Fix PROCEEDS_IN_HERITAGE_SYSTEM ambiguous transition

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/workflow/ccd/StartBusinessProcessWorkflowTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/workflow/ccd/StartBusinessProcessWorkflowTest.java
@@ -1,0 +1,44 @@
+package uk.gov.hmcts.reform.civil.workflow.ccd;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.enums.BusinessProcessStatus;
+import uk.gov.hmcts.reform.civil.model.StateFlowDTO;
+import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
+import uk.gov.hmcts.reform.civil.service.flowstate.IStateFlowEngine;
+import uk.gov.hmcts.reform.civil.stateflow.model.State;
+import uk.gov.hmcts.reform.civil.workflow.WorkflowIntegrationTest;
+import uk.gov.hmcts.reform.civil.workflow.ccd.fixture.StartBusinessProcessFixtures;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings({"java:S5960", "java:S6813"})
+class StartBusinessProcessWorkflowTest extends WorkflowIntegrationTest {
+
+    @Autowired
+    private IStateFlowEngine stateFlowEngine;
+
+    @MockBean
+    private FeatureToggleService featureToggleService;
+
+    @Test
+    void shouldStartBusinessProcessAndResolveStateFlowForProceedsInHeritageSystemCaseData() throws Exception {
+        startWorkflow(StartBusinessProcessFixtures.proceedsInHeritageSystemCaseData())
+            .eventId(CaseEvent.START_BUSINESS_PROCESS)
+            .aboutToSubmit()
+            .then(result -> {
+                assertThat(result.response().getErrors()).isNullOrEmpty();
+                assertThat(result.caseData().getBusinessProcess())
+                    .extracting("status", "camundaEvent")
+                    .containsExactly(BusinessProcessStatus.STARTED, CaseEvent.START_BUSINESS_PROCESS.name());
+
+                StateFlowDTO stateFlow = stateFlowEngine.getStateFlow(result.caseData());
+
+                assertThat(stateFlow.getState().getName())
+                    .as("state history: %s", stateFlow.getStateHistory())
+                    .isNotEqualTo(State.ERROR_STATE);
+            });
+    }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/workflow/ccd/fixture/StartBusinessProcessFixtures.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/workflow/ccd/fixture/StartBusinessProcessFixtures.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.civil.workflow.ccd.fixture;
+
+import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.enums.CaseState;
+import uk.gov.hmcts.reform.civil.model.BusinessProcess;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.workflow.helper.CaseDataTemplates;
+
+public final class StartBusinessProcessFixtures {
+
+    private static final String PROCEEDS_IN_HERITAGE_SYSTEM_TEMPLATE =
+        "start-business-process-proceeds-in-heritage-system";
+    private static final long CASE_REFERENCE = 1779198401913981L;
+
+    private StartBusinessProcessFixtures() {
+    }
+
+    public static CaseData proceedsInHeritageSystemCaseData() {
+        return CaseDataTemplates.load(PROCEEDS_IN_HERITAGE_SYSTEM_TEMPLATE, template -> {
+            CaseDataTemplates.set(template, "ccdCaseReference", CASE_REFERENCE);
+            CaseDataTemplates.set(template, "ccdState", CaseState.PROCEEDS_IN_HERITAGE_SYSTEM);
+            CaseDataTemplates.set(template, "businessProcess", BusinessProcess.ready(CaseEvent.START_BUSINESS_PROCESS));
+        });
+    }
+}

--- a/src/integrationTest/resources/templates/case-data/start-business-process-proceeds-in-heritage-system.json
+++ b/src/integrationTest/resources/templates/case-data/start-business-process-proceeds-in-heritage-system.json
@@ -1,0 +1,889 @@
+{
+  "claimFee": {
+    "code": "FEE0209",
+    "version": "3",
+    "calculatedAmountInPence": "250000"
+  },
+  "caseNotes": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "note": "Debug case note",
+        "createdBy": "Debug User",
+        "createdOn": "2025-12-30T12:34:27"
+      }
+    },
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "note": "Debug case note",
+        "createdBy": "Debug User",
+        "createdOn": "2025-12-17T08:33:59"
+      }
+    },
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "note": "Debug case note",
+        "createdBy": "Debug User",
+        "createdOn": "2025-12-02T12:50:50"
+      }
+    }
+  ],
+  "claimType": "PERSONAL_INJURY",
+  "issueDate": "2025-11-24",
+  "applicant1": {
+    "type": "INDIVIDUAL",
+    "flags": {
+      "partyName": "Debug Claimant v Debug Defendant One Ltd",
+      "roleOnCase": "Claimant 1"
+    },
+    "partyID": "debug-party-id",
+    "partyName": "Debug Claimant v Debug Defendant One Ltd",
+    "primaryAddress": {
+      "PostCode": "ZZ1 1ZZ",
+      "PostTown": "Debugtown",
+      "AddressLine1": "1 Debug Street",
+      "AddressLine2": "Debug Area"
+    },
+    "individualTitle": "Ms",
+    "individualLastName": "Claimant",
+    "individualFirstName": "Debug",
+    "individualDateOfBirth": "1990-01-01",
+    "partyTypeDisplayValue": "Individual"
+  },
+  "claimValue": {
+    "statementOfValueInPennies": "5000000"
+  },
+  "respondent1": {
+    "type": "COMPANY",
+    "flags": {
+      "partyName": "Debug Claimant v Debug Defendant One Ltd",
+      "roleOnCase": "Defendant 1"
+    },
+    "partyID": "debug-party-id",
+    "partyName": "Debug Claimant v Debug Defendant One Ltd",
+    "companyName": "Debug Claimant v Debug Defendant One Ltd",
+    "primaryAddress": {
+      "PostCode": "ZZ1 1ZZ",
+      "PostTown": "Debugtown",
+      "AddressLine1": "1 Debug Street"
+    },
+    "partyTypeDisplayValue": "Company"
+  },
+  "respondent2": {
+    "type": "COMPANY",
+    "flags": {
+      "partyName": "Debug Claimant v Debug Defendant One Ltd",
+      "roleOnCase": "Defendant 2"
+    },
+    "partyID": "debug-party-id",
+    "partyName": "Debug Claimant v Debug Defendant One Ltd",
+    "companyName": "Debug Claimant v Debug Defendant One Ltd",
+    "primaryAddress": {
+      "PostCode": "ZZ1 1ZZ",
+      "PostTown": "Debugtown",
+      "AddressLine1": "1 Debug Street",
+      "AddressLine2": "Debug Area"
+    },
+    "partyTypeDisplayValue": "Company"
+  },
+  "nextDeadline": "2026-05-14",
+  "addApplicant2": "No",
+  "allPartyNames": "Debug Claimant v Debug Defendant One Ltd",
+  "courtLocation": {
+    "caseLocation": {
+      "region": "2",
+      "baseLocation": "000000"
+    },
+    "applicantPreferredCourt": "000",
+    "reasonForHearingAtSpecificCourt": "Debug text"
+  },
+  "submittedDate": "2025-11-24T17:26:27",
+  "SearchCriteria": {
+    "SearchParties": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "Name": "Debug Claimant v Debug Defendant One Ltd",
+          "PostCode": "ZZ1 1ZZ",
+          "AddressLine1": "1 Debug Street",
+          "EmailAddress": "debug.user@example.test"
+        }
+      },
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "Name": "Debug Claimant v Debug Defendant One Ltd",
+          "PostCode": "ZZ1 1ZZ",
+          "AddressLine1": "1 Debug Street",
+          "EmailAddress": "debug.user@example.test"
+        }
+      },
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "Name": "Debug Claimant v Debug Defendant One Ltd",
+          "PostCode": "ZZ1 1ZZ",
+          "DateOfBirth": "1990-01-01",
+          "AddressLine1": "1 Debug Street",
+          "EmailAddress": "debug.user@example.test"
+        }
+      }
+    ],
+    "OtherCaseReferences": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": "DEBUG-CASE-001"
+      }
+    ]
+  },
+  "addRespondent2": "Yes",
+  "allocatedTrack": "INTERMEDIATE_CLAIM",
+  "anyRepresented": "Yes",
+  "caseNamePublic": "Debug Claimant v Debug Defendant One Ltd",
+  "detailsOfClaim": "Debug text",
+  "gaAddlDocStaff": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "applications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-19T13:46:40.364490331",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 0,
+        "createdDatetime": "2026-05-19T14:46:41"
+      }
+    }
+  ],
+  "businessProcess": {
+    "status": "STARTED",
+    "camundaEvent": "CASE_PROCEEDS_IN_CASEMAN",
+    "processInstanceId": "debug-process-instance"
+  },
+  "claimTypeUnSpec": "PERSONAL_INJURY",
+  "featureToggleWA": "Prod",
+  "gaDraftDocStaff": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "applications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-20T15:23:07.770900351",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 47165,
+        "documentType": "GENERAL_APPLICATION_DRAFT",
+        "createdDatetime": "2026-05-20T16:23:07"
+      }
+    }
+  ],
+  "generalAppTypeLR": {
+    "types": [
+      "EXTEND_TIME"
+    ]
+  },
+  "gaAddlDocClaimant": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "applications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-19T13:46:40.364490331",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 0,
+        "createdDatetime": "2026-05-19T14:46:41"
+      }
+    }
+  ],
+  "CaseAccessCategory": "UNSPEC_CLAIM",
+  "gaDraftDocClaimant": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "applications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-20T15:23:07.770900351",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 47165,
+        "documentType": "GENERAL_APPLICATION_DRAFT",
+        "createdDatetime": "2026-05-20T16:23:07"
+      }
+    }
+  ],
+  "personalInjuryType": "WORK_ACCIDENT",
+  "generalApplications": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "caseLink": {
+          "CaseReference": "1111222233334444"
+        },
+        "gaWaTrackLabel": " - Intermediate Track",
+        "generalAppType": {
+          "types": [
+            "EXTEND_TIME"
+          ]
+        },
+        "businessProcess": {
+          "status": "FINISHED",
+          "camundaEvent": "CREATE_GENERAL_APPLICATION_CASE",
+          "processInstanceId": "debug-process-instance"
+        },
+        "isGaApplicantLip": "No",
+        "litigiousPartyID": "debug-party-id",
+        "caseNameGaInternal": "Debug Claimant v Debug Defendant One Ltd",
+        "emailPartyReference": "debug.user@example.test",
+        "isGaRespondentOneLip": "No",
+        "isGaRespondentTwoLip": "No",
+        "mainCaseSubmittedDate": "2025-11-24T17:26:27",
+        "caseManagementLocation": {
+          "region": "2",
+          "address": "Debug Court, 1 Debug Street",
+          "postcode": "ZZ1 1ZZ",
+          "siteName": "Debug Hearing Centre",
+          "baseLocation": "000000"
+        },
+        "generalAppConsentOrder": "No",
+        "generalAppDateDeadline": "2026-05-26T16:00:00",
+        "parentClaimantIsApplicant": "No",
+        "generalAppSubmittedDateGAspec": "2026-05-19T13:46:40",
+        "generalAppApplicantAddlSolicitors": [
+          {
+            "id": "00000000-0000-4000-8000-000000000001",
+            "value": {
+              "id": "00000000-0000-4000-8000-000000000001",
+              "email": "debug.user@example.test",
+              "organisationIdentifier": "DEBUGORG"
+            }
+          },
+          {
+            "id": "00000000-0000-4000-8000-000000000001",
+            "value": {
+              "id": "00000000-0000-4000-8000-000000000001",
+              "email": "debug.user@example.test",
+              "organisationIdentifier": "DEBUGORG"
+            }
+          },
+          {
+            "id": "00000000-0000-4000-8000-000000000001",
+            "value": {
+              "id": "00000000-0000-4000-8000-000000000001",
+              "email": "debug.user@example.test",
+              "organisationIdentifier": "DEBUGORG"
+            }
+          },
+          {
+            "id": "00000000-0000-4000-8000-000000000001",
+            "value": {
+              "id": "00000000-0000-4000-8000-000000000001",
+              "email": "debug.user@example.test",
+              "organisationIdentifier": "DEBUGORG"
+            }
+          },
+          {
+            "id": "00000000-0000-4000-8000-000000000001",
+            "value": {
+              "id": "00000000-0000-4000-8000-000000000001",
+              "email": "debug.user@example.test",
+              "organisationIdentifier": "DEBUGORG"
+            }
+          },
+          {
+            "id": "00000000-0000-4000-8000-000000000001",
+            "value": {
+              "id": "00000000-0000-4000-8000-000000000001",
+              "email": "debug.user@example.test",
+              "organisationIdentifier": "DEBUGORG"
+            }
+          },
+          {
+            "id": "00000000-0000-4000-8000-000000000001",
+            "value": {
+              "id": "00000000-0000-4000-8000-000000000001",
+              "email": "debug.user@example.test",
+              "organisationIdentifier": "DEBUGORG"
+            }
+          },
+          {
+            "id": "00000000-0000-4000-8000-000000000001",
+            "value": {
+              "id": "00000000-0000-4000-8000-000000000001",
+              "email": "debug.user@example.test",
+              "organisationIdentifier": "DEBUGORG"
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "legacyCaseReference": "DEBUG-CASE-REFERENCE",
+  "notificationSummary": "Debug notification summary",
+  "servedDocumentFiles": {
+    "other": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "document": {
+            "category_id": "particularsOfClaim",
+            "document_url": "http://example.test/documents/debug-document",
+            "upload_timestamp": "2026-03-19T09:30:38.034499135",
+            "document_filename": "debug-document.pdf",
+            "document_binary_url": "http://example.test/documents/debug-document/binary"
+          }
+        }
+      }
+    ],
+    "medicalReport": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "document": {
+            "category_id": "particularsOfClaim",
+            "document_url": "http://example.test/documents/debug-document",
+            "upload_timestamp": "2026-03-19T08:27:53.830875427",
+            "document_filename": "debug-document.pdf",
+            "document_binary_url": "http://example.test/documents/debug-document/binary"
+          }
+        }
+      }
+    ],
+    "scheduleOfLoss": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "document": {
+            "category_id": "particularsOfClaim",
+            "document_url": "http://example.test/documents/debug-document",
+            "upload_timestamp": "2026-03-19T08:27:53.830875427",
+            "document_filename": "debug-document.pdf",
+            "document_binary_url": "http://example.test/documents/debug-document/binary"
+          }
+        }
+      }
+    ],
+    "particularsOfClaimDocument": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "category_id": "particularsOfClaim",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-03-19T08:27:53.830875427",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        }
+      }
+    ]
+  },
+  "solicitorReferences": {
+    "applicantSolicitor1Reference": "DEBUG-REFERENCE",
+    "respondentSolicitor1Reference": "DEBUG-REFERENCE"
+  },
+  "claimantGaAppDetails": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "caseLink": {
+          "CaseReference": "1111222233334444"
+        },
+        "caseState": "Order Made",
+        "generalApplicationType": "Extend time",
+        "parentClaimantIsApplicant": "No",
+        "generalAppSubmittedDateGAspec": "2026-05-19T13:46:40"
+      }
+    }
+  ],
+  "generalOrderDocStaff": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "ordersMadeOnApplications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-25T07:45:32.773818381",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 39292,
+        "documentType": "GENERAL_ORDER",
+        "createdDatetime": "2026-05-25T08:45:32"
+      }
+    }
+  ],
+  "caseNameHmctsInternal": "Debug Claimant v Debug Defendant One Ltd",
+  "claimIssuedPBADetails": {
+    "fee": {
+      "code": "FEE0209",
+      "version": "3",
+      "calculatedAmountInPence": "250000"
+    },
+    "serviceRequestReference": "DEBUG-CASE-REFERENCE"
+  },
+  "claimNotificationDate": "2026-03-19T09:27:13",
+  "caseManagementCategory": {
+    "value": {
+      "code": "Civil",
+      "label": "Civil"
+    },
+    "list_items": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "code": "Civil",
+          "label": "Civil"
+        }
+      }
+    ]
+  },
+  "caseManagementLocation": {
+    "region": "2",
+    "baseLocation": "000000"
+  },
+  "changeOfRepresentation": {
+    "caseRole": "[RESPONDENTSOLICITORTWO]",
+    "timestamp": "2026-03-24T15:11:34",
+    "organisationToAddID": "DEBUGORG"
+  },
+  "claimDismissedDeadline": "2029-05-21T23:59:59",
+  "claimProceedsInCaseman": {
+    "date": "2026-06-15",
+    "other": "Debug text",
+    "reason": "OTHER"
+  },
+  "cosNotifyClaimDetails2": {
+    "cosSender": "Debug Party",
+    "cosDocSaved": "Yes",
+    "cosRecipient": "Debug Party",
+    "cosSenderFirm": "Debug Party",
+    "cosEvidenceDocument": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "category_id": "particularsOfClaim",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-03-19T09:30:38.034499135",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        }
+      }
+    ],
+    "cosRecipientServeType": "POSTED",
+    "cosServedDocumentFiles": "sealed claim form, particulars of claim, medical report, provisional schedule of loss, response pack",
+    "cosRecipientServeLocation": "1 Debug Street, Debugtown ZZ1 1ZZ",
+    "cosDateOfServiceForDefendant": "2026-03-19",
+    "cosRecipientServeLocationType": "PLACE_OF_BUSINESS",
+    "cosSenderStatementOfTruthLabel": [
+      "CERTIFIED"
+    ],
+    "cosDateDeemedServedForDefendant": "2026-03-23",
+    "cosRecipientServeLocationOwnerType": "SOLICITOR"
+  },
+  "gaAddlDocRespondentSol": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "applications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-19T13:46:40.364490331",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 0,
+        "createdDatetime": "2026-05-19T14:46:41"
+      }
+    }
+  ],
+  "respondent1Represented": "Yes",
+  "respondent2Represented": "Yes",
+  "gaDraftDocRespondentSol": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "applications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-20T15:23:07.770900351",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 47165,
+        "documentType": "GENERAL_APPLICATION_DRAFT",
+        "createdDatetime": "2026-05-20T16:23:07"
+      }
+    }
+  ],
+  "generalOrderDocClaimant": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "ordersMadeOnApplications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-25T07:45:32.773818381",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 39292,
+        "documentType": "GENERAL_ORDER",
+        "createdDatetime": "2026-05-25T08:45:32"
+      }
+    }
+  ],
+  "respondent1ResponseDate": "2026-05-13T15:06:50",
+  "takenOfflineByStaffDate": "2026-06-15T09:26:31",
+  "cosNotifyClaimDefendant2": {
+    "cosSender": "Debug Party",
+    "cosRecipient": "Debug Party",
+    "cosSenderFirm": "Debug Party",
+    "cosRecipientServeType": "POSTED",
+    "cosServedDocumentFiles": "sealed claim form, particulars of claim, medical report, provisional schedule of loss, response pack",
+    "cosRecipientServeLocation": "1 Debug Street, Debugtown ZZ1 1ZZ",
+    "cosDateOfServiceForDefendant": "2026-03-19",
+    "cosRecipientServeLocationType": "PLACE_OF_BUSINESS",
+    "cosSenderStatementOfTruthLabel": [
+      "CERTIFIED"
+    ],
+    "cosDateDeemedServedForDefendant": "2026-03-23",
+    "cosRecipientServeLocationOwnerType": "SOLICITOR"
+  },
+  "respondent1OrgRegistered": "Yes",
+  "respondent2OrgRegistered": "Yes",
+  "uploadParticularsOfClaim": "No",
+  "applicant1DQRemoteHearing": {
+    "reasonForRemoteHearing": "Debug text",
+    "remoteHearingRequested": "Yes"
+  },
+  "claimIssuedPaymentDetails": {
+    "status": "SUCCESS",
+    "reference": "DEBUG-REFERENCE"
+  },
+  "claimNotificationDeadline": "2026-03-24T23:59:59",
+  "gaAddlDocRespondentSolTwo": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "applications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-19T13:46:40.364490331",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 0,
+        "createdDatetime": "2026-05-19T14:46:41"
+      }
+    }
+  ],
+  "gaDetailsMasterCollection": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "caseLink": {
+          "CaseReference": "1111222233334444"
+        },
+        "caseState": "Order Made",
+        "generalApplicationType": "Extend time",
+        "parentClaimantIsApplicant": "No",
+        "generalAppSubmittedDateGAspec": "2026-05-19T13:46:40"
+      }
+    }
+  ],
+  "respondentSolGaAppDetails": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "caseLink": {
+          "CaseReference": "1111222233334444"
+        },
+        "caseState": "Order Made",
+        "generalApplicationType": "Extend time",
+        "parentClaimantIsApplicant": "No",
+        "generalAppSubmittedDateGAspec": "2026-05-19T13:46:40"
+      }
+    }
+  ],
+  "defendant1LIPAtClaimIssued": "No",
+  "defendant2LIPAtClaimIssued": "No",
+  "defendantResponseDocuments": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "defendant1DefenseDirectionsQuestionnaire",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-13T14:06:50.262413918",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 0,
+        "documentType": "DEFENDANT_DEFENCE",
+        "createdDatetime": "2026-05-13T15:06:50"
+      }
+    }
+  ],
+  "gaDraftDocRespondentSolTwo": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "applications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-20T15:23:07.770900351",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 47165,
+        "documentType": "GENERAL_APPLICATION_DRAFT",
+        "createdDatetime": "2026-05-20T16:23:07"
+      }
+    }
+  ],
+  "multiPartyResponseTypeFlags": "PART_ADMISSION",
+  "respondent1ResponseDeadline": "2026-05-14T16:00:00",
+  "respondent2ResponseDeadline": "2026-05-19T16:00:00",
+  "applicant1OrganisationPolicy": {
+    "Organisation": {
+      "OrganisationID": "DEBUGORG"
+    },
+    "OrgPolicyReference": "DEBUG-REFERENCE",
+    "OrgPolicyCaseAssignedRole": "[APPLICANTSOLICITORONE]"
+  },
+  "claimDetailsNotificationDate": "2026-03-19T09:30:37",
+  "generalOrderDocRespondentSol": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "ordersMadeOnApplications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-25T07:45:32.773818381",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 39292,
+        "documentType": "GENERAL_ORDER",
+        "createdDatetime": "2026-05-25T08:45:32"
+      }
+    }
+  ],
+  "respondent1ClaimResponseType": "PART_ADMISSION",
+  "respondent1TimeExtensionDate": "2026-04-14T14:41:18",
+  "respondent2TimeExtensionDate": "2026-04-20T12:35:19",
+  "respondentSolTwoGaAppDetails": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "caseLink": {
+          "CaseReference": "1111222233334444"
+        },
+        "caseState": "Order Made",
+        "generalApplicationType": "Extend time",
+        "parentClaimantIsApplicant": "No",
+        "generalAppSubmittedDateGAspec": "2026-05-19T13:46:40"
+      }
+    }
+  ],
+  "systemGeneratedCaseDocuments": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "detailsOfClaim",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2025-11-24T17:27:24.742485322",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 132692,
+        "documentType": "SEALED_CLAIM",
+        "createdDatetime": "2025-11-24T17:27:24"
+      }
+    },
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "defendant1DefenseDirectionsQuestionnaire",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-03-26T15:47:29.169935766",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 89599,
+        "documentType": "ACKNOWLEDGEMENT_OF_CLAIM",
+        "createdDatetime": "2026-03-26T15:47:28"
+      }
+    },
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "defendant2DefenseDirectionsQuestionnaire",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-04-02T14:52:40.689781671",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 88963,
+        "documentType": "ACKNOWLEDGEMENT_OF_CLAIM",
+        "createdDatetime": "2026-04-02T15:52:40"
+      }
+    }
+  ],
+  "respondent1DQStatementOfTruth": {
+    "name": "Debug Claimant v Debug Defendant One Ltd",
+    "role": "Debug Role"
+  },
+  "respondent1OrganisationIDCopy": "DEBUGORG",
+  "respondent1OrganisationPolicy": {
+    "Organisation": {
+      "OrganisationID": "DEBUGORG"
+    },
+    "OrgPolicyReference": "DEBUG-REFERENCE",
+    "OrgPolicyCaseAssignedRole": "[RESPONDENTSOLICITORONE]"
+  },
+  "respondent2OrganisationIDCopy": "DEBUGORG",
+  "respondent2OrganisationPolicy": {
+    "Organisation": {
+      "OrganisationID": "DEBUGORG"
+    },
+    "PreviousOrganisations": [
+      {
+        "id": "00000000-0000-4000-8000-000000000001",
+        "value": {
+          "ToTimestamp": "2026-03-24T15:11:36",
+          "FromTimestamp": "2025-11-24T17:26:27"
+        }
+      }
+    ],
+    "OrgPolicyCaseAssignedRole": "[RESPONDENTSOLICITORTWO]"
+  },
+  "applicantSolicitor1UserDetails": {
+    "email": "debug.user@example.test"
+  },
+  "generalOrderDocRespondentSolTwo": [
+    {
+      "id": "00000000-0000-4000-8000-000000000001",
+      "value": {
+        "createdBy": "Debug User",
+        "documentLink": {
+          "category_id": "ordersMadeOnApplications",
+          "document_url": "http://example.test/documents/debug-document",
+          "upload_timestamp": "2026-05-25T07:45:32.773818381",
+          "document_filename": "debug-document.pdf",
+          "document_binary_url": "http://example.test/documents/debug-document/binary"
+        },
+        "documentName": "debug-document.pdf",
+        "documentSize": 39292,
+        "documentType": "GENERAL_ORDER",
+        "createdDatetime": "2026-05-25T08:45:32"
+      }
+    }
+  ],
+  "claimDetailsNotificationDeadline": "2026-03-24T23:59:59",
+  "respondent1ClaimResponseDocument": {
+    "file": {
+      "category_id": "defendant1DefenseDirectionsQuestionnaire",
+      "document_url": "http://example.test/documents/debug-document",
+      "upload_timestamp": "2026-05-13T14:06:50.262413918",
+      "document_filename": "debug-document.pdf",
+      "document_binary_url": "http://example.test/documents/debug-document/binary"
+    }
+  },
+  "respondentSolicitor1EmailAddress": "debug.user@example.test",
+  "respondentSolicitor2EmailAddress": "debug.user@example.test",
+  "applicant1LitigationFriendRequired": "No",
+  "respondent2SameLegalRepresentative": "No",
+  "respondentSolicitor1ServiceAddress": {
+    "Country": "United Kingdom",
+    "PostCode": "ZZ1 1ZZ",
+    "PostTown": "Debugtown",
+    "AddressLine1": "1 Debug Street",
+    "AddressLine2": "Debug Area"
+  },
+  "respondent1DetailsForClaimDetailsTab": {
+    "type": "COMPANY",
+    "partyID": "debug-party-id",
+    "partyName": "Debug Claimant v Debug Defendant One Ltd",
+    "companyName": "Debug Claimant v Debug Defendant One Ltd",
+    "primaryAddress": {
+      "PostCode": "ZZ1 1ZZ",
+      "PostTown": "Debugtown",
+      "AddressLine1": "1 Debug Street"
+    },
+    "partyTypeDisplayValue": "Company"
+  },
+  "respondent2DetailsForClaimDetailsTab": {
+    "type": "COMPANY",
+    "partyID": "debug-party-id",
+    "partyName": "Debug Claimant v Debug Defendant One Ltd",
+    "companyName": "Debug Claimant v Debug Defendant One Ltd",
+    "primaryAddress": {
+      "PostCode": "ZZ1 1ZZ",
+      "PostTown": "Debugtown",
+      "AddressLine1": "1 Debug Street",
+      "AddressLine2": "Debug Area"
+    },
+    "partyTypeDisplayValue": "Company"
+  },
+  "respondent1ClaimResponseIntentionType": "FULL_DEFENCE",
+  "respondent2ClaimResponseIntentionType": "FULL_DEFENCE",
+  "respondent1AcknowledgeNotificationDate": "2026-03-26T15:47:27",
+  "respondent2AcknowledgeNotificationDate": "2026-04-02T15:52:39",
+  "applicantSolicitor1ClaimStatementOfTruth": {
+    "name": "Debug Claimant v Debug Defendant One Ltd",
+    "role": "Debug Role"
+  },
+  "applicantSolicitor1ServiceAddressRequired": "No",
+  "respondentSolicitor1ServiceAddressRequired": "Yes",
+  "respondentSolicitor2ServiceAddressRequired": "No",
+  "specApplicantCorrespondenceAddressRequired": "No",
+  "caseListDisplayDefendantSolicitorReferences": "DEBUG-REFERENCE",
+  "respondentSolicitor1AgreedDeadlineExtension": "2026-05-14",
+  "respondentSolicitor2AgreedDeadlineExtension": "2026-05-19",
+  "specRespondentCorrespondenceAddressRequired": "No",
+  "specRespondent2CorrespondenceAddressRequired": "No",
+  "unassignedCaseListDisplayOrganisationReferences": "DEBUG-REFERENCE"
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/stateflow/transitions/NotificationAcknowledgedTimeExtensionTransitionBuilder.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/stateflow/transitions/NotificationAcknowledgedTimeExtensionTransitionBuilder.java
@@ -50,13 +50,19 @@ public class NotificationAcknowledgedTimeExtensionTransitionBuilder extends MidT
             .moveTo(AWAITING_RESPONSES_FULL_ADMIT_RECEIVED, transitions)
             .onlyWhen(ResponsePredicate.notificationAcknowledged
                 .and(ResponsePredicate.respondentTimeExtension)
-                .and(ResponsePredicate.awaitingResponsesFullAdmitReceived), transitions)
+                .and(ResponsePredicate.awaitingResponsesFullAdmitReceived)
+                .and(
+                    not(TakenOfflinePredicate.byStaff.and(TakenOfflinePredicate.afterClaimNotifiedAckExtension))
+                ), transitions)
 
             .moveTo(AWAITING_RESPONSES_NOT_FULL_DEFENCE_OR_FULL_ADMIT_RECEIVED, transitions)
             .onlyWhen(ResponsePredicate.notificationAcknowledged
                 .and(ResponsePredicate.respondentTimeExtension)
                 .and(not(DismissedPredicate.afterClaimAcknowledgedExtension))
-                .and(ResponsePredicate.awaitingResponsesNonFullDefenceOrFullAdmitReceived), transitions)
+                .and(ResponsePredicate.awaitingResponsesNonFullDefenceOrFullAdmitReceived)
+                .and(
+                    not(TakenOfflinePredicate.byStaff.and(TakenOfflinePredicate.afterClaimNotifiedAckExtension))
+                ), transitions)
 
             .moveTo(TAKEN_OFFLINE_BY_STAFF, transitions)
             .onlyWhen(TakenOfflinePredicate.byStaff.and(TakenOfflinePredicate.afterClaimNotifiedAckExtension), transitions)

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/SimpleStateFlowEngineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/flowstate/SimpleStateFlowEngineTest.java
@@ -559,75 +559,9 @@ class SimpleStateFlowEngineTest {
             }
 
             // Unrepresented
-            // 2. Def1 unrepresented, Def2 registered
-            @Test
-            void shouldContinueOnline_Cos_WhenCaseDataAtStateClaimDraftIssuedAndRespondent1NotRepresented() {
-                // Given
-                CaseData caseData = CaseDataBuilder.builder()
-                    .atStateClaimIssuedUnrepresentedDefendant1()
-                    .build();
-                when(featureToggleService.isDashboardEnabledForCase(caseData)).thenReturn(true);
-
-                // When
-                StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
-
-                // Then
-                assertThat(stateFlow.getState())
-                    .extracting(State::getName)
-                    .isNotNull()
-                    .isEqualTo(PENDING_CLAIM_ISSUED_UNREPRESENTED_DEFENDANT.fullName());
-                assertThat(stateFlow.getStateHistory())
-                    .hasSize(4)
-                    .extracting(State::getName)
-                    .containsExactly(
-                        DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
-                        PENDING_CLAIM_ISSUED_UNREPRESENTED_DEFENDANT.fullName()
-                    );
-
-                assertThat(stateFlow.getFlags()).hasSize(11).contains(
-                    entry(FlowFlag.UNREPRESENTED_DEFENDANT_ONE.name(), true),
-                    entry(FlowFlag.UNREPRESENTED_DEFENDANT_TWO.name(), false),
-                    entry(FlowFlag.DASHBOARD_SERVICE_ENABLED.name(), true)
-                );
-            }
-
-            // Unrepresented
             // 3. Def1 registered, Def 2 unrepresented when Cos service not activated
             @Test
             void shouldContinueOnline_WhenCaseDataAtStateClaimDraftIssuedAndRespondent2NotRepresented() {
-                // Given
-                CaseData caseData = CaseDataBuilder.builder()
-                    .atStateClaimIssuedUnrepresentedDefendant2()
-                    .defendant2LIPAtClaimIssued(YES)
-                    .build();
-
-                // When
-                StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
-
-                // Then
-                assertThat(stateFlow.getState())
-                    .extracting(State::getName)
-                    .isNotNull()
-                    .isEqualTo(PENDING_CLAIM_ISSUED_UNREPRESENTED_DEFENDANT.fullName());
-                assertThat(stateFlow.getStateHistory())
-                    .hasSize(4)
-                    .extracting(State::getName)
-                    .containsExactly(
-                        DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
-                        PENDING_CLAIM_ISSUED_UNREPRESENTED_DEFENDANT.fullName()
-                    );
-
-                assertThat(stateFlow.getFlags()).hasSize(11).contains(
-                    entry(FlowFlag.UNREPRESENTED_DEFENDANT_ONE.name(), false),
-                    entry(FlowFlag.UNREPRESENTED_DEFENDANT_TWO.name(), true),
-                    entry(FlowFlag.DASHBOARD_SERVICE_ENABLED.name(), false)
-                );
-            }
-
-            // Unrepresented
-            // 3. Def1 registered, Def 2 unrepresented when Cos service activated
-            @Test
-            void shouldContinueOnline_Cos_WhenCaseDataAtStateClaimDraftIssuedAndRespondent2NotRepresented() {
                 // Given
                 CaseData caseData = CaseDataBuilder.builder()
                     .atStateClaimIssuedUnrepresentedDefendant2()
@@ -1381,34 +1315,6 @@ class SimpleStateFlowEngineTest {
             );
         }
 
-        @Test
-        void shouldReturnExtensionRequested_whenCaseDataAtStateClaimDetailsNotifiedTimeExtension() {
-            // Given
-            CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotifiedTimeExtension().build();
-
-            // When
-            StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
-
-            // Then
-            assertThat(stateFlow.getState())
-                .extracting(State::getName)
-                .isNotNull()
-                .isEqualTo(CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION.fullName());
-            assertThat(stateFlow.getStateHistory())
-                .hasSize(8)
-                .extracting(State::getName)
-                .containsExactly(
-                    DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
-                    PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
-                    CLAIM_DETAILS_NOTIFIED.fullName(), CLAIM_DETAILS_NOTIFIED_TIME_EXTENSION.fullName()
-                );
-
-            assertThat(stateFlow.getFlags()).hasSize(10).contains(
-                entry("ONE_RESPONDENT_REPRESENTATIVE", true),
-                entry(FlowFlag.DASHBOARD_SERVICE_ENABLED.name(), false)
-            );
-        }
-
         @Nested
         class RespondentResponse {
 
@@ -1629,44 +1535,6 @@ class SimpleStateFlowEngineTest {
                         PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                         CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
                         AWAITING_RESPONSES_NOT_FULL_DEFENCE_OR_FULL_ADMIT_RECEIVED.fullName()
-                    );
-
-                assertThat(stateFlow.getFlags()).hasSize(11).contains(
-                    entry("ONE_RESPONDENT_REPRESENTATIVE", false),
-                    entry("TWO_RESPONDENT_REPRESENTATIVES", true),
-                    entry(FlowFlag.DASHBOARD_SERVICE_ENABLED.name(), false)
-                );
-            }
-
-            //1v2 Different solicitor scenario-first response FullDefence received
-            @Test
-            void shouldGenerateDQ_in1v2Scenario_whenFirstPartySubmitFullDefenceResponse() {
-                // Given
-                CaseData caseData = CaseDataBuilder.builder()
-                    .atStateRespondentFullDefence()
-                    .multiPartyClaimTwoDefendantSolicitors()
-                    .build();
-                if (caseData.getRespondent2OrgRegistered() != null
-                    && caseData.getRespondent2Represented() == null) {
-                    caseData.setRespondent2Represented(YES);
-                }
-
-                // When
-                StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
-
-                // Then
-                assertThat(stateFlow.getState())
-                    .extracting(State::getName)
-                    .isNotNull()
-                    .isEqualTo(AWAITING_RESPONSES_FULL_DEFENCE_RECEIVED.fullName());
-                assertThat(stateFlow.getStateHistory())
-                    .hasSize(9)
-                    .extracting(State::getName)
-                    .containsExactly(
-                        DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
-                        PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
-                        CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
-                        AWAITING_RESPONSES_FULL_DEFENCE_RECEIVED.fullName()
                     );
 
                 assertThat(stateFlow.getFlags()).hasSize(11).contains(
@@ -2885,6 +2753,78 @@ class SimpleStateFlowEngineTest {
         }
 
         @Test
+        void shouldReturnTakenOfflineByStaff_whenFirstResponseIsPartAdmissionAfterAcknowledgeClaimAndTimeExtension1v2() {
+            // Given
+            CaseData caseData = CaseDataBuilder.builder()
+                .atStateTakenOfflineByStaffAfterNotificationAcknowledgeExtension1v2()
+                .respondent1ClaimResponseType(RespondentResponseType.PART_ADMISSION)
+                .respondent1ResponseDate(LocalDateTime.now())
+                .build();
+
+            // When
+            StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
+
+            // Then
+            assertThat(stateFlow.getState())
+                .extracting(State::getName)
+                .isNotNull()
+                .isEqualTo(TAKEN_OFFLINE_BY_STAFF.fullName());
+            assertThat(stateFlow.getStateHistory())
+                .hasSize(10)
+                .extracting(State::getName)
+                .containsExactly(
+                    DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
+                    PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
+                    CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
+                    NOTIFICATION_ACKNOWLEDGED_TIME_EXTENSION.fullName(),
+                    TAKEN_OFFLINE_BY_STAFF.fullName()
+                );
+
+            assertThat(stateFlow.getFlags()).hasSize(11).contains(
+                entry("ONE_RESPONDENT_REPRESENTATIVE", false),
+                entry(FlowFlag.BULK_CLAIM_ENABLED.name(), false),
+                entry("TWO_RESPONDENT_REPRESENTATIVES", true),
+                entry(FlowFlag.DASHBOARD_SERVICE_ENABLED.name(), false)
+            );
+        }
+
+        @Test
+        void shouldReturnTakenOfflineByStaff_whenFirstResponseIsFullAdmissionAfterAcknowledgeClaimAndTimeExtension1v2() {
+            // Given
+            CaseData caseData = CaseDataBuilder.builder()
+                .atStateTakenOfflineByStaffAfterNotificationAcknowledgeExtension1v2()
+                .respondent1ClaimResponseType(RespondentResponseType.FULL_ADMISSION)
+                .respondent1ResponseDate(LocalDateTime.now())
+                .build();
+
+            // When
+            StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
+
+            // Then
+            assertThat(stateFlow.getState())
+                .extracting(State::getName)
+                .isNotNull()
+                .isEqualTo(TAKEN_OFFLINE_BY_STAFF.fullName());
+            assertThat(stateFlow.getStateHistory())
+                .hasSize(10)
+                .extracting(State::getName)
+                .containsExactly(
+                    DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
+                    PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
+                    CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
+                    NOTIFICATION_ACKNOWLEDGED_TIME_EXTENSION.fullName(),
+                    TAKEN_OFFLINE_BY_STAFF.fullName()
+                );
+
+            assertThat(stateFlow.getFlags()).hasSize(11).contains(
+                entry("ONE_RESPONDENT_REPRESENTATIVE", false),
+                entry(FlowFlag.BULK_CLAIM_ENABLED.name(), false),
+                entry("TWO_RESPONDENT_REPRESENTATIVES", true),
+                entry(FlowFlag.DASHBOARD_SERVICE_ENABLED.name(), false)
+            );
+        }
+
+        @Test
         void shouldReturnProceedsWithOfflineJourney_whenCaseTakenOfflineAfterDefendantResponse() {
             // Given
             CaseData caseData = CaseDataBuilder.builder().atStateTakenOfflineByStaffAfterDefendantResponse()
@@ -3411,86 +3351,6 @@ class SimpleStateFlowEngineTest {
                         PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
                         CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
                         AWAITING_RESPONSES_NOT_FULL_DEFENCE_OR_FULL_ADMIT_RECEIVED.fullName()
-                    );
-
-                assertThat(stateFlow.getFlags()).hasSize(11).contains(
-                    entry("ONE_RESPONDENT_REPRESENTATIVE", false),
-                    entry("TWO_RESPONDENT_REPRESENTATIVES", true),
-                    entry(FlowFlag.BULK_CLAIM_ENABLED.name(), false),
-                    entry(FlowFlag.DASHBOARD_SERVICE_ENABLED.name(), false)
-                );
-            }
-
-            @Test
-            //1v2 Different solicitor scenario-first response FullDefence received
-            void shouldGenerateDQ_in1v2Scenario_whenFirstPartySubmitFullDefenceResponse() {
-                // Given
-                CaseData caseData = CaseDataBuilder.builder()
-                    .atStateRespondentFullDefence()
-                    .multiPartyClaimTwoDefendantSolicitors()
-                    .build();
-                if (caseData.getRespondent2OrgRegistered() != null
-                    && caseData.getRespondent2Represented() == null) {
-                    caseData.setRespondent2Represented(YES);
-                }
-
-                // When
-                StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
-
-                // Then
-                assertThat(stateFlow.getState())
-                    .extracting(State::getName)
-                    .isNotNull()
-                    .isEqualTo(AWAITING_RESPONSES_FULL_DEFENCE_RECEIVED.fullName());
-                assertThat(stateFlow.getStateHistory())
-                    .hasSize(9)
-                    .extracting(State::getName)
-                    .containsExactly(
-                        DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
-                        PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
-                        CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
-                        AWAITING_RESPONSES_FULL_DEFENCE_RECEIVED.fullName()
-                    );
-
-                assertThat(stateFlow.getFlags()).hasSize(11).contains(
-                    entry("ONE_RESPONDENT_REPRESENTATIVE", false),
-                    entry("TWO_RESPONDENT_REPRESENTATIVES", true),
-                    entry(FlowFlag.BULK_CLAIM_ENABLED.name(), false),
-                    entry(FlowFlag.JO_ONLINE_LIVE_ENABLED.name(), false),
-                    entry(FlowFlag.DASHBOARD_SERVICE_ENABLED.name(), false)
-                );
-            }
-
-            @Test
-            //1v2 Different solicitor scenario-first party acknowledges, not responds
-            //second party submits response FullDefence
-            void shouldGenerateDQ_in1v2Scenario_whenSecondPartySubmitFullDefenceResponse() {
-                // Given
-                CaseData caseData = CaseDataBuilder.builder()
-                    .atStateRespondentFullDefenceRespondent2()
-                    .multiPartyClaimTwoDefendantSolicitors()
-                    .build();
-                if (caseData.getRespondent2OrgRegistered() != null
-                    && caseData.getRespondent2Represented() == null) {
-                    caseData.setRespondent2Represented(YES);
-                }
-
-                // When
-                StateFlow stateFlow = stateFlowEngine.evaluate(caseData);
-
-                // Then
-                assertThat(stateFlow.getState())
-                    .extracting(State::getName)
-                    .isNotNull()
-                    .isEqualTo(AWAITING_RESPONSES_FULL_DEFENCE_RECEIVED.fullName());
-                assertThat(stateFlow.getStateHistory())
-                    .hasSize(9)
-                    .extracting(State::getName)
-                    .containsExactly(
-                        DRAFT.fullName(), CLAIM_SUBMITTED.fullName(), CLAIM_ISSUED_PAYMENT_SUCCESSFUL.fullName(),
-                        PENDING_CLAIM_ISSUED.fullName(), CLAIM_ISSUED.fullName(), CLAIM_NOTIFIED.fullName(),
-                        CLAIM_DETAILS_NOTIFIED.fullName(), NOTIFICATION_ACKNOWLEDGED.fullName(),
-                        AWAITING_RESPONSES_FULL_DEFENCE_RECEIVED.fullName()
                     );
 
                 assertThat(stateFlow.getFlags()).hasSize(11).contains(


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5678


### Change description ###
The same manual-offline exclusion that already existed for the full-defence branch added to the full-admit and non-full-response branches, so TAKEN_OFFLINE_BY_STAFF wins when the case has `takenOfflineByStaffDate` after acknowledged time extensions.
Added `WorkflowIntegrationTest` for `Start Business Process`
`NOTIFICATION_ACKNOWLEDGED` tests updated to prevent regression
Duplicate existing tests removed for Sonar

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
