### PR TITLE
DTSCCI-5730: Handle EngineException in ExternalTaskCompletionService

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/ExternalTaskCompletionService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/ExternalTaskCompletionService.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.civil.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.client.exception.BadRequestException;
+import org.camunda.bpm.client.exception.EngineException;
 import org.camunda.bpm.client.exception.NotFoundException;
 import org.camunda.bpm.client.exception.ValueMapperException;
 import org.camunda.bpm.client.task.ExternalTask;
@@ -57,6 +58,9 @@ public class ExternalTaskCompletionService {
             throw new NotRetryableException(e.getMessage());
         } catch (NoSuchElementException e) {
             log.error("Completing task '{}' No Such Element error, processInstanceId '{}'", topicName, processInstanceId, e);
+            throw new NotRetryableException(e.getMessage());
+        } catch (EngineException e) {
+            log.error("Completing task '{}' Camunda BPM client exception, processInstanceId '{}'", topicName, processInstanceId, e);
             throw new NotRetryableException(e.getMessage());
         } catch (Exception e) {
             // Inc EngineException | ConnectionLostException | UnknownHttpErrorException

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/ExternalTaskCompletionServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/ExternalTaskCompletionServiceTest.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.civil.service;
 
 import org.camunda.bpm.client.exception.BadRequestException;
+import org.camunda.bpm.client.exception.EngineException;
 import org.camunda.bpm.client.exception.NotFoundException;
 import org.camunda.bpm.client.exception.RestException;
 import org.camunda.bpm.client.task.ExternalTask;
@@ -101,6 +102,17 @@ class ExternalTaskCompletionServiceTest {
             VariableMap variables = Variables.createVariables();
             when(handler.getVariableMap(data)).thenReturn(variables);
             doThrow(new BadRequestException("Bad Request", new RestException("", "", 400)))
+                .when(externalTaskService).complete(externalTask, variables);
+
+            assertThrows(NotRetryableException.class, () ->
+                service.completeTask(handler, externalTask, externalTaskService, data));
+        }
+
+        @Test
+        void shouldThrowNotRetryableException_whenEngineExceptionIsThrown() {
+            VariableMap variables = Variables.createVariables();
+            when(handler.getVariableMap(data)).thenReturn(variables);
+            doThrow(new EngineException("Engine Exception", new RestException("", "", 400)))
                 .when(externalTaskService).complete(externalTask, variables);
 
             assertThrows(NotRetryableException.class, () ->


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5730

### Change description ###
Refine completeTask in ExternalTaskCompletionService for camunda.bpm.client.exception.EngineException Not Retryable Exception

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
