### PR TITLE
DTSCCI-5479 Add dashboard notification retrigger migration task

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DashboardNotificationTaskCaseReference.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DashboardNotificationTaskCaseReference.java
@@ -1,0 +1,25 @@
+package uk.gov.hmcts.reform.civil.bulkupdate.csv;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@EqualsAndHashCode(callSuper = true)
+@JsonPropertyOrder(value = {"caseReference"})
+@AllArgsConstructor
+@NoArgsConstructor
+@SuppressWarnings("java:S1700")
+public class DashboardNotificationTaskCaseReference extends CaseReference {
+
+    @JsonProperty
+    private String dashboardTaskId;
+
+    @JsonProperty
+    private String dashboardProcessInstanceId;
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandler.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseNoteReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReferenceCsvLoader;
+import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardNotificationTaskCaseReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardScenarioCaseReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.ExcelMappable;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.NotificationCaseReference;
@@ -22,6 +23,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.IntStream;
 import uk.gov.hmcts.reform.civil.config.properties.EventProperties;
 import uk.gov.hmcts.reform.civil.service.ExternalTaskCompletionService;
 
@@ -33,6 +35,9 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
     protected static final String CSV_FILE_NAME = "csvFileName";
     private static final String CASE_IDS = "caseIds";
     private static final String SCENARIO = "scenario";
+    private static final String DASHBOARD_TASK_ID = "dashboardTaskId";
+    private static final String DASHBOARD_PROCESS_INSTANCE_ID = "dashboardProcessInstanceId";
+    private static final String DASHBOARD_PROCESS_INSTANCE_IDS = "dashboardProcessInstanceIds";
     private static final String NOTIFICATION_CAMUNDA_PROCESS_IDENTIFIER = "notificationCamundaProcessIdentifier";
     private static final String CASE_NOTE_ELEMENT_ID = "caseNoteElementId";
     private static final String NOTIFY_EVENT_ID = "notifyEventId";
@@ -93,6 +98,9 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
     private <T extends CaseReference> List<T> resolveCaseReferences(ExternalTask externalTask, MigrationTask<T> task) {
         String caseIds = externalTask.getVariable(CASE_IDS);
         String scenario = externalTask.getVariable(SCENARIO);
+        String dashboardTaskId = externalTask.getVariable(DASHBOARD_TASK_ID);
+        String dashboardProcessInstanceId = externalTask.getVariable(DASHBOARD_PROCESS_INSTANCE_ID);
+        String dashboardProcessInstanceIds = externalTask.getVariable(DASHBOARD_PROCESS_INSTANCE_IDS);
         String camundaProcessIdentifier = externalTask.getVariable(NOTIFICATION_CAMUNDA_PROCESS_IDENTIFIER);
         String caseNoteElementId = externalTask.getVariable(CASE_NOTE_ELEMENT_ID);
         String notifyEventId = externalTask.getVariable(NOTIFY_EVENT_ID);
@@ -104,7 +112,15 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
 
         if (caseIds != null && !caseIds.isEmpty()) {
             return getCaseReferencesFromVariables(
-                task, caseIds, scenario, camundaProcessIdentifier, caseNoteElementId, notifyEventId
+                task,
+                caseIds,
+                scenario,
+                dashboardTaskId,
+                dashboardProcessInstanceId,
+                dashboardProcessInstanceIds,
+                camundaProcessIdentifier,
+                caseNoteElementId,
+                notifyEventId
             );
         }
 
@@ -137,29 +153,76 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
         MigrationTask<T> task,
         String caseIds,
         String scenario,
+        String dashboardTaskId,
+        String dashboardProcessInstanceId,
+        String dashboardProcessInstanceIds,
         String camundaProcessIdentifier,
         String caseNoteElementId,
         String notifyEventId
     ) {
-        List<T> caseReferences = Arrays.stream(caseIds.split(","))
+        List<String> caseReferenceIds = Arrays.stream(caseIds.split(","))
             .map(String::trim)
             .filter(s -> !s.isEmpty())
-            .map(id -> buildCaseReference(task.getType(), id, scenario, camundaProcessIdentifier, caseNoteElementId, notifyEventId))
+            .toList();
+        List<String> dashboardProcessInstanceIdList = toList(dashboardProcessInstanceIds);
+
+        List<T> caseReferences = IntStream.range(0, caseReferenceIds.size())
+            .mapToObj(index -> buildCaseReference(
+                task.getType(),
+                caseReferenceIds.get(index),
+                scenario,
+                dashboardTaskId,
+                resolveDashboardProcessInstanceId(index, dashboardProcessInstanceId, dashboardProcessInstanceIdList),
+                camundaProcessIdentifier,
+                caseNoteElementId,
+                notifyEventId
+            ))
             .toList();
         log.info("Created {} case references from Camunda variables", caseReferences.size());
         return caseReferences;
+    }
+
+    private List<String> toList(String values) {
+        if (values == null || values.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(values.split(","))
+            .map(String::trim)
+            .toList();
+    }
+
+    private String resolveDashboardProcessInstanceId(
+        int caseIndex,
+        String dashboardProcessInstanceId,
+        List<String> dashboardProcessInstanceIds
+    ) {
+        if (!dashboardProcessInstanceIds.isEmpty()) {
+            return caseIndex < dashboardProcessInstanceIds.size()
+                ? dashboardProcessInstanceIds.get(caseIndex)
+                : null;
+        }
+        return dashboardProcessInstanceId;
     }
 
     private <T extends CaseReference> T buildCaseReference(
         Class<T> type,
         String caseId,
         String scenario,
+        String dashboardTaskId,
+        String dashboardProcessInstanceId,
         String camundaProcessIdentifier,
         String caseNoteElementId,
         String notifyEventId
     ) {
         if (scenario != null) {
             return type.cast(buildScenarioCaseReference(caseId, scenario));
+        }
+        if (dashboardTaskId != null) {
+            return type.cast(buildDashboardNotificationTaskCaseReference(
+                caseId,
+                dashboardTaskId,
+                dashboardProcessInstanceId
+            ));
         }
         if (camundaProcessIdentifier != null) {
             return type.cast(buildNotificationCaseReference(caseId, camundaProcessIdentifier));
@@ -171,6 +234,18 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
             return type.cast(buildNotifyRpaFeedCaseReference(caseId, notifyEventId));
         }
         return type.cast(buildBaseCaseReference(caseId));
+    }
+
+    private DashboardNotificationTaskCaseReference buildDashboardNotificationTaskCaseReference(
+        String caseId,
+        String dashboardTaskId,
+        String dashboardProcessInstanceId
+    ) {
+        DashboardNotificationTaskCaseReference caseReference = new DashboardNotificationTaskCaseReference();
+        caseReference.setCaseReference(caseId);
+        caseReference.setDashboardTaskId(dashboardTaskId);
+        caseReference.setDashboardProcessInstanceId(dashboardProcessInstanceId);
+        return caseReference;
     }
 
     private DashboardScenarioCaseReference buildScenarioCaseReference(String caseId, String scenario) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandler.java
@@ -96,35 +96,31 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
     }
 
     private <T extends CaseReference> List<T> resolveCaseReferences(ExternalTask externalTask, MigrationTask<T> task) {
-        String caseIds = externalTask.getVariable(CASE_IDS);
-        String scenario = externalTask.getVariable(SCENARIO);
-        String dashboardTaskId = externalTask.getVariable(DASHBOARD_TASK_ID);
-        String dashboardProcessInstanceId = externalTask.getVariable(DASHBOARD_PROCESS_INSTANCE_ID);
-        String dashboardProcessInstanceIds = externalTask.getVariable(DASHBOARD_PROCESS_INSTANCE_IDS);
-        String camundaProcessIdentifier = externalTask.getVariable(NOTIFICATION_CAMUNDA_PROCESS_IDENTIFIER);
-        String caseNoteElementId = externalTask.getVariable(CASE_NOTE_ELEMENT_ID);
-        String notifyEventId = externalTask.getVariable(NOTIFY_EVENT_ID);
+        MigrationVariables variables = migrationVariables(externalTask);
 
         FileValue excelFileValue = externalTask.getVariableTyped(EXCEL_FILE, false);
         if (excelFileValue != null) {
             return getCaseReferencesFromExcel(task, excelFileValue);
         }
 
-        if (caseIds != null && !caseIds.isEmpty()) {
-            return getCaseReferencesFromVariables(
-                task,
-                caseIds,
-                scenario,
-                dashboardTaskId,
-                dashboardProcessInstanceId,
-                dashboardProcessInstanceIds,
-                camundaProcessIdentifier,
-                caseNoteElementId,
-                notifyEventId
-            );
+        if (variables.hasCaseIds()) {
+            return getCaseReferencesFromVariables(task, variables);
         }
 
         return getCaseReferencesFromCsv(externalTask, task.getType());
+    }
+
+    private MigrationVariables migrationVariables(ExternalTask externalTask) {
+        return new MigrationVariables(
+            externalTask.getVariable(CASE_IDS),
+            externalTask.getVariable(SCENARIO),
+            externalTask.getVariable(DASHBOARD_TASK_ID),
+            externalTask.getVariable(DASHBOARD_PROCESS_INSTANCE_ID),
+            externalTask.getVariable(DASHBOARD_PROCESS_INSTANCE_IDS),
+            externalTask.getVariable(NOTIFICATION_CAMUNDA_PROCESS_IDENTIFIER),
+            externalTask.getVariable(CASE_NOTE_ELEMENT_ID),
+            externalTask.getVariable(NOTIFY_EVENT_ID)
+        );
     }
 
     private <T extends CaseReference> List<T> getCaseReferencesFromExcel(MigrationTask<T> task, FileValue excelFileValue) {
@@ -151,31 +147,21 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
 
     private <T extends CaseReference> List<T> getCaseReferencesFromVariables(
         MigrationTask<T> task,
-        String caseIds,
-        String scenario,
-        String dashboardTaskId,
-        String dashboardProcessInstanceId,
-        String dashboardProcessInstanceIds,
-        String camundaProcessIdentifier,
-        String caseNoteElementId,
-        String notifyEventId
+        MigrationVariables variables
     ) {
-        List<String> caseReferenceIds = Arrays.stream(caseIds.split(","))
+        List<String> caseReferenceIds = Arrays.stream(variables.caseIds().split(","))
             .map(String::trim)
             .filter(s -> !s.isEmpty())
             .toList();
-        List<String> dashboardProcessInstanceIdList = toList(dashboardProcessInstanceIds);
+        List<String> dashboardProcessInstanceIdList = toList(variables.dashboardProcessInstanceIds());
 
         List<T> caseReferences = IntStream.range(0, caseReferenceIds.size())
             .mapToObj(index -> buildCaseReference(
                 task.getType(),
                 caseReferenceIds.get(index),
-                scenario,
-                dashboardTaskId,
-                resolveDashboardProcessInstanceId(index, dashboardProcessInstanceId, dashboardProcessInstanceIdList),
-                camundaProcessIdentifier,
-                caseNoteElementId,
-                notifyEventId
+                variables.withDashboardProcessInstanceId(
+                    resolveDashboardProcessInstanceId(index, variables.dashboardProcessInstanceId(), dashboardProcessInstanceIdList)
+                )
             ))
             .toList();
         log.info("Created {} case references from Camunda variables", caseReferences.size());
@@ -207,31 +193,26 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
     private <T extends CaseReference> T buildCaseReference(
         Class<T> type,
         String caseId,
-        String scenario,
-        String dashboardTaskId,
-        String dashboardProcessInstanceId,
-        String camundaProcessIdentifier,
-        String caseNoteElementId,
-        String notifyEventId
+        MigrationVariables variables
     ) {
-        if (scenario != null) {
-            return type.cast(buildScenarioCaseReference(caseId, scenario));
+        if (variables.scenario() != null) {
+            return type.cast(buildScenarioCaseReference(caseId, variables.scenario()));
         }
-        if (dashboardTaskId != null) {
+        if (variables.dashboardTaskId() != null) {
             return type.cast(buildDashboardNotificationTaskCaseReference(
                 caseId,
-                dashboardTaskId,
-                dashboardProcessInstanceId
+                variables.dashboardTaskId(),
+                variables.dashboardProcessInstanceId()
             ));
         }
-        if (camundaProcessIdentifier != null) {
-            return type.cast(buildNotificationCaseReference(caseId, camundaProcessIdentifier));
+        if (variables.camundaProcessIdentifier() != null) {
+            return type.cast(buildNotificationCaseReference(caseId, variables.camundaProcessIdentifier()));
         }
-        if (caseNoteElementId != null) {
-            return type.cast(buildCaseNoteReference(caseId, caseNoteElementId));
+        if (variables.caseNoteElementId() != null) {
+            return type.cast(buildCaseNoteReference(caseId, variables.caseNoteElementId()));
         }
-        if (notifyEventId != null) {
-            return type.cast(buildNotifyRpaFeedCaseReference(caseId, notifyEventId));
+        if (variables.notifyEventId() != null) {
+            return type.cast(buildNotifyRpaFeedCaseReference(caseId, variables.notifyEventId()));
         }
         return type.cast(buildBaseCaseReference(caseId));
     }
@@ -297,6 +278,35 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
             return caseReferenceCsvLoader.loadCaseReferenceList(type, csvFileName, encryptionSecret);
         } else {
             return caseReferenceCsvLoader.loadCaseReferenceList(type, csvFileName);
+        }
+    }
+
+    private record MigrationVariables(
+        String caseIds,
+        String scenario,
+        String dashboardTaskId,
+        String dashboardProcessInstanceId,
+        String dashboardProcessInstanceIds,
+        String camundaProcessIdentifier,
+        String caseNoteElementId,
+        String notifyEventId
+    ) {
+
+        boolean hasCaseIds() {
+            return caseIds != null && !caseIds.isEmpty();
+        }
+
+        MigrationVariables withDashboardProcessInstanceId(String processInstanceId) {
+            return new MigrationVariables(
+                caseIds,
+                scenario,
+                dashboardTaskId,
+                processInstanceId,
+                dashboardProcessInstanceIds,
+                camundaProcessIdentifier,
+                caseNoteElementId,
+                notifyEventId
+            );
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
@@ -1,0 +1,100 @@
+package uk.gov.hmcts.reform.civil.handler.migration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardNotificationTaskCaseReference;
+import uk.gov.hmcts.reform.civil.callback.CallbackParams;
+import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardCaseType;
+import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardNotificationRegistry;
+import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardTaskContext;
+import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardWorkflowTask;
+import uk.gov.hmcts.reform.civil.model.BusinessProcess;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.service.UserService;
+
+import java.util.List;
+import java.util.Map;
+
+import static uk.gov.hmcts.reform.civil.callback.CallbackParams.Params.BEARER_TOKEN;
+
+@Component
+@Slf4j
+public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardNotificationTaskCaseReference> {
+
+    private final DashboardNotificationRegistry registry;
+    private final UserService userService;
+    private final SystemUpdateUserConfiguration userConfig;
+
+    public RetriggerDashboardNotificationTask(
+        DashboardNotificationRegistry registry,
+        UserService userService,
+        SystemUpdateUserConfiguration userConfig
+    ) {
+        super(DashboardNotificationTaskCaseReference.class);
+        this.registry = registry;
+        this.userService = userService;
+        this.userConfig = userConfig;
+    }
+
+    @Override
+    protected String getTaskName() {
+        return "RetriggerDashboardNotificationTask";
+    }
+
+    @Override
+    protected String getEventSummary() {
+        return "Retrigger dashboard notification task via Migration Task";
+    }
+
+    @Override
+    protected String getEventDescription() {
+        return "This task runs the dashboard notification workflow for a Camunda dashboard task id";
+    }
+
+    @Override
+    protected CaseData migrateCaseData(CaseData caseData, DashboardNotificationTaskCaseReference caseReference) {
+        if (caseReference == null
+            || StringUtils.isBlank(caseReference.getCaseReference())
+            || StringUtils.isBlank(caseReference.getDashboardTaskId())) {
+            throw new IllegalArgumentException("Case reference and dashboardTaskId must not be blank");
+        }
+
+        CaseData dashboardCaseData = caseData.toBuilder().build();
+        dashboardCaseData.setBusinessProcess(businessProcessForDashboardTask(caseData, caseReference));
+
+        String dashboardTaskId = caseReference.getDashboardTaskId();
+        List<DashboardWorkflowTask> workflows = registry.workflowsFor(dashboardTaskId, DashboardCaseType.CIVIL);
+
+        if (workflows.isEmpty()) {
+            throw new IllegalArgumentException("No dashboard notification handlers registered for: " + dashboardTaskId);
+        }
+
+        String authToken = userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+        DashboardTaskContext context = DashboardTaskContext.from(new CallbackParams()
+            .caseData(dashboardCaseData)
+            .isCivilCaseType(true)
+            .params(Map.of(BEARER_TOKEN, authToken)));
+
+        log.info("Retriggering dashboard task {} for case {}", dashboardTaskId, caseReference.getCaseReference());
+        workflows.forEach(task -> task.execute(context));
+        return caseData;
+    }
+
+    private BusinessProcess businessProcessForDashboardTask(
+        CaseData caseData,
+        DashboardNotificationTaskCaseReference caseReference
+    ) {
+        BusinessProcess businessProcess = caseData.getBusinessProcess() != null
+            ? caseData.getBusinessProcess().copy()
+            : new BusinessProcess();
+
+        businessProcess.updateActivityId(caseReference.getDashboardTaskId());
+        if (StringUtils.isNotBlank(caseReference.getDashboardProcessInstanceId())) {
+            businessProcess.updateProcessInstanceId(caseReference.getDashboardProcessInstanceId());
+        }
+
+        return businessProcess;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
@@ -39,13 +39,13 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
     }
 
     @Override
-    protected String getTaskName() {
-        return "RetriggerDashboardNotificationTask";
+    protected String getEventSummary() {
+        return "Retrigger dashboard notification task via Migration Task";
     }
 
     @Override
-    protected String getEventSummary() {
-        return "Retrigger dashboard notification task via Migration Task";
+    protected String getTaskName() {
+        return "RetriggerDashboardNotificationTask";
     }
 
     @Override

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
@@ -39,32 +39,35 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
     }
 
     @Override
+    @SuppressWarnings("java:S4144")
     protected String getEventSummary() {
         return "Retrigger dashboard notification task via Migration Task";
     }
 
     @Override
+    @SuppressWarnings("java:S4144")
     protected String getTaskName() {
         return "RetriggerDashboardNotificationTask";
     }
 
     @Override
+    @SuppressWarnings("java:S4144")
     protected String getEventDescription() {
         return "This task runs the dashboard notification workflow for a Camunda dashboard task id";
     }
 
     @Override
-    protected CaseData migrateCaseData(CaseData caseData, DashboardNotificationTaskCaseReference caseReference) {
-        if (caseReference == null
-            || StringUtils.isBlank(caseReference.getCaseReference())
-            || StringUtils.isBlank(caseReference.getDashboardTaskId())) {
+    protected CaseData migrateCaseData(CaseData caseData, DashboardNotificationTaskCaseReference dashboardReference) {
+        if (dashboardReference == null
+            || StringUtils.isBlank(dashboardReference.getCaseReference())
+            || StringUtils.isBlank(dashboardReference.getDashboardTaskId())) {
             throw new IllegalArgumentException("Case reference and dashboardTaskId must not be blank");
         }
 
         CaseData dashboardCaseData = caseData.toBuilder().build();
-        dashboardCaseData.setBusinessProcess(businessProcessForDashboardTask(caseData, caseReference));
+        dashboardCaseData.setBusinessProcess(businessProcessForDashboardTask(caseData, dashboardReference));
 
-        String dashboardTaskId = caseReference.getDashboardTaskId();
+        String dashboardTaskId = dashboardReference.getDashboardTaskId();
         List<DashboardWorkflowTask> workflows = registry.workflowsFor(dashboardTaskId, DashboardCaseType.CIVIL);
 
         if (workflows.isEmpty()) {
@@ -77,7 +80,7 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
             .isCivilCaseType(true)
             .params(Map.of(BEARER_TOKEN, authToken)));
 
-        log.info("Retriggering dashboard task {} for case {}", dashboardTaskId, caseReference.getCaseReference());
+        log.info("Retriggering dashboard task {} for case {}", dashboardTaskId, dashboardReference.getCaseReference());
         workflows.forEach(task -> task.execute(context));
         return caseData;
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.civil.handler.migration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardNotificationTaskCaseReference;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
@@ -14,6 +16,7 @@ import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.UserService;
 
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.Map;
 
@@ -26,16 +29,22 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
     private final DashboardNotificationRegistry registry;
     private final UserService userService;
     private final SystemUpdateUserConfiguration userConfig;
+    private final PlatformTransactionManager transactionManager;
+    private final EntityManager entityManager;
 
     public RetriggerDashboardNotificationTask(
         DashboardNotificationRegistry registry,
         UserService userService,
-        SystemUpdateUserConfiguration userConfig
+        SystemUpdateUserConfiguration userConfig,
+        PlatformTransactionManager transactionManager,
+        EntityManager entityManager
     ) {
         super(DashboardNotificationTaskCaseReference.class);
         this.registry = registry;
         this.userService = userService;
         this.userConfig = userConfig;
+        this.transactionManager = transactionManager;
+        this.entityManager = entityManager;
     }
 
     @Override
@@ -81,7 +90,11 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
             .params(Map.of(BEARER_TOKEN, authToken)));
 
         log.info("Retriggering dashboard task {} for case {}", dashboardTaskId, dashboardReference.getCaseReference());
-        workflows.forEach(task -> task.execute(context));
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            entityManager.joinTransaction();
+            workflows.forEach(task -> task.execute(context));
+            entityManager.flush();
+        });
         return caseData;
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandlerTest.java
@@ -10,9 +10,12 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseNoteReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReferenceCsvLoader;
+import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardNotificationTaskCaseReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardScenarioCaseReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.ExcelMappable;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.NotificationCaseReference;
@@ -43,6 +46,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 class MigrateCasesEventHandlerTest {
 
     @Mock
@@ -122,6 +126,77 @@ class MigrateCasesEventHandlerTest {
         assertNotNull(result);
         verify(asyncCaseMigrationService, times(1))
             .migrateCasesAsync(eq(migrationTask), anyList(), isNull(), eq(false));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void shouldHandleTaskWithCaseIdsAndDashboardTaskId() {
+        ExternalTask externalTask = mock(ExternalTask.class);
+        when(externalTask.getVariable("taskName")).thenReturn("testTask");
+        when(externalTask.getVariable("caseIds")).thenReturn("123, 456");
+        when(externalTask.getVariable("scenario")).thenReturn(null);
+        when(externalTask.getVariable("dashboardTaskId")).thenReturn("GenerateDashboardNotificationsHearingScheduledHmc");
+        when(externalTask.getVariable("dashboardProcessInstanceId")).thenReturn("process-123");
+        when(externalTask.getVariable("dashboardProcessInstanceIds")).thenReturn(null);
+        when(externalTask.getVariable("notificationCamundaProcessIdentifier")).thenReturn(null);
+        when(externalTask.getVariable("caseNoteElementId")).thenReturn(null);
+        when(externalTask.getVariable("notifyEventId")).thenReturn(null);
+        when(externalTask.getVariable("state")).thenReturn(null);
+        when(externalTask.getVariable("isGACase")).thenReturn(null);
+
+        MigrationTask<? extends CaseReference> migrationTask = mock(MigrationTask.class);
+        when(migrationTask.getType()).thenReturn((Class) DashboardNotificationTaskCaseReference.class);
+        doReturn(Optional.of(migrationTask))
+            .when(migrationTaskFactory)
+            .getMigrationTask("testTask");
+
+        ExternalTaskData result = handler.handleTask(externalTask);
+
+        assertNotNull(result);
+
+        ArgumentCaptor<List> referencesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(asyncCaseMigrationService, times(1))
+            .migrateCasesAsync(eq(migrationTask), referencesCaptor.capture(), isNull(), eq(false));
+
+        List<DashboardNotificationTaskCaseReference> references = referencesCaptor.getValue();
+        assertEquals(2, references.size());
+        assertEquals("123", references.get(0).getCaseReference());
+        assertEquals("456", references.get(1).getCaseReference());
+        assertEquals("GenerateDashboardNotificationsHearingScheduledHmc", references.get(0).getDashboardTaskId());
+        assertEquals("process-123", references.get(0).getDashboardProcessInstanceId());
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void shouldHandleTaskWithCaseIdsAndDashboardProcessInstanceIds() {
+        ExternalTask externalTask = mock(ExternalTask.class);
+        when(externalTask.getVariable("taskName")).thenReturn("testTask");
+        when(externalTask.getVariable("caseIds")).thenReturn("123, 456");
+        when(externalTask.getVariable("scenario")).thenReturn(null);
+        when(externalTask.getVariable("dashboardTaskId")).thenReturn("GenerateDashboardNotificationsHearingScheduledHmc");
+        when(externalTask.getVariable("dashboardProcessInstanceId")).thenReturn(null);
+        when(externalTask.getVariable("dashboardProcessInstanceIds")).thenReturn("process-123, process-456");
+        when(externalTask.getVariable("notificationCamundaProcessIdentifier")).thenReturn(null);
+        when(externalTask.getVariable("caseNoteElementId")).thenReturn(null);
+        when(externalTask.getVariable("notifyEventId")).thenReturn(null);
+        when(externalTask.getVariable("state")).thenReturn(null);
+        when(externalTask.getVariable("isGACase")).thenReturn(null);
+
+        MigrationTask<? extends CaseReference> migrationTask = mock(MigrationTask.class);
+        when(migrationTask.getType()).thenReturn((Class) DashboardNotificationTaskCaseReference.class);
+        doReturn(Optional.of(migrationTask))
+            .when(migrationTaskFactory)
+            .getMigrationTask("testTask");
+
+        handler.handleTask(externalTask);
+
+        ArgumentCaptor<List> referencesCaptor = ArgumentCaptor.forClass(List.class);
+        verify(asyncCaseMigrationService, times(1))
+            .migrateCasesAsync(eq(migrationTask), referencesCaptor.capture(), isNull(), eq(false));
+
+        List<DashboardNotificationTaskCaseReference> references = referencesCaptor.getValue();
+        assertEquals("process-123", references.get(0).getDashboardProcessInstanceId());
+        assertEquals("process-456", references.get(1).getDashboardProcessInstanceId());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTaskTest.java
@@ -82,10 +82,11 @@ class RetriggerDashboardNotificationTaskTest {
     void migrateCaseDataShouldThrowWhenDashboardTaskIdIsMissing() {
         DashboardNotificationTaskCaseReference caseReference = new DashboardNotificationTaskCaseReference();
         caseReference.setCaseReference(CASE_REFERENCE);
+        CaseData caseData = CaseData.builder().build();
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> task.migrateCaseData(CaseData.builder().build(), caseReference)
+            () -> task.migrateCaseData(caseData, caseReference)
         );
 
         assertEquals("Case reference and dashboardTaskId must not be blank", exception.getMessage());
@@ -93,11 +94,13 @@ class RetriggerDashboardNotificationTaskTest {
 
     @Test
     void migrateCaseDataShouldThrowWhenNoWorkflowIsRegistered() {
+        CaseData caseData = CaseData.builder().build();
+        DashboardNotificationTaskCaseReference caseReference = caseReference();
         when(registry.workflowsFor(DASHBOARD_TASK_ID, DashboardCaseType.CIVIL)).thenReturn(List.of());
 
         IllegalArgumentException exception = assertThrows(
             IllegalArgumentException.class,
-            () -> task.migrateCaseData(CaseData.builder().build(), caseReference())
+            () -> task.migrateCaseData(caseData, caseReference)
         );
 
         assertEquals("No dashboard notification handlers registered for: " + DASHBOARD_TASK_ID, exception.getMessage());

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTaskTest.java
@@ -1,0 +1,113 @@
+package uk.gov.hmcts.reform.civil.handler.migration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardNotificationTaskCaseReference;
+import uk.gov.hmcts.reform.civil.callback.CallbackParams;
+import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardCaseType;
+import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardNotificationRegistry;
+import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardTaskContext;
+import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardWorkflowTask;
+import uk.gov.hmcts.reform.civil.model.BusinessProcess;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.service.UserService;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RetriggerDashboardNotificationTaskTest {
+
+    private static final String DASHBOARD_TASK_ID = "GenerateDashboardNotificationsHearingScheduledHmc";
+    private static final String PROCESS_INSTANCE_ID = "process-123";
+    private static final String CASE_REFERENCE = "1234567890123456";
+    private static final String AUTH_TOKEN = "Bearer token";
+
+    private DashboardNotificationRegistry registry;
+    private UserService userService;
+    private RetriggerDashboardNotificationTask task;
+
+    @BeforeEach
+    void setUp() {
+        registry = mock(DashboardNotificationRegistry.class);
+        userService = mock(UserService.class);
+        task = new RetriggerDashboardNotificationTask(
+            registry,
+            userService,
+            new SystemUpdateUserConfiguration("system-user", "password")
+        );
+    }
+
+    @Test
+    void migrateCaseDataShouldRunRegisteredDashboardWorkflow() {
+        AtomicReference<DashboardTaskContext> contextReference = new AtomicReference<>();
+        DashboardWorkflowTask workflow = new DashboardWorkflowTask() {
+            @Override
+            public void execute(DashboardTaskContext context) {
+                contextReference.set(context);
+            }
+        };
+
+        when(registry.workflowsFor(DASHBOARD_TASK_ID, DashboardCaseType.CIVIL)).thenReturn(List.of(workflow));
+        when(userService.getAccessToken("system-user", "password")).thenReturn(AUTH_TOKEN);
+
+        CaseData caseData = CaseData.builder()
+            .ccdCaseReference(Long.valueOf(CASE_REFERENCE))
+            .businessProcess(new BusinessProcess().updateProcessInstanceId("existing-process"))
+            .build();
+        DashboardNotificationTaskCaseReference caseReference = caseReference();
+
+        CaseData result = task.migrateCaseData(caseData, caseReference);
+
+        assertSame(caseData, result);
+        verify(registry).workflowsFor(DASHBOARD_TASK_ID, DashboardCaseType.CIVIL);
+        verify(userService).getAccessToken("system-user", "password");
+
+        CallbackParams callbackParams = contextReference.get().callbackParams();
+        assertEquals(AUTH_TOKEN, callbackParams.getParams().get(CallbackParams.Params.BEARER_TOKEN));
+        assertEquals(Long.valueOf(CASE_REFERENCE), contextReference.get().caseData().getCcdCaseReference());
+        assertEquals(DASHBOARD_TASK_ID, contextReference.get().caseData().getBusinessProcess().getActivityId());
+        assertEquals(PROCESS_INSTANCE_ID, contextReference.get().caseData().getBusinessProcess().getProcessInstanceId());
+        assertEquals("existing-process", caseData.getBusinessProcess().getProcessInstanceId());
+    }
+
+    @Test
+    void migrateCaseDataShouldThrowWhenDashboardTaskIdIsMissing() {
+        DashboardNotificationTaskCaseReference caseReference = new DashboardNotificationTaskCaseReference();
+        caseReference.setCaseReference(CASE_REFERENCE);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> task.migrateCaseData(CaseData.builder().build(), caseReference)
+        );
+
+        assertEquals("Case reference and dashboardTaskId must not be blank", exception.getMessage());
+    }
+
+    @Test
+    void migrateCaseDataShouldThrowWhenNoWorkflowIsRegistered() {
+        when(registry.workflowsFor(DASHBOARD_TASK_ID, DashboardCaseType.CIVIL)).thenReturn(List.of());
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> task.migrateCaseData(CaseData.builder().build(), caseReference())
+        );
+
+        assertEquals("No dashboard notification handlers registered for: " + DASHBOARD_TASK_ID, exception.getMessage());
+    }
+
+    private DashboardNotificationTaskCaseReference caseReference() {
+        DashboardNotificationTaskCaseReference caseReference = new DashboardNotificationTaskCaseReference();
+        caseReference.setCaseReference(CASE_REFERENCE);
+        caseReference.setDashboardTaskId(DASHBOARD_TASK_ID);
+        caseReference.setDashboardProcessInstanceId(PROCESS_INSTANCE_ID);
+        return caseReference;
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTaskTest.java
@@ -2,6 +2,9 @@ package uk.gov.hmcts.reform.civil.handler.migration;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardNotificationTaskCaseReference;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
@@ -16,9 +19,12 @@ import uk.gov.hmcts.reform.civil.service.UserService;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import jakarta.persistence.EntityManager;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -32,16 +38,24 @@ class RetriggerDashboardNotificationTaskTest {
 
     private DashboardNotificationRegistry registry;
     private UserService userService;
+    private PlatformTransactionManager transactionManager;
+    private EntityManager entityManager;
     private RetriggerDashboardNotificationTask task;
 
     @BeforeEach
     void setUp() {
         registry = mock(DashboardNotificationRegistry.class);
         userService = mock(UserService.class);
+        transactionManager = mock(PlatformTransactionManager.class);
+        entityManager = mock(EntityManager.class);
+        TransactionStatus transactionStatus = new SimpleTransactionStatus();
+        when(transactionManager.getTransaction(any())).thenReturn(transactionStatus);
         task = new RetriggerDashboardNotificationTask(
             registry,
             userService,
-            new SystemUpdateUserConfiguration("system-user", "password")
+            new SystemUpdateUserConfiguration("system-user", "password"),
+            transactionManager,
+            entityManager
         );
     }
 
@@ -76,6 +90,9 @@ class RetriggerDashboardNotificationTaskTest {
         assertEquals(DASHBOARD_TASK_ID, contextReference.get().caseData().getBusinessProcess().getActivityId());
         assertEquals(PROCESS_INSTANCE_ID, contextReference.get().caseData().getBusinessProcess().getProcessInstanceId());
         assertEquals("existing-process", caseData.getBusinessProcess().getProcessInstanceId());
+        verify(entityManager).joinTransaction();
+        verify(entityManager).flush();
+        verify(transactionManager).commit(any());
     }
 
     @Test


### PR DESCRIPTION
## What
- Adds a migration task to retrigger a registered dashboard notification workflow by Camunda dashboard task id.
- Extends MIGRATE_CASES_SCHEDULER variables with dashboardTaskId and optional dashboardProcessInstanceId / dashboardProcessInstanceIds.
- Keeps the existing scenario-only retrigger task unchanged.

## Why
Some dashboard notification workflows perform task-specific enrichment before recording scenarios, for example hearing scheduled derives hearingLocationCourtName from reference data. Retiggering only the raw scenario skips that enrichment and can fail or produce incomplete notifications.

## How to run
Use MIGRATE_CASES_SCHEDULER with:
- taskName = RetriggerDashboardNotificationTask
- caseIds = comma-separated CCD references
- dashboardTaskId = the Camunda dashboard task id, for example GenerateDashboardNotificationsHearingScheduledHmc
- dashboardProcessInstanceId = optional single process instance id applied to all cases
- dashboardProcessInstanceIds = optional comma-separated process instance ids aligned with caseIds, for workflows that need per-case process variables

## Validation
- ./gradlew compileJava checkstyleMain checkstyleTest test --tests uk.gov.hmcts.reform.civil.handler.migration.RetriggerDashboardNotificationTaskTest --tests uk.gov.hmcts.reform.civil.handler.migration.MigrateCasesEventHandlerTest