### PR TITLE
Add Spring Scheduler feature toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,33 @@ The service includes a common framework for implementing scheduled tasks. This f
     - Use `ScheduledTaskRunner.run()` to execute the task.
 4. **Add Configuration**: Add settings to `application.yaml` for enabling the scheduler and defining its cron expression.
 
+### Spring Scheduler Configuration
+
+Spring-based schedulers are controlled by both a LaunchDarkly feature flag and an allowlist of active schedulers.
+
+#### Feature Flag
+The `spring-scheduler-enabled` flag in LaunchDarkly acts as a global kill-switch for all Spring-managed scheduled tasks. If this flag is disabled, no Spring schedulers will execute, regardless of their individual configuration.
+
+#### Active Schedulers List
+To enable specific Spring schedulers, they must be added to the `active-schedulers` list in `application.yaml` or via the `SCHEDULER_ACTIVE_SCHEDULERS` environment variable.
+
+**Configuration in `application.yaml`:**
+```yaml
+scheduler:
+  active-schedulers: ${SCHEDULER_ACTIVE_SCHEDULERS:JudgementBuffer,DefendantResponseDeadline}
+```
+
+**Using Environment Variables:**
+To enable multiple schedulers, provide a comma-separated list:
+```bash
+export SCHEDULER_ACTIVE_SCHEDULERS="JudgementBuffer,DefendantResponseDeadline"
+```
+
+To disable all Spring schedulers (even if the feature flag is on), set the list to be empty:
+```bash
+export SCHEDULER_ACTIVE_SCHEDULERS=""
+```
+
 ### JudgementBufferScheduler
 
 The `JudgementBufferScheduler` is used to process cases where a default judgement has been requested and a buffer period has expired.

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerITest.java
@@ -51,6 +51,7 @@ public class JudgementBufferSchedulerITest {
     @BeforeEach
     void setUp() {
         when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(true);
+        when(featureToggleService.isSpringSchedulerEnabled("JudgementBuffer")).thenReturn(true);
         coreCaseDataApiMockHelper.setupIdamClient();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.reform.civil.service.search.JudgementBufferExpiredSearchServ
 @ConditionalOnProperty(prefix = "scheduler.judgementBuffer", name = "enabled", havingValue = "true")
 public class JudgementBufferScheduler implements CivilScheduler {
 
-    private static final String SCHEDULER_NAME = "JudgementBuffer";
+    public static final String SCHEDULER_NAME = "JudgementBuffer";
 
     private final JudgementBufferExpiredSearchService searchService;
     private final ScheduledTaskRunner scheduledTaskRunner;
@@ -36,7 +36,8 @@ public class JudgementBufferScheduler implements CivilScheduler {
         lockAtLeastFor = "${scheduler.lockAtLeastFor}")
     @Override
     public void runScheduledTask() {
-        if (featureToggleService.isJudgmentBufferEnabled()) {
+        if (featureToggleService.isJudgmentBufferEnabled()
+            && featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)) {
             log.info("Running {} scheduler", SCHEDULER_NAME);
             scheduledTaskRunner.run(
                 new ScheduledTaskEventConfiguration(SCHEDULER_NAME),

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/FeatureToggleService.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.civil.service;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.launchdarkly.FeatureToggleApi;
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.civil.service.flowstate.predicate.LipPredicate;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 
 import static uk.gov.hmcts.reform.civil.enums.CaseCategory.SPEC_CLAIM;
 import static uk.gov.hmcts.reform.civil.ga.service.flowstate.GaFlowPredicate.caseContainsLiPGa;
@@ -17,10 +18,16 @@ import static uk.gov.hmcts.reform.civil.utils.JudgeReallocatedClaimTrack.judgeRe
 
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class FeatureToggleService {
 
+    private final List<String> activeSchedulers;
     private final FeatureToggleApi featureToggleApi;
+
+    public FeatureToggleService(FeatureToggleApi featureToggleApi,
+                                @Value("${scheduler.active-schedulers}") List<String> activeSchedulers) {
+        this.featureToggleApi = featureToggleApi;
+        this.activeSchedulers = activeSchedulers;
+    }
 
     public boolean isFeatureEnabled(String feature) {
         return this.featureToggleApi.isFeatureEnabled(feature);
@@ -171,7 +178,8 @@ public class FeatureToggleService {
         return featureToggleApi.isFeatureEnabled("judgment-buffer");
     }
 
-    public boolean isSpringSchedulerEnabled() {
-        return featureToggleApi.isFeatureEnabled("spring-scheduler-enabled");
+    public boolean isSpringSchedulerEnabled(String schedulerName) {
+        return featureToggleApi.isFeatureEnabled("spring-scheduler-enabled")
+            && activeSchedulers.contains(schedulerName);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/FeatureToggleService.java
@@ -170,4 +170,8 @@ public class FeatureToggleService {
     public boolean isJudgmentBufferEnabled() {
         return featureToggleApi.isFeatureEnabled("judgment-buffer");
     }
+
+    public boolean isSpringSchedulerEnabled() {
+        return featureToggleApi.isFeatureEnabled("spring-scheduler-enabled");
+    }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,6 +57,7 @@ spring:
     baseline-on-migrate: true
 
 scheduler:
+  active-schedulers: ${SCHEDULER_ACTIVE_SCHEDULERS:JudgementBuffer}
   circuitBreakerThreshold: ${CIRCUIT_BREAKER_THRESHOLD:5}
   lockAtLeastFor: ${LOCK_AT_LEAST_FOR:PT1M}
   lockAtMostFor: ${LOCK_AT_MOST_FOR:PT5M}

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferSchedulerTest.java
@@ -17,6 +17,7 @@ import java.util.stream.Stream;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.civil.scheduler.judgementbuffer.JudgementBufferScheduler.SCHEDULER_NAME;
 
 @ExtendWith(MockitoExtension.class)
 class JudgementBufferSchedulerTest {
@@ -42,6 +43,7 @@ class JudgementBufferSchedulerTest {
         @Test
         void shouldRunTaskRunner_whenSchedulerIsEnabledAndFeatureToggleIsEnabled() {
             when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(true);
+            when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
 
             ScheduledTaskEventConfiguration expectedConfig = new ScheduledTaskEventConfiguration(scheduler.getName());
             ElasticSearchResult elasticSearchResult = new ElasticSearchResult(Stream.empty(), 0);
@@ -59,6 +61,16 @@ class JudgementBufferSchedulerTest {
         @Test
         void shouldNotRunTaskRunner_whenSchedulerIsEnabledAndFeatureToggleIsDisabled() {
             when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(false);
+
+            scheduler.runScheduledTask();
+
+            verifyNoInteractions(scheduledTaskRunner);
+        }
+
+        @Test
+        void shouldNotRunTaskRunner_whenSpringSchedulerIsDisabled() {
+            when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(true);
+            when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(false);
 
             scheduler.runScheduledTask();
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/FeatureToggleServiceTest.java
@@ -291,4 +291,11 @@ class FeatureToggleServiceTest {
         givenToggle("judgment-buffer", toggleStat);
         assertThat(featureToggleService.isJudgmentBufferEnabled()).isEqualTo(toggleStat);
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void shouldCallBoolVariation_whenSpringSchedulerEnabled(Boolean toggleStat) {
+        givenToggle("spring-scheduler-enabled", toggleStat);
+        assertThat(featureToggleService.isSpringSchedulerEnabled()).isEqualTo(toggleStat);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/FeatureToggleServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/FeatureToggleServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,7 +36,7 @@ class FeatureToggleServiceTest {
 
     @BeforeEach
     void setUp() {
-        featureToggleService = new FeatureToggleService(featureToggleApi);
+        featureToggleService = new FeatureToggleService(featureToggleApi, List.of("JudgementBuffer", "DefendantResponseDeadline"));
     }
 
     @ParameterizedTest
@@ -296,6 +297,14 @@ class FeatureToggleServiceTest {
     @ValueSource(booleans = {true, false})
     void shouldCallBoolVariation_whenSpringSchedulerEnabled(Boolean toggleStat) {
         givenToggle("spring-scheduler-enabled", toggleStat);
-        assertThat(featureToggleService.isSpringSchedulerEnabled()).isEqualTo(toggleStat);
+        assertThat(featureToggleService.isSpringSchedulerEnabled("JudgementBuffer")).isEqualTo(toggleStat);
+        assertThat(featureToggleService.isSpringSchedulerEnabled("DefendantResponseDeadline")).isEqualTo(toggleStat);
+    }
+
+    @Test
+    void shouldReturnFalse_whenActiveSchedulersIsEmpty() {
+        FeatureToggleService emptyService = new FeatureToggleService(featureToggleApi, List.of());
+        givenToggle("spring-scheduler-enabled", true);
+        assertThat(emptyService.isSpringSchedulerEnabled("JudgementBufferScheduledTask")).isFalse();
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5652


### Change description ###
This PR introduces a new feature toggle mechanism to control Spring-based schedulers, allowing them to be enabled/disabled both globally and individually.

#### Key Changes

- **Global Feature Toggle**: Added `isSpringSchedulerEnabled()` to `FeatureToggleService` (via LaunchDarkly) to provide a master switch for Spring schedulers.
- **Granular Scheduler Control**: Updated `isSpringSchedulerEnabled(String schedulerName)` to check both the global toggle and a new configuration property `scheduler.active-schedulers`.
- **Scheduler Integration**: Updated `JudgementBufferScheduler` to respect these new toggles before execution.
- **Configuration**: Added `scheduler.active-schedulers` to `application.yaml` to manage the list of active schedulers.
- **Documentation**: Updated `README.md` with instructions on how to use the new scheduler framework and toggle features.
- **Testing**: Added unit and integration tests to verify the toggle logic, including cases for empty scheduler lists and various toggle states.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
