### PR TITLE
Add scheduler framework generics and refactor back pressure handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ The service includes a common framework for implementing scheduled tasks. This f
 
 - **`CivilScheduler`**: The main interface for scheduler components. Implementations should be annotated with `@Component` and `@Scheduled`.
 - **`ScheduledTask`**: An interface extending `Consumer<CaseDetails>`, representing the logic to be executed for each case found.
-- **`ScheduledTaskRunner`**: A prototype-scoped component that coordinates the task execution, including case retrieval via a `Supplier<Set<CaseDetails>>`.
+- **`ScheduledTaskRunner`**: A component that coordinates the task execution, including case retrieval via a `Supplier<? extends TaskResult<T>>`.
 - **`ElasticSearchService`**: A base class for services that search for cases to be processed by a scheduler.
 
 ### Creating a New Scheduler

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/DefendantResponseDeadlineSchedulerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/DefendantResponseDeadlineSchedulerIT.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.SearchResult;
@@ -27,10 +28,11 @@ import static org.mockito.Mockito.when;
 
 @ActiveProfiles("integration-test")
 @SpringBootTest(classes = {Application.class, TestIdamConfiguration.class}, properties = {
-    "test.id=DefendantResponseDeadlineSchedulerITest",
+    "test.id=DefendantResponseDeadlineSchedulerIT",
     "scheduler.defendant-response.enabled=true"
 })
-public class DefendantResponseDeadlineSchedulerITest {
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
+public class DefendantResponseDeadlineSchedulerIT {
 
     @Autowired
     private DefendantResponseDeadlineScheduler scheduler;
@@ -47,6 +49,7 @@ public class DefendantResponseDeadlineSchedulerITest {
     @Test
     void shouldExecuteDefendantResponseDeadlineScheduler() {
         // Given
+        when(featureToggleService.isSpringSchedulerEnabled("DefendantResponseDeadline")).thenReturn(true);
         when(featureToggleService.isWelshEnabledForMainCase()).thenReturn(false);
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
         SearchResult searchResult = SearchResult.builder()

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerIT.java
@@ -30,14 +30,12 @@ import static org.mockito.Mockito.when;
 
 @ActiveProfiles("integration-test")
 @SpringBootTest(classes = {Application.class, TestIdamConfiguration.class, CoreCaseDataApiMockHelperConfiguration.class}, properties = {
-    "test.id=JudgementBufferSchedulerITest",
+    "test.id=JudgementBufferSchedulerIT",
     "scheduler.judgement-buffer.enabled=true",
     "search.judgement-buffer.pageSize=50"
 })
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class JudgementBufferSchedulerIT {
-
-    private static final Long CASE_ID = 123L;
 
     @Autowired
     private JudgementBufferScheduler scheduler;
@@ -56,29 +54,6 @@ public class JudgementBufferSchedulerIT {
         when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(true);
         when(featureToggleService.isSpringSchedulerEnabled("JudgementBuffer")).thenReturn(true);
         coreCaseDataApiMockHelper.setupIdamClient();
-    }
-
-    @Test
-    void shouldExecuteJudgementBufferScheduler() {
-        // Given
-        String caseIdString = CASE_ID.toString();
-        CaseDetails caseDetails = CaseDetailsBuilder.builder().atStateJudgmentRequested().id(CASE_ID)
-            .build();
-        SearchResult page1 = SearchResult.builder().total(1).cases(List.of(caseDetails)).build();
-        StartEventResponse startEventResponse = StartEventResponse.builder().eventId(caseIdString).caseDetails(
-            caseDetails).build();
-
-        coreCaseDataApiMockHelper.mockElasticSearchResultPaginated(page1);
-        coreCaseDataApiMockHelper.mockStartEvent(caseIdString, startEventResponse);
-        coreCaseDataApiMockHelper.mockSubmitEvent(caseIdString, caseDetails);
-
-        // When
-        scheduler.runScheduledTask();
-
-        // Then
-        verify(telemetryService).trackEvent(eq("JudgementBufferJobStarted"), anyMap());
-        verify(telemetryService).trackEvent(eq("JudgementBufferJobCompleted"), anyMap());
-        coreCaseDataApiMockHelper.verifySubmitEvent(1);
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/DefaultBackPressureConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/DefaultBackPressureConfiguration.java
@@ -9,15 +9,5 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties(prefix = "scheduler")
 public class DefaultBackPressureConfiguration {
 
-    private static ScheduledTaskBackPressureConfiguration holdDefault;
     private ScheduledTaskBackPressureConfiguration defaultBackPressure;
-
-    public void setDefaultBackPressure(ScheduledTaskBackPressureConfiguration defaultBackPressure) {
-        this.defaultBackPressure = defaultBackPressure;
-        holdDefault = defaultBackPressure;
-    }
-
-    public static ScheduledTaskBackPressureConfiguration getDefault() {
-        return holdDefault;
-    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ListTaskResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ListTaskResult.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.civil.scheduler.common;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public record ListTaskResult<T>(List<T> items, int totalResults) implements TaskResult<T> {
+
+    @Override
+    public Stream<T> itemStream() {
+        return items.stream();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return totalResults == 0;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledEventTracker.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledEventTracker.java
@@ -25,6 +25,8 @@ public class ScheduledEventTracker {
     private static final String STATUS = "status";
     private static final String ERROR = "error";
     private static final String ERROR_CATEGORY = "errorCategory";
+    private static final String PREVIOUS_DELAY = "previousDelay";
+    private static final String CURRENT_DELAY = "currentDelay";
 
     private final ErrorCategorizer errorCategorizer;
     private final TelemetryService telemetryService;
@@ -131,6 +133,17 @@ public class ScheduledEventTracker {
                 FAILED_CASES, ZERO,
                 ABORT_REASON, reason != null ? reason : UNKNOWN,
                 CUMULATIVE_DELAY, ZERO
+            )
+        );
+    }
+
+    public void backPressureUpdatedEvent(ScheduledTaskEventConfiguration eventConfig, Duration oldDelay, Duration newDelay) {
+        telemetryService.trackEvent(
+            eventConfig.getBackPressureUpdatedEvent(),
+            Map.of(
+                SCHEDULER_NAME, eventConfig.getSchedulerName(),
+                PREVIOUS_DELAY, String.valueOf(oldDelay.toMillis()),
+                CURRENT_DELAY, String.valueOf(newDelay.toMillis())
             )
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledEventTracker.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledEventTracker.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.civil.service.TelemetryService;
 
+import java.time.Duration;
 import java.util.Map;
 
 @Component
@@ -15,6 +16,7 @@ public class ScheduledEventTracker {
     private static final String SUCCEEDED_CASES = "succeededCases";
     private static final String FAILED_CASES = "failedCases";
     private static final String ABORT_REASON = "abortReason";
+    private static final String CUMULATIVE_DELAY = "cumulativeDelay";
     private static final String UNKNOWN = "Unknown";
     private static final String ZERO = String.valueOf(0);
     private static final String FAILURE = "FAILURE";
@@ -40,21 +42,29 @@ public class ScheduledEventTracker {
     }
 
     public void caseProcessedEvent(ScheduledTaskEventConfiguration eventConfig, Long caseId) {
+        caseProcessedEvent(eventConfig, String.valueOf(caseId));
+    }
+
+    public void caseProcessedEvent(ScheduledTaskEventConfiguration eventConfig, String caseId) {
         telemetryService.trackEvent(
             eventConfig.getCaseProcessedEvent(),
             Map.of(
                 SCHEDULER_NAME, eventConfig.getSchedulerName(),
-                CASE_ID, String.valueOf(caseId),
+                CASE_ID, caseId,
                 STATUS, SUCCESS
             )
         );
     }
 
     public void caseFailedEvent(ScheduledTaskEventConfiguration eventConfig, Long caseId, Exception e) {
+        caseFailedEvent(eventConfig, String.valueOf(caseId), e);
+    }
+
+    public void caseFailedEvent(ScheduledTaskEventConfiguration eventConfig, String caseId, Exception e) {
         telemetryService.trackEvent(
             eventConfig.getCaseFailedEvent(), Map.of(
                 SCHEDULER_NAME, eventConfig.getSchedulerName(),
-                CASE_ID, String.valueOf(caseId),
+                CASE_ID, caseId,
                 STATUS, FAILURE,
                 ERROR, e.getMessage(),
                 ERROR_CATEGORY, errorCategorizer.categorizeError(e)
@@ -65,14 +75,16 @@ public class ScheduledEventTracker {
     public void jobCompletedEvent(ScheduledTaskEventConfiguration eventConfig,
                                   int totalCases,
                                   int succeededCases,
-                                  int failedCases) {
+                                  int failedCases,
+                                  Duration cumulativeDelay) {
         telemetryService.trackEvent(
             eventConfig.getJobCompletedEvent(),
             Map.of(
                 SCHEDULER_NAME, eventConfig.getSchedulerName(),
                 TOTAL_CASES, String.valueOf(totalCases),
                 SUCCEEDED_CASES, String.valueOf(succeededCases),
-                FAILED_CASES, String.valueOf(failedCases)
+                FAILED_CASES, String.valueOf(failedCases),
+                CUMULATIVE_DELAY, String.valueOf(cumulativeDelay.toMillis())
             )
         );
     }
@@ -84,7 +96,8 @@ public class ScheduledEventTracker {
                 SCHEDULER_NAME, eventConfig.getSchedulerName(),
                 TOTAL_CASES, ZERO,
                 SUCCEEDED_CASES, ZERO,
-                FAILED_CASES, ZERO
+                FAILED_CASES, ZERO,
+                CUMULATIVE_DELAY, ZERO
             )
         );
     }
@@ -93,7 +106,8 @@ public class ScheduledEventTracker {
                                 int totalCases,
                                 int succeededCases,
                                 int failedCases,
-                                String reason) {
+                                String reason,
+                                Duration cumulativeDelay) {
         telemetryService.trackEvent(
             eventConfig.getJobAbortedEvent(),
             Map.of(
@@ -101,7 +115,8 @@ public class ScheduledEventTracker {
                 TOTAL_CASES, String.valueOf(totalCases),
                 SUCCEEDED_CASES, String.valueOf(succeededCases),
                 FAILED_CASES, String.valueOf(failedCases),
-                ABORT_REASON, reason != null ? reason : UNKNOWN
+                ABORT_REASON, reason != null ? reason : UNKNOWN,
+                CUMULATIVE_DELAY, String.valueOf(cumulativeDelay.toMillis())
             )
         );
     }
@@ -114,7 +129,8 @@ public class ScheduledEventTracker {
                 TOTAL_CASES, ZERO,
                 SUCCEEDED_CASES, ZERO,
                 FAILED_CASES, ZERO,
-                ABORT_REASON, reason != null ? reason : UNKNOWN
+                ABORT_REASON, reason != null ? reason : UNKNOWN,
+                CUMULATIVE_DELAY, ZERO
             )
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTask.java
@@ -1,10 +1,10 @@
 package uk.gov.hmcts.reform.civil.scheduler.common;
 
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-
 import java.util.function.Consumer;
 
-public interface ScheduledTask extends Consumer<CaseDetails> {
+public interface ScheduledTask<T, I> extends Consumer<T> {
+
+    I getItemId(T item);
 
     default long maxCasesPerRun() {
         return Long.MAX_VALUE;

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskBackPressure.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskBackPressure.java
@@ -1,16 +1,28 @@
 package uk.gov.hmcts.reform.civil.scheduler.common;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.time.Duration;
 
+@Slf4j
 class ScheduledTaskBackPressure {
 
+    private final String schedulerName;
     private final ScheduledTaskBackPressureConfiguration configuration;
+    private final ScheduledEventTracker eventTracker;
+    private final ScheduledTaskEventConfiguration eventConfig;
     private Duration currentDelay;
 
-    ScheduledTaskBackPressure(ScheduledTaskBackPressureConfiguration configuration) {
+    ScheduledTaskBackPressure(String schedulerName,
+                              ScheduledTaskBackPressureConfiguration configuration,
+                              ScheduledEventTracker eventTracker,
+                              ScheduledTaskEventConfiguration eventConfig) {
+        this.schedulerName = schedulerName;
         this.configuration = configuration != null
             ? configuration
             : ScheduledTaskBackPressureConfiguration.disabled();
+        this.eventTracker = eventTracker;
+        this.eventConfig = eventConfig;
         this.currentDelay = this.configuration.initialDelay();
     }
 
@@ -36,16 +48,32 @@ class ScheduledTaskBackPressure {
     }
 
     private void increaseDelay(Duration increase) {
+        Duration previousDelay = currentDelay;
         currentDelay = currentDelay.plus(increase);
         if (currentDelay.compareTo(configuration.maxDelay()) > 0) {
             currentDelay = configuration.maxDelay();
         }
+
+        notifyIfChanged(previousDelay);
     }
 
     private void reduceDelay(Duration reduction) {
+        Duration previousDelay = currentDelay;
         currentDelay = currentDelay.minus(reduction);
         if (currentDelay.compareTo(configuration.initialDelay()) < 0) {
             currentDelay = configuration.initialDelay();
+        }
+
+        notifyIfChanged(previousDelay);
+    }
+
+    private void notifyIfChanged(Duration previousDelay) {
+        if (!currentDelay.equals(previousDelay)) {
+            log.info("{} backpressure: delay changed from {}ms to {}ms",
+                     schedulerName, previousDelay.toMillis(), currentDelay.toMillis());
+            if (eventTracker != null && eventConfig != null) {
+                eventTracker.backPressureUpdatedEvent(eventConfig, previousDelay, currentDelay);
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskBackPressure.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskBackPressure.java
@@ -36,18 +36,16 @@ class ScheduledTaskBackPressure {
     }
 
     private void increaseDelay(Duration increase) {
-        currentDelay = min(configuration.maxDelay(), currentDelay.plus(increase));
+        currentDelay = currentDelay.plus(increase);
+        if (currentDelay.compareTo(configuration.maxDelay()) > 0) {
+            currentDelay = configuration.maxDelay();
+        }
     }
 
     private void reduceDelay(Duration reduction) {
-        currentDelay = max(Duration.ZERO, currentDelay.minus(reduction));
-    }
-
-    private Duration min(Duration left, Duration right) {
-        return left.compareTo(right) <= 0 ? left : right;
-    }
-
-    private Duration max(Duration left, Duration right) {
-        return left.compareTo(right) >= 0 ? left : right;
+        currentDelay = currentDelay.minus(reduction);
+        if (currentDelay.compareTo(configuration.initialDelay()) < 0) {
+            currentDelay = configuration.initialDelay();
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskEventConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskEventConfiguration.java
@@ -11,6 +11,7 @@ public class ScheduledTaskEventConfiguration {
     String caseFailedEvent;
     String jobCompletedEvent;
     String jobAbortedEvent;
+    String backPressureUpdatedEvent;
 
     public ScheduledTaskEventConfiguration(String schedulerName) {
         this.schedulerName = schedulerName;
@@ -19,5 +20,6 @@ public class ScheduledTaskEventConfiguration {
         this.caseFailedEvent = schedulerName + "CaseFailed";
         this.jobCompletedEvent = schedulerName + "JobCompleted";
         this.jobAbortedEvent = schedulerName + "JobAborted";
+        this.backPressureUpdatedEvent = schedulerName + "BackPressureUpdated";
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskOutcome.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskOutcome.java
@@ -1,10 +1,12 @@
 package uk.gov.hmcts.reform.civil.scheduler.common;
 
+import java.time.Duration;
 import java.util.List;
 
-public record ScheduledTaskOutcome(
-    List<Long> succeededCases,
-    List<Long> failedCases,
+public record ScheduledTaskOutcome<I>(
+    List<I> succeededCases,
+    List<I> failedCases,
     boolean abortedEarly,
-    String abortReason
+    String abortReason,
+    Duration cumulativeDelay
 ) {}

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessor.java
@@ -44,7 +44,10 @@ public class ScheduledTaskProcessor<T, I> {
         AtomicReference<String> abortReason = new AtomicReference<>();
         AtomicLong cumulativeDelayMillis = new AtomicLong();
         ScheduledTaskBackPressure backPressure = new ScheduledTaskBackPressure(
-            scheduledTask.backPressureConfiguration()
+            eventConfig.getSchedulerName(),
+            scheduledTask.backPressureConfiguration(),
+            eventTracker,
+            eventConfig
         );
 
         Stream<T> sequentialStream = searchResult.itemStream()

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessor.java
@@ -4,20 +4,21 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
-import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-public class ScheduledTaskProcessor {
+public class ScheduledTaskProcessor<T, I> {
 
     private final ScheduledEventTracker eventTracker;
 
@@ -25,84 +26,99 @@ public class ScheduledTaskProcessor {
     private int circuitBreakerThreshold;
 
     /**
-     * Performs processing of scheduled tasks for a stream of cases.
+     * Performs processing of scheduled tasks for a stream of items.
      * Use allMatch to short-circuit the stream if the circuit breaker is triggered.
      * Once the predicate returns false, allMatch stops processing further elements.
      *
      * @param eventConfig   the event configuration
-     * @param scheduledTask the task to be performed on each case
-     * @param searchResult  the result of the elastic search containing the stream of cases
+     * @param scheduledTask the task to be performed on each item
+     * @param searchResult  the result of the search containing the stream of items
      * @return the outcome of the scheduled task processing
      */
-    public ScheduledTaskOutcome performProcessing(ScheduledTaskEventConfiguration eventConfig,
-                                                  ScheduledTask scheduledTask,
-                                                  ElasticSearchResult searchResult) {
-        List<Long> succeededCases = new ArrayList<>();
-        List<Long> failedCases = new ArrayList<>();
-        int[] consecutiveFailures = new int[1];
-        String[] abortReason = new String[1];
+    public ScheduledTaskOutcome<I> performProcessing(ScheduledTaskEventConfiguration eventConfig,
+                                                     ScheduledTask<T, I> scheduledTask,
+                                                     TaskResult<T> searchResult) {
+        List<I> succeededItems = new ArrayList<>();
+        List<I> failedItems = new ArrayList<>();
+        AtomicInteger consecutiveFailures = new AtomicInteger();
+        AtomicReference<String> abortReason = new AtomicReference<>();
+        AtomicLong cumulativeDelayMillis = new AtomicLong();
         ScheduledTaskBackPressure backPressure = new ScheduledTaskBackPressure(
             scheduledTask.backPressureConfiguration()
         );
 
-        Stream<CaseDetails> sequentialStream = searchResult.caseDetailsStream()
+        Stream<T> sequentialStream = searchResult.itemStream()
             .sequential()
             .limit(maxCasesPerRun(scheduledTask));
 
         try {
-            boolean completed = sequentialStream.allMatch(caseDetails -> processCaseDetails(
+            boolean completed = sequentialStream.allMatch(item -> processItem(
                 eventConfig,
                 scheduledTask,
-                caseDetails,
+                item,
                 backPressure,
-                succeededCases,
-                failedCases,
+                succeededItems,
+                failedItems,
                 consecutiveFailures,
-                abortReason
+                abortReason,
+                cumulativeDelayMillis
             ));
 
-            return new ScheduledTaskOutcome(succeededCases, failedCases, !completed, abortReason[0]);
+            return new ScheduledTaskOutcome<>(
+                succeededItems,
+                failedItems,
+                !completed,
+                abortReason.get(),
+                Duration.ofMillis(cumulativeDelayMillis.get())
+            );
         } catch (ScheduledTaskInterruptedException e) {
-            abortReason[0] = e.getMessage();
-            return new ScheduledTaskOutcome(succeededCases, failedCases, true, abortReason[0]);
+            abortReason.set(e.getMessage());
+            return new ScheduledTaskOutcome<>(
+                succeededItems,
+                failedItems,
+                true,
+                abortReason.get(),
+                Duration.ofMillis(cumulativeDelayMillis.get())
+            );
         }
     }
 
-    private boolean processCaseDetails(ScheduledTaskEventConfiguration eventConfig,
-                                       ScheduledTask scheduledTask,
-                                       CaseDetails caseDetails,
+    private boolean processItem(ScheduledTaskEventConfiguration eventConfig,
+                                       ScheduledTask<T, I> scheduledTask,
+                                       T item,
                                        ScheduledTaskBackPressure backPressure,
-                                       List<Long> succeededCases,
-                                       List<Long> failedCases,
-                                       int[] consecutiveFailures,
-                                       String[] abortReason) {
-        applyBackPressure(backPressure);
+                                       List<I> succeededItems,
+                                       List<I> failedItems,
+                                       AtomicInteger consecutiveFailures,
+                                       AtomicReference<String> abortReason,
+                                       AtomicLong cumulativeDelayMillis) {
+        applyBackPressure(backPressure, cumulativeDelayMillis);
 
-        Long caseId = caseDetails.getId();
+        I itemId = scheduledTask.getItemId(item);
         Instant startedAt = Instant.now();
 
         try {
-            scheduledTask.accept(caseDetails);
+            scheduledTask.accept(item);
             backPressure.afterSuccess(Duration.between(startedAt, Instant.now()));
-            eventTracker.caseProcessedEvent(eventConfig, caseId);
-            succeededCases.add(caseId);
-            consecutiveFailures[0] = 0;
+            eventTracker.caseProcessedEvent(eventConfig, itemId.toString());
+            succeededItems.add(itemId);
+            consecutiveFailures.set(0);
         } catch (Exception e) {
             backPressure.afterFailure();
-            failedCases.add(caseId);
-            eventTracker.caseFailedEvent(eventConfig, caseId, e);
-            log.error("Error processing case {}: {}", caseId, e.getMessage(), e);
-            int failures = ++consecutiveFailures[0];
+            failedItems.add(itemId);
+            eventTracker.caseFailedEvent(eventConfig, itemId.toString(), e);
+            log.error("Error processing item {}: {}", itemId, e.getMessage(), e);
+            int failures = consecutiveFailures.incrementAndGet();
 
             if (failures >= circuitBreakerThreshold) {
-                abortReason[0] = Objects.toString(e.getMessage(), e.getClass().getSimpleName());
+                abortReason.set(Objects.toString(e.getMessage(), e.getClass().getSimpleName()));
                 return false;
             }
         }
         return true;
     }
 
-    private long maxCasesPerRun(ScheduledTask scheduledTask) {
+    private long maxCasesPerRun(ScheduledTask<T, I> scheduledTask) {
         long maxCasesPerRun = scheduledTask.maxCasesPerRun();
         if (maxCasesPerRun < 0) {
             throw new IllegalArgumentException("maxCasesPerRun cannot be negative");
@@ -110,7 +126,7 @@ public class ScheduledTaskProcessor {
         return maxCasesPerRun;
     }
 
-    private void applyBackPressure(ScheduledTaskBackPressure backPressure) {
+    private void applyBackPressure(ScheduledTaskBackPressure backPressure, AtomicLong cumulativeDelayMillis) {
         Duration delay = backPressure.currentDelay();
         if (delay.isZero()) {
             return;
@@ -118,6 +134,7 @@ public class ScheduledTaskProcessor {
 
         try {
             log.debug("Applying scheduled task backpressure delay: {}", delay);
+            cumulativeDelayMillis.addAndGet(delay.toMillis());
             sleep(delay);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunner.java
@@ -2,35 +2,52 @@ package uk.gov.hmcts.reform.civil.scheduler.common;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
+import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
+
+import java.util.function.Supplier;
 
 /**
  * Runner for scheduled tasks that coordinates between event tracking, searching and processing.
- * This component is prototype-scoped to ensure isolated state per scheduler instance.
  */
 @Component
-@Scope(value = ConfigurableBeanFactory.SCOPE_PROTOTYPE)
 @RequiredArgsConstructor
 @Slf4j
-public class ScheduledTaskRunner {
+public class ScheduledTaskRunner<T, I> {
 
     private final ScheduledEventTracker eventTracker;
-    private final ScheduledTaskProcessor scheduledTaskProcessor;
+    private final ScheduledTaskProcessor<T, I> scheduledTaskProcessor;
+    private final FeatureToggleService featureToggleService;
 
     /**
-     * Executes the scheduled task for cases found in the search result.
+     * Executes the scheduled task if the feature toggle is enabled.
+     * Handles searching, logging and processing of items.
+     *
+     * @param schedulerName         the name of the scheduler
+     * @param searchResultSupplier  the supplier for search results
+     * @param scheduledTask         the task to be performed on each item
+     */
+    public void run(String schedulerName,
+                    Supplier<? extends TaskResult<T>> searchResultSupplier,
+                    ScheduledTask<T, I> scheduledTask) {
+        if (featureToggleService.isSpringSchedulerEnabled(schedulerName)) {
+            log.info("Running {} scheduler", schedulerName);
+            TaskResult<T> searchResult = searchResultSupplier.get();
+            run(new ScheduledTaskEventConfiguration(schedulerName), searchResult, scheduledTask);
+        }
+    }
+
+    /**
+     * Executes the scheduled task for items found in the search result.
      * Handles null search results and empty search results by logging and tracking events appropriately.
      *
      * @param eventConfig   the event configuration
-     * @param searchResult  the result of the elastic search
-     * @param scheduledTask the task to be performed on each case
+     * @param searchResult  the result of the search
+     * @param scheduledTask the task to be performed on each item
      */
     public void run(ScheduledTaskEventConfiguration eventConfig,
-                    ElasticSearchResult searchResult,
-                    ScheduledTask scheduledTask) {
+                    TaskResult<T> searchResult,
+                    ScheduledTask<T, I> scheduledTask) {
 
         if (searchResult == null) {
             eventTracker.jobAbortedEvent(eventConfig, "SearchResult cannot be null");
@@ -48,25 +65,25 @@ public class ScheduledTaskRunner {
             return;
         }
 
-        processCaseDetails(eventConfig, scheduledTask, searchResult);
+        processItems(eventConfig, scheduledTask, searchResult);
     }
 
     /**
-     * Orchestrates the processing of case details by delegating to {@link ScheduledTaskProcessor}.
+     * Orchestrates the processing of items by delegating to {@link ScheduledTaskProcessor}.
      * Tracks the start, completion, or early abortion of the job.
      *
      * @param eventConfig   the event configuration
-     * @param scheduledTask the task to be performed on each case
-     * @param searchResult  the result of the elastic search containing the stream of cases
+     * @param scheduledTask the task to be performed on each item
+     * @param searchResult  the result of the search containing the stream of items
      */
-    private void processCaseDetails(ScheduledTaskEventConfiguration eventConfig,
-                                    ScheduledTask scheduledTask,
-                                    ElasticSearchResult searchResult) {
+    private void processItems(ScheduledTaskEventConfiguration eventConfig,
+                                    ScheduledTask<T, I> scheduledTask,
+                                    TaskResult<T> searchResult) {
         int totalCases = searchResult.totalResults();
         eventTracker.jobStartedEvent(eventConfig, totalCases);
         log.info("Running scheduled task: {}, totalCases: {}", eventConfig.getSchedulerName(), totalCases);
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(
+        ScheduledTaskOutcome<I> outcome = scheduledTaskProcessor.performProcessing(
             eventConfig,
             scheduledTask,
             searchResult
@@ -78,29 +95,33 @@ public class ScheduledTaskRunner {
                 totalCases,
                 outcome.succeededCases().size(),
                 outcome.failedCases().size(),
-                outcome.abortReason()
+                outcome.abortReason(),
+                outcome.cumulativeDelay()
             );
             log.info(
-                "Scheduled task aborted: {}, totalCases: {}, succeededCases: {}, failedCases: {}, abortReason: {}",
+                "Scheduled task aborted: {}, totalCases: {}, succeededCases: {}, failedCases: {}, abortReason: {}, cumulativeDelay: {}",
                 eventConfig.getSchedulerName(),
                 totalCases,
                 outcome.succeededCases().size(),
                 outcome.failedCases().size(),
-                outcome.abortReason()
+                outcome.abortReason(),
+                outcome.cumulativeDelay()
             );
         } else {
             eventTracker.jobCompletedEvent(
                 eventConfig,
                 totalCases,
                 outcome.succeededCases().size(),
-                outcome.failedCases().size()
+                outcome.failedCases().size(),
+                outcome.cumulativeDelay()
             );
             log.info(
-                "Scheduled task completed: {}, totalCases: {}, succeededCases: {}, failedCases: {}",
+                "Scheduled task completed: {}, totalCases: {}, succeededCases: {}, failedCases: {}, cumulativeDelay: {}",
                 eventConfig.getSchedulerName(),
                 totalCases,
                 outcome.succeededCases().size(),
-                outcome.failedCases().size()
+                outcome.failedCases().size(),
+                outcome.cumulativeDelay()
             );
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunner.java
@@ -33,7 +33,7 @@ public class ScheduledTaskRunner<T, I> {
         if (featureToggleService.isSpringSchedulerEnabled(schedulerName)) {
             log.info("Running {} scheduler", schedulerName);
             TaskResult<T> searchResult = searchResultSupplier.get();
-            run(new ScheduledTaskEventConfiguration(schedulerName), searchResult, scheduledTask);
+            execute(new ScheduledTaskEventConfiguration(schedulerName), searchResult, scheduledTask);
         }
     }
 
@@ -45,9 +45,9 @@ public class ScheduledTaskRunner<T, I> {
      * @param searchResult  the result of the search
      * @param scheduledTask the task to be performed on each item
      */
-    public void run(ScheduledTaskEventConfiguration eventConfig,
-                    TaskResult<T> searchResult,
-                    ScheduledTask<T, I> scheduledTask) {
+    private void execute(ScheduledTaskEventConfiguration eventConfig,
+                         TaskResult<T> searchResult,
+                         ScheduledTask<T, I> scheduledTask) {
 
         if (searchResult == null) {
             eventTracker.jobAbortedEvent(eventConfig, "SearchResult cannot be null");

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/TaskResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/common/TaskResult.java
@@ -1,0 +1,12 @@
+package uk.gov.hmcts.reform.civil.scheduler.common;
+
+import java.util.stream.Stream;
+
+public interface TaskResult<T> {
+
+    int totalResults();
+
+    Stream<T> itemStream();
+
+    boolean isEmpty();
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineScheduler.java
@@ -6,8 +6,8 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.scheduler.common.CivilScheduler;
-import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskEventConfiguration;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.search.DefendantResponseDeadlineCheckSearchService;
 
@@ -20,7 +20,7 @@ public class DefendantResponseDeadlineScheduler implements CivilScheduler {
     private static final String SCHEDULER_NAME = "DefendantResponseDeadline";
 
     private final DefendantResponseDeadlineCheckSearchService searchService;
-    private final ScheduledTaskRunner scheduledTaskRunner;
+    private final ScheduledTaskRunner<CaseDetails, Long> scheduledTaskRunner;
     private final DefendantResponseDeadlineTask defendantResponseDeadlineTask;
 
     @Override
@@ -34,10 +34,9 @@ public class DefendantResponseDeadlineScheduler implements CivilScheduler {
         lockAtLeastFor = "${scheduler.lockAtLeastFor}")
     @Override
     public void runScheduledTask() {
-        log.info("Running {} scheduler", SCHEDULER_NAME);
         scheduledTaskRunner.run(
-            new ScheduledTaskEventConfiguration(SCHEDULER_NAME),
-            searchService.getElasticSearchResult(),
+            SCHEDULER_NAME,
+            searchService::getElasticSearchResult,
             defendantResponseDeadlineTask
         );
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineTask.java
@@ -4,16 +4,30 @@ import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.civil.scheduler.common.DefaultBackPressureConfiguration;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTask;
+import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskBackPressureConfiguration;
 
 @Component
 @AllArgsConstructor
 @Slf4j
-public class DefendantResponseDeadlineTask implements ScheduledTask {
+public class DefendantResponseDeadlineTask implements ScheduledTask<CaseDetails, Long> {
+
+    private final DefaultBackPressureConfiguration defaultBackPressureConfiguration;
+
+    @Override
+    public Long getItemId(CaseDetails caseDetails) {
+        return caseDetails.getId();
+    }
 
     @Override
     public void accept(CaseDetails caseDetails) {
         log.info("DefendantResponseDeadlineTask::accept case {}", caseDetails.getId());
         //Add logic to publish event for defendant response deadline
+    }
+
+    @Override
+    public ScheduledTaskBackPressureConfiguration backPressureConfiguration() {
+        return defaultBackPressureConfiguration.getDefaultBackPressure();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduledTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduledTask.java
@@ -13,9 +13,15 @@ import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
 @Component
 @Slf4j
 @AllArgsConstructor
-public class JudgementBufferScheduledTask implements ScheduledTask {
+public class JudgementBufferScheduledTask implements ScheduledTask<CaseDetails, Long> {
 
     private final CoreCaseDataService coreCaseDataService;
+    private final DefaultBackPressureConfiguration defaultBackPressureConfiguration;
+
+    @Override
+    public Long getItemId(CaseDetails caseDetails) {
+        return caseDetails.getId();
+    }
 
     @Override
     public void accept(CaseDetails caseDetails) {
@@ -26,6 +32,6 @@ public class JudgementBufferScheduledTask implements ScheduledTask {
 
     @Override
     public ScheduledTaskBackPressureConfiguration backPressureConfiguration() {
-        return DefaultBackPressureConfiguration.getDefault();
+        return defaultBackPressureConfiguration.getDefaultBackPressure();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
@@ -6,8 +6,8 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.scheduler.common.CivilScheduler;
-import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskEventConfiguration;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.service.search.judgementbuffer.JudgementBufferExpiredSearchService;
@@ -21,7 +21,7 @@ public class JudgementBufferScheduler implements CivilScheduler {
     public static final String SCHEDULER_NAME = "JudgementBuffer";
 
     private final JudgementBufferExpiredSearchService searchService;
-    private final ScheduledTaskRunner scheduledTaskRunner;
+    private final ScheduledTaskRunner<CaseDetails, Long> scheduledTaskRunner;
     private final JudgementBufferScheduledTask judgementBufferScheduledTask;
     private final FeatureToggleService featureToggleService;
 
@@ -36,12 +36,10 @@ public class JudgementBufferScheduler implements CivilScheduler {
         lockAtLeastFor = "${scheduler.lockAtLeastFor}")
     @Override
     public void runScheduledTask() {
-        if (featureToggleService.isJudgmentBufferEnabled()
-            && featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)) {
-            log.info("Running {} scheduler", SCHEDULER_NAME);
+        if (featureToggleService.isJudgmentBufferEnabled()) {
             scheduledTaskRunner.run(
-                new ScheduledTaskEventConfiguration(SCHEDULER_NAME),
-                searchService.getElasticSearchResult(),
+                SCHEDULER_NAME,
+                searchService::getElasticSearchResult,
                 judgementBufferScheduledTask
             );
         }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchResult.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/common/ElasticSearchResult.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.reform.civil.service.search.common;
 
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.civil.scheduler.common.TaskResult;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
@@ -10,7 +11,7 @@ import java.util.stream.Stream;
  * Contains the total number of results and a stream to consume them.
  * Note: the stream should be consumed only once.
  */
-public final class ElasticSearchResult {
+public final class ElasticSearchResult implements TaskResult<CaseDetails> {
 
     private final Stream<CaseDetails> caseDetailsStream;
     private final int totalResults;
@@ -42,6 +43,11 @@ public final class ElasticSearchResult {
             throw new IllegalStateException("Stream has already been consumed");
         }
         return caseDetailsStream;
+    }
+
+    @Override
+    public Stream<CaseDetails> itemStream() {
+        return caseDetailsStream();
     }
 
     public boolean isEmpty() {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/search/judgementbuffer/JudgementBufferExpiredQueryProvider.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/search/judgementbuffer/JudgementBufferExpiredQueryProvider.java
@@ -40,9 +40,9 @@ public class JudgementBufferExpiredQueryProvider implements PaginatedQueryProvid
      */
     @Override
     public PaginatedQuery getPaginatedQuery(PageToken pageToken, int pageSize) {
-        String timeNow = ZonedDateTime.now(ZoneOffset.UTC).toString();
+        ZonedDateTime timeNow = ZonedDateTime.now(ZoneOffset.UTC);
         log.info("Call to JudgementBufferExpiredSearchService query with timeNow {}", timeNow);
-        ZonedDateTime timeMinus48Hours = ZonedDateTime.parse(timeNow).minusHours(48);
+        ZonedDateTime timeMinus48Hours = timeNow.minusHours(48);
         return new PaginatedQuery(
             generateSearchForExpiredJudgments(timeMinus48Hours),
             List.of("reference"),

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ListTaskResultTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ListTaskResultTest.java
@@ -1,0 +1,26 @@
+package uk.gov.hmcts.reform.civil.scheduler.common;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ListTaskResultTest {
+
+    @Test
+    void shouldExposeItemsAndTotalResults() {
+        ListTaskResult<String> result = new ListTaskResult<>(List.of("one", "two"), 2);
+
+        assertThat(result.totalResults()).isEqualTo(2);
+        assertThat(result.itemStream()).containsExactly("one", "two");
+        assertThat(result.isEmpty()).isFalse();
+    }
+
+    @Test
+    void shouldBeEmptyWhenTotalResultsIsZero() {
+        ListTaskResult<String> result = new ListTaskResult<>(List.of("not-counted"), 0);
+
+        assertThat(result.isEmpty()).isTrue();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledEventTrackerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledEventTrackerTest.java
@@ -8,6 +8,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.civil.service.TelemetryService;
 
+import java.time.Duration;
 import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.eq;
@@ -82,7 +83,7 @@ class ScheduledEventTrackerTest {
 
     @Test
     void shouldTrackJobCompletedEvent() {
-        scheduledEventTracker.jobCompletedEvent(eventConfig, 3, 2, 1);
+        scheduledEventTracker.jobCompletedEvent(eventConfig, 3, 2, 1, Duration.ofMillis(500));
 
         verify(telemetryService).trackEvent(
             eq("TestSchedulerJobCompleted"),
@@ -90,14 +91,15 @@ class ScheduledEventTrackerTest {
                 "schedulerName", "TestScheduler",
                 "totalCases", "3",
                 "succeededCases", "2",
-                "failedCases", "1"
+                "failedCases", "1",
+                "cumulativeDelay", "500"
             ))
         );
     }
 
     @Test
     void shouldTrackJobAbortedEvent() {
-        scheduledEventTracker.jobAbortedEvent(eventConfig, 2, 0, 2, "Aborted due to too many errors");
+        scheduledEventTracker.jobAbortedEvent(eventConfig, 2, 0, 2, "Aborted due to too many errors", Duration.ofMillis(100));
 
         verify(telemetryService).trackEvent(
             eq("TestSchedulerJobAborted"),
@@ -106,14 +108,15 @@ class ScheduledEventTrackerTest {
                 "totalCases", "2",
                 "succeededCases", "0",
                 "failedCases", "2",
-                "abortReason", "Aborted due to too many errors"
+                "abortReason", "Aborted due to too many errors",
+                "cumulativeDelay", "100"
             ))
         );
     }
 
     @Test
     void shouldTrackJobAbortedEventWithUnknownReason_whenReasonIsNull() {
-        scheduledEventTracker.jobAbortedEvent(eventConfig, 0, 0, 0, null);
+        scheduledEventTracker.jobAbortedEvent(eventConfig, 0, 0, 0, null, Duration.ZERO);
 
         verify(telemetryService).trackEvent(
             eq("TestSchedulerJobAborted"),
@@ -122,7 +125,8 @@ class ScheduledEventTrackerTest {
                 "totalCases", "0",
                 "succeededCases", "0",
                 "failedCases", "0",
-                "abortReason", "Unknown"
+                "abortReason", "Unknown",
+                "cumulativeDelay", "0"
             ))
         );
     }
@@ -137,7 +141,8 @@ class ScheduledEventTrackerTest {
                 "schedulerName", "TestScheduler",
                 "totalCases", "0",
                 "succeededCases", "0",
-                "failedCases", "0"
+                "failedCases", "0",
+                "cumulativeDelay", "0"
             ))
         );
     }
@@ -153,7 +158,8 @@ class ScheduledEventTrackerTest {
                 "totalCases", "0",
                 "succeededCases", "0",
                 "failedCases", "0",
-                "abortReason", "Error reason"
+                "abortReason", "Error reason",
+                "cumulativeDelay", "0"
             ))
         );
     }
@@ -169,7 +175,8 @@ class ScheduledEventTrackerTest {
                 "totalCases", "0",
                 "succeededCases", "0",
                 "failedCases", "0",
-                "abortReason", "Unknown"
+                "abortReason", "Unknown",
+                "cumulativeDelay", "0"
             ))
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessorTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.scheduler.common;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
@@ -23,7 +24,9 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -35,10 +38,18 @@ class ScheduledTaskProcessorTest {
     private ScheduledEventTracker scheduledEventTracker;
 
     @Mock(answer = Answers.CALLS_REAL_METHODS)
-    private ScheduledTask scheduledTask;
+    private ScheduledTask<CaseDetails, Long> scheduledTask;
 
     @InjectMocks
-    private ScheduledTaskProcessor scheduledTaskProcessor;
+    private ScheduledTaskProcessor<CaseDetails, Long> scheduledTaskProcessor;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(scheduledTask.getItemId(any())).thenAnswer(invocation -> {
+            CaseDetails caseDetails = invocation.getArgument(0);
+            return caseDetails != null ? caseDetails.getId() : null;
+        });
+    }
 
     @Test
     void shouldProcessAllCases_whenNoFailures() {
@@ -50,7 +61,7 @@ class ScheduledTaskProcessorTest {
         List<CaseDetails> cases = List.of(case1, case2, case3);
         ElasticSearchResult searchResult = new ElasticSearchResult(cases.stream(), 3);
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
+        ScheduledTaskOutcome<Long> outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
 
         assertThat(outcome).isNotNull();
         assertThat(outcome.succeededCases().size()).isEqualTo(3);
@@ -61,11 +72,12 @@ class ScheduledTaskProcessorTest {
         verify(scheduledTask).accept(case3);
         verify(scheduledTask).backPressureConfiguration();
         verify(scheduledTask).maxCasesPerRun();
+        verify(scheduledTask, times(3)).getItemId(any());
         verifyNoMoreInteractions(scheduledTask);
 
-        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, case1.getId());
-        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, case2.getId());
-        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, case3.getId());
+        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, String.valueOf(case1.getId()));
+        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, String.valueOf(case2.getId()));
+        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, String.valueOf(case3.getId()));
         verifyNoMoreInteractions(scheduledEventTracker);
     }
 
@@ -73,7 +85,7 @@ class ScheduledTaskProcessorTest {
     void shouldNotProcess_whenNoCases() {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, new ElasticSearchResult(Stream.empty(), 0));
+        ScheduledTaskOutcome<Long> outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, new ElasticSearchResult(Stream.empty(), 0));
 
         assertThat(outcome).isNotNull();
         assertThat(outcome.succeededCases()).isEmpty();
@@ -81,6 +93,7 @@ class ScheduledTaskProcessorTest {
 
         verify(scheduledTask).backPressureConfiguration();
         verify(scheduledTask).maxCasesPerRun();
+        verify(scheduledTask, never()).getItemId(any());
         verifyNoMoreInteractions(scheduledTask);
         verifyNoInteractions(scheduledEventTracker);
     }
@@ -95,16 +108,16 @@ class ScheduledTaskProcessorTest {
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, task, searchResult);
+        ScheduledTaskOutcome<Long> outcome = scheduledTaskProcessor.performProcessing(eventConfig, task, searchResult);
 
         assertThat(outcome.abortedEarly()).isFalse();
         assertThat(outcome.succeededCases()).containsExactly(1L, 2L);
         assertThat(outcome.failedCases()).isEmpty();
         assertThat(task.processedCases()).containsExactly(1L, 2L);
 
-        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, 1L);
-        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, 2L);
-        verify(scheduledEventTracker, never()).caseProcessedEvent(eventConfig, 3L);
+        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, "1");
+        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, "2");
+        verify(scheduledEventTracker, never()).caseProcessedEvent(eventConfig, "3");
         verifyNoMoreInteractions(scheduledEventTracker);
     }
 
@@ -132,16 +145,17 @@ class ScheduledTaskProcessorTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1, case2, case3), 3);
 
-        ScheduledTaskOutcome outcome = processor.performProcessing(eventConfig, task, searchResult);
+        ScheduledTaskOutcome<Long> outcome = processor.performProcessing(eventConfig, task, searchResult);
 
         assertThat(outcome.abortedEarly()).isFalse();
         assertThat(outcome.failedCases()).containsExactly(1L);
         assertThat(outcome.succeededCases()).containsExactly(2L, 3L);
         assertThat(processor.delays()).containsExactly(Duration.ofMillis(10), Duration.ofMillis(5));
+        assertThat(outcome.cumulativeDelay()).isEqualTo(Duration.ofMillis(15));
 
-        verify(scheduledEventTracker).caseFailedEvent(eventConfig, 1L, error);
-        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, 2L);
-        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, 3L);
+        verify(scheduledEventTracker).caseFailedEvent(eventConfig, "1", error);
+        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, "2");
+        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, "3");
     }
 
     @Test
@@ -162,7 +176,7 @@ class ScheduledTaskProcessorTest {
         );
 
         try {
-            ScheduledTaskOutcome outcome = processor.performProcessing(
+            ScheduledTaskOutcome<Long> outcome = processor.performProcessing(
                 new ScheduledTaskEventConfiguration("JudgmentBuffer"),
                 task,
                 new ElasticSearchResult(Stream.of(case1), 1)
@@ -201,7 +215,7 @@ class ScheduledTaskProcessorTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ElasticSearchResult searchResult = new ElasticSearchResult(cases.stream(), 4);
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
+        ScheduledTaskOutcome<Long> outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
 
         assertThat(outcome.abortedEarly()).isTrue();
         assertThat(outcome.abortReason()).isEqualTo("Error 2");
@@ -211,8 +225,8 @@ class ScheduledTaskProcessorTest {
         verify(scheduledTask).accept(case1);
         verify(scheduledTask).accept(case2);
 
-        verify(scheduledEventTracker).caseFailedEvent(eventConfig, 1L, error1);
-        verify(scheduledEventTracker).caseFailedEvent(eventConfig, 2L, error2);
+        verify(scheduledEventTracker).caseFailedEvent(eventConfig, "1", error1);
+        verify(scheduledEventTracker).caseFailedEvent(eventConfig, "2", error2);
         verifyNoMoreInteractions(scheduledEventTracker);
     }
 
@@ -227,23 +241,23 @@ class ScheduledTaskProcessorTest {
 
         // Fail case 1, succeed case 2, fail case 3
         RuntimeException error1 = new RuntimeException("Error 1");
-        doThrow(error1).when(scheduledTask).accept(argThat(c -> c != null && c.getId().equals(101L)));
-        doNothing().when(scheduledTask).accept(argThat(c -> c != null && c.getId().equals(102L)));
+        doThrow(error1).when(scheduledTask).accept(argThat((CaseDetails c) -> c != null && c.getId().equals(101L)));
+        doNothing().when(scheduledTask).accept(argThat((CaseDetails c) -> c != null && c.getId().equals(102L)));
         RuntimeException error3 = new RuntimeException("Error 3");
-        doThrow(error3).when(scheduledTask).accept(argThat(c -> c != null && c.getId().equals(103L)));
+        doThrow(error3).when(scheduledTask).accept(argThat((CaseDetails c) -> c != null && c.getId().equals(103L)));
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ElasticSearchResult searchResult = new ElasticSearchResult(cases.stream(), 3);
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
+        ScheduledTaskOutcome<Long> outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
 
         assertThat(outcome.abortedEarly()).isFalse();
         assertThat(outcome.succeededCases()).containsExactly(102L);
         assertThat(outcome.failedCases()).containsExactly(101L, 103L);
 
-        verify(scheduledEventTracker).caseFailedEvent(eventConfig, 101L, error1);
-        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, 102L);
-        verify(scheduledEventTracker).caseFailedEvent(eventConfig, 103L, error3);
+        verify(scheduledEventTracker).caseFailedEvent(eventConfig, "101", error1);
+        verify(scheduledEventTracker).caseProcessedEvent(eventConfig, "102");
+        verify(scheduledEventTracker).caseFailedEvent(eventConfig, "103", error3);
     }
 
     @Test
@@ -257,7 +271,7 @@ class ScheduledTaskProcessorTest {
         doThrow(errorWithoutMessage).when(scheduledTask).accept(case1);
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
+        ScheduledTaskOutcome<Long> outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
 
         assertThat(outcome.abortedEarly()).isTrue();
         assertThat(outcome.abortReason()).isEqualTo("RuntimeException");
@@ -282,7 +296,7 @@ class ScheduledTaskProcessorTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ElasticSearchResult searchResult = new ElasticSearchResult(cases.stream(), 3);
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
+        ScheduledTaskOutcome<Long> outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
 
         assertThat(outcome.abortedEarly()).isFalse();
         assertThat(outcome.succeededCases()).containsExactly(3L);
@@ -302,7 +316,7 @@ class ScheduledTaskProcessorTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         ElasticSearchResult searchResult = new ElasticSearchResult(cases.stream(), 2);
 
-        ScheduledTaskOutcome outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
+        ScheduledTaskOutcome<Long> outcome = scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult);
 
         assertThat(outcome.abortedEarly()).isTrue();
         assertThat(outcome.failedCases()).containsExactly(1L);
@@ -314,7 +328,7 @@ class ScheduledTaskProcessorTest {
         verify(scheduledEventTracker, never()).caseFailedEvent(any(), eq(2L), any());
     }
 
-    private static class RecordingScheduledTask implements ScheduledTask {
+    private static class RecordingScheduledTask implements ScheduledTask<CaseDetails, Long> {
 
         private final long maxCasesPerRun;
         private final ScheduledTaskBackPressureConfiguration backPressureConfiguration;
@@ -335,6 +349,11 @@ class ScheduledTaskProcessorTest {
             this.maxCasesPerRun = maxCasesPerRun;
             this.backPressureConfiguration = backPressureConfiguration;
             this.failures = failures;
+        }
+
+        @Override
+        public Long getItemId(CaseDetails caseDetails) {
+            return caseDetails.getId();
         }
 
         @Override
@@ -361,7 +380,7 @@ class ScheduledTaskProcessorTest {
         }
     }
 
-    private static class CapturingScheduledTaskProcessor extends ScheduledTaskProcessor {
+    private static class CapturingScheduledTaskProcessor extends ScheduledTaskProcessor<CaseDetails, Long> {
 
         private final List<Duration> delays = new ArrayList<>();
 
@@ -379,7 +398,7 @@ class ScheduledTaskProcessorTest {
         }
     }
 
-    private static class InterruptingScheduledTaskProcessor extends ScheduledTaskProcessor {
+    private static class InterruptingScheduledTaskProcessor extends ScheduledTaskProcessor<CaseDetails, Long> {
 
         InterruptingScheduledTaskProcessor(ScheduledEventTracker eventTracker) {
             super(eventTracker);

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskProcessorTest.java
@@ -156,6 +156,9 @@ class ScheduledTaskProcessorTest {
         verify(scheduledEventTracker).caseFailedEvent(eventConfig, "1", error);
         verify(scheduledEventTracker).caseProcessedEvent(eventConfig, "2");
         verify(scheduledEventTracker).caseProcessedEvent(eventConfig, "3");
+        verify(scheduledEventTracker).backPressureUpdatedEvent(eventConfig, Duration.ZERO, Duration.ofMillis(10));
+        verify(scheduledEventTracker).backPressureUpdatedEvent(eventConfig, Duration.ofMillis(10), Duration.ofMillis(5));
+        verify(scheduledEventTracker).backPressureUpdatedEvent(eventConfig, Duration.ofMillis(5), Duration.ZERO);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunnerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunnerTest.java
@@ -72,9 +72,10 @@ class ScheduledTaskRunnerTest {
 
     @Test
     void shouldAbort_whenCaseRetrievalFails() {
-        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+        when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
+        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration(SCHEDULER_NAME);
 
-        scheduledTaskRunner.run(eventConfig, null, scheduledTask);
+        scheduledTaskRunner.run(SCHEDULER_NAME, () -> null, scheduledTask);
 
         verify(scheduledEventTracker).jobAbortedEvent(eventConfig, "SearchResult cannot be null");
         verifyNoMoreInteractions(scheduledTask);
@@ -82,10 +83,11 @@ class ScheduledTaskRunnerTest {
 
     @Test
     void shouldHandleZeroCases_whenTotalResultsIsZero() {
-        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+        when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
+        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration(SCHEDULER_NAME);
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.empty(), 0);
 
-        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
+        scheduledTaskRunner.run(SCHEDULER_NAME, () -> searchResult, scheduledTask);
 
         verify(scheduledEventTracker).jobStartedEvent(eventConfig, 0);
         verify(scheduledEventTracker).jobCompletedNoCasesEvent(eventConfig);
@@ -94,7 +96,8 @@ class ScheduledTaskRunnerTest {
 
     @Test
     void shouldHandleCases_whenCaseRetrievalIsSuccessful() {
-        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+        when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
+        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration(SCHEDULER_NAME);
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1), 1);
         ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(List.of(1L), List.of(), false, "", Duration.ZERO);
@@ -102,7 +105,7 @@ class ScheduledTaskRunnerTest {
         when(scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
+        scheduledTaskRunner.run(SCHEDULER_NAME, () -> searchResult, scheduledTask);
 
         verify(scheduledEventTracker).jobStartedEvent(eventConfig, 1);
         verify(scheduledTaskProcessor).performProcessing(eventConfig, scheduledTask, searchResult);
@@ -111,27 +114,29 @@ class ScheduledTaskRunnerTest {
 
     @Test
     void shouldRunProcessor_whenCasesPresent() {
+        when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1), 1);
 
-        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration(SCHEDULER_NAME);
         ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(List.of(1L), List.of(), false, "", Duration.ZERO);
 
         when(scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
+        scheduledTaskRunner.run(SCHEDULER_NAME, () -> searchResult, scheduledTask);
 
         verify(scheduledTaskProcessor).performProcessing(eventConfig, scheduledTask, searchResult);
     }
 
     @Test
     void shouldAbortEarly_whenConsecutiveFailuresThresholdReached() {
+        when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
         CaseDetails case2 = CaseDetailsBuilder.builder().id(2L).build();
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1, case2), 2);
 
-        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration(SCHEDULER_NAME);
         ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(
             List.of(),
             List.of(1L, 2L),
@@ -143,24 +148,25 @@ class ScheduledTaskRunnerTest {
         when(scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
+        scheduledTaskRunner.run(SCHEDULER_NAME, () -> searchResult, scheduledTask);
 
         verify(scheduledEventTracker).jobAbortedEvent(eventConfig, 2, 0, 2, "Error 2", Duration.ofMillis(100));
     }
 
     @Test
     void shouldNotAbortEarly_whenFailuresAreNotConsecutive() {
+        when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
         CaseDetails case2 = CaseDetailsBuilder.builder().id(2L).build();
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1, case2), 2);
 
-        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
+        ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration(SCHEDULER_NAME);
         ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(List.of(1L), List.of(2L), false, "", Duration.ZERO);
 
         when(scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult))
             .thenReturn(outcome);
 
-        scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
+        scheduledTaskRunner.run(SCHEDULER_NAME, () -> searchResult, scheduledTask);
 
         verify(scheduledEventTracker).jobCompletedEvent(eventConfig, 2, 1, 1, Duration.ZERO);
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunnerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/common/ScheduledTaskRunnerTest.java
@@ -9,12 +9,17 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
+import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
@@ -22,17 +27,48 @@ import static org.mockito.Mockito.when;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ScheduledTaskRunnerTest {
 
+    private static final String SCHEDULER_NAME = "JudgmentBuffer";
+
     @Mock
-    private ScheduledTask scheduledTask;
+    private ScheduledTask<CaseDetails, Long> scheduledTask;
 
     @Mock
     private ScheduledEventTracker scheduledEventTracker;
 
     @Mock
-    private ScheduledTaskProcessor scheduledTaskProcessor;
+    private ScheduledTaskProcessor<CaseDetails, Long> scheduledTaskProcessor;
+
+    @Mock
+    private FeatureToggleService featureToggleService;
 
     @InjectMocks
-    private ScheduledTaskRunner scheduledTaskRunner;
+    private ScheduledTaskRunner<CaseDetails, Long> scheduledTaskRunner;
+
+    @Test
+    void shouldRunScheduledTask_whenFeatureToggleIsEnabled() {
+        when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
+        CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
+        ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1), 1);
+        ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(List.of(1L), List.of(), false, "", Duration.ZERO);
+
+        when(scheduledTaskProcessor.performProcessing(any(), eq(scheduledTask), eq(searchResult)))
+            .thenReturn(outcome);
+
+        scheduledTaskRunner.run(SCHEDULER_NAME, () -> searchResult, scheduledTask);
+
+        verify(featureToggleService).isSpringSchedulerEnabled(SCHEDULER_NAME);
+        verify(scheduledEventTracker).jobStartedEvent(any(), eq(1));
+    }
+
+    @Test
+    void shouldNotRunScheduledTask_whenFeatureToggleIsDisabled() {
+        when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(false);
+
+        scheduledTaskRunner.run(SCHEDULER_NAME, () -> null, scheduledTask);
+
+        verify(featureToggleService).isSpringSchedulerEnabled(SCHEDULER_NAME);
+        verifyNoInteractions(scheduledTaskProcessor, scheduledEventTracker, scheduledTask);
+    }
 
     @Test
     void shouldAbort_whenCaseRetrievalFails() {
@@ -61,7 +97,7 @@ class ScheduledTaskRunnerTest {
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
         CaseDetails case1 = CaseDetailsBuilder.builder().id(1L).build();
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1), 1);
-        ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(1L), List.of(), false, "");
+        ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(List.of(1L), List.of(), false, "", Duration.ZERO);
 
         when(scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult))
             .thenReturn(outcome);
@@ -70,7 +106,7 @@ class ScheduledTaskRunnerTest {
 
         verify(scheduledEventTracker).jobStartedEvent(eventConfig, 1);
         verify(scheduledTaskProcessor).performProcessing(eventConfig, scheduledTask, searchResult);
-        verify(scheduledEventTracker).jobCompletedEvent(eventConfig, 1, 1, 0);
+        verify(scheduledEventTracker).jobCompletedEvent(eventConfig, 1, 1, 0, Duration.ZERO);
     }
 
     @Test
@@ -79,7 +115,7 @@ class ScheduledTaskRunnerTest {
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1), 1);
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
-        ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(1L), List.of(), false, "");
+        ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(List.of(1L), List.of(), false, "", Duration.ZERO);
 
         when(scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult))
             .thenReturn(outcome);
@@ -96,14 +132,20 @@ class ScheduledTaskRunnerTest {
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1, case2), 2);
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
-        ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(), List.of(1L, 2L), true, "Error 2");
+        ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(
+            List.of(),
+            List.of(1L, 2L),
+            true,
+            "Error 2",
+            Duration.ofMillis(100)
+        );
 
         when(scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult))
             .thenReturn(outcome);
 
         scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
 
-        verify(scheduledEventTracker).jobAbortedEvent(eventConfig, 2, 0, 2, "Error 2");
+        verify(scheduledEventTracker).jobAbortedEvent(eventConfig, 2, 0, 2, "Error 2", Duration.ofMillis(100));
     }
 
     @Test
@@ -113,13 +155,13 @@ class ScheduledTaskRunnerTest {
         ElasticSearchResult searchResult = new ElasticSearchResult(Stream.of(case1, case2), 2);
 
         ScheduledTaskEventConfiguration eventConfig = new ScheduledTaskEventConfiguration("JudgmentBuffer");
-        ScheduledTaskOutcome outcome = new ScheduledTaskOutcome(List.of(1L), List.of(2L), false, "");
+        ScheduledTaskOutcome<Long> outcome = new ScheduledTaskOutcome<>(List.of(1L), List.of(2L), false, "", Duration.ZERO);
 
         when(scheduledTaskProcessor.performProcessing(eventConfig, scheduledTask, searchResult))
             .thenReturn(outcome);
 
         scheduledTaskRunner.run(eventConfig, searchResult, scheduledTask);
 
-        verify(scheduledEventTracker).jobCompletedEvent(eventConfig, 2, 1, 1);
+        verify(scheduledEventTracker).jobCompletedEvent(eventConfig, 2, 1, 1, Duration.ZERO);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineSchedulerTest.java
@@ -5,24 +5,24 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskEventConfiguration;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.search.DefendantResponseDeadlineCheckSearchService;
-import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
-import java.util.stream.Stream;
-
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DefendantResponseDeadlineSchedulerTest {
+
+    private static final String SCHEDULER_NAME = "DefendantResponseDeadline";
 
     @Mock
     private DefendantResponseDeadlineCheckSearchService searchService;
 
     @Mock
-    private ScheduledTaskRunner scheduledTaskRunner;
+    private ScheduledTaskRunner<CaseDetails, Long> scheduledTaskRunner;
 
     @Mock
     private DefendantResponseDeadlineTask defendantResponseDeadlineTask;
@@ -31,18 +31,13 @@ class DefendantResponseDeadlineSchedulerTest {
     private DefendantResponseDeadlineScheduler scheduler;
 
     @Test
-    void shouldRunTaskRunner_whenDeadlineCheckIsCalled() {
-        ScheduledTaskEventConfiguration expectedConfig = new ScheduledTaskEventConfiguration(scheduler.getName());
-
-        ElasticSearchResult elasticSearchResult = new ElasticSearchResult(Stream.empty(), 0);
-        when(searchService.getElasticSearchResult()).thenReturn(elasticSearchResult);
-
+    void shouldRunScheduledTaskRunner() {
         scheduler.runScheduledTask();
 
         verify(scheduledTaskRunner).run(
-            expectedConfig,
-            elasticSearchResult,
-            defendantResponseDeadlineTask
+            eq(SCHEDULER_NAME),
+            any(),
+            eq(defendantResponseDeadlineTask)
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineTaskTest.java
@@ -1,0 +1,51 @@
+package uk.gov.hmcts.reform.civil.scheduler.defendantresponse;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
+import uk.gov.hmcts.reform.civil.scheduler.common.DefaultBackPressureConfiguration;
+import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskBackPressureConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DefendantResponseDeadlineTaskTest {
+
+    private static final long CASE_ID = 123L;
+
+    @Mock
+    private DefaultBackPressureConfiguration defaultBackPressureConfiguration;
+    @Mock
+    private ScheduledTaskBackPressureConfiguration backPressureConfiguration;
+
+    private DefendantResponseDeadlineTask task;
+    private CaseDetails caseDetails;
+
+    @BeforeEach
+    void setUp() {
+        task = new DefendantResponseDeadlineTask(defaultBackPressureConfiguration);
+        caseDetails = CaseDetails.builder().id(CASE_ID).build();
+    }
+
+    @Test
+    void shouldReturnCaseId() {
+        assertThat(task.getItemId(caseDetails)).isEqualTo(CASE_ID);
+    }
+
+    @Test
+    void shouldUseDefaultBackPressureConfiguration() {
+        when(defaultBackPressureConfiguration.getDefaultBackPressure()).thenReturn(backPressureConfiguration);
+
+        assertThat(task.backPressureConfiguration()).isSameAs(backPressureConfiguration);
+    }
+
+    @Test
+    void shouldAcceptCaseDetails() {
+        assertThatCode(() -> task.accept(caseDetails)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduledTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduledTaskTest.java
@@ -15,12 +15,15 @@ import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class JudgementBufferScheduledTaskTest {
 
     @Mock
     private CoreCaseDataService coreCaseDataService;
+    @Mock
+    private DefaultBackPressureConfiguration defaultBackPressureConfiguration;
 
     @InjectMocks
     private JudgementBufferScheduledTask task;
@@ -46,8 +49,7 @@ class JudgementBufferScheduledTaskTest {
             Duration.ofSeconds(5)
         );
 
-        DefaultBackPressureConfiguration configuration = new DefaultBackPressureConfiguration();
-        configuration.setDefaultBackPressure(backPressure);
+        when(defaultBackPressureConfiguration.getDefaultBackPressure()).thenReturn(backPressure);
 
         ScheduledTaskBackPressureConfiguration result = task.backPressureConfiguration();
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferSchedulerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferSchedulerTest.java
@@ -6,14 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskEventConfiguration;
+import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.civil.scheduler.common.ScheduledTaskRunner;
 import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import uk.gov.hmcts.reform.civil.service.search.judgementbuffer.JudgementBufferExpiredSearchService;
-import uk.gov.hmcts.reform.civil.service.search.common.ElasticSearchResult;
 
-import java.util.stream.Stream;
-
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -26,7 +25,7 @@ class JudgementBufferSchedulerTest {
     private JudgementBufferExpiredSearchService searchService;
 
     @Mock
-    private ScheduledTaskRunner scheduledTaskRunner;
+    private ScheduledTaskRunner<CaseDetails, Long> scheduledTaskRunner;
 
     @Mock
     private JudgementBufferScheduledTask judgementBufferScheduledTask;
@@ -41,36 +40,21 @@ class JudgementBufferSchedulerTest {
     class Execute {
 
         @Test
-        void shouldRunTaskRunner_whenSchedulerIsEnabledAndFeatureToggleIsEnabled() {
+        void shouldRunScheduledTaskRunner() {
             when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(true);
-            when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(true);
-
-            ScheduledTaskEventConfiguration expectedConfig = new ScheduledTaskEventConfiguration(scheduler.getName());
-            ElasticSearchResult elasticSearchResult = new ElasticSearchResult(Stream.empty(), 0);
-            when(searchService.getElasticSearchResult()).thenReturn(elasticSearchResult);
 
             scheduler.runScheduledTask();
 
             verify(scheduledTaskRunner).run(
-                expectedConfig,
-                elasticSearchResult,
-                judgementBufferScheduledTask
+                eq(SCHEDULER_NAME),
+                any(),
+                eq(judgementBufferScheduledTask)
             );
         }
 
         @Test
-        void shouldNotRunTaskRunner_whenSchedulerIsEnabledAndFeatureToggleIsDisabled() {
+        void shouldNotRunScheduledTaskRunner_whenJudgmentBufferIsDisabled() {
             when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(false);
-
-            scheduler.runScheduledTask();
-
-            verifyNoInteractions(scheduledTaskRunner);
-        }
-
-        @Test
-        void shouldNotRunTaskRunner_whenSpringSchedulerIsDisabled() {
-            when(featureToggleService.isJudgmentBufferEnabled()).thenReturn(true);
-            when(featureToggleService.isSpringSchedulerEnabled(SCHEDULER_NAME)).thenReturn(false);
 
             scheduler.runScheduledTask();
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-5652


### Change description ###
This PR introduces improvements to the common scheduler framework. Key focuses include improving type safety through generics, enhancing back pressure observability, and refactoring core components for better maintainability and performance.

**Key Changes**

#### 1. Framework Refactoring (Generics & Type Safety)
- **Generics Support**: Refactored `ScheduledTask`, `ScheduledTaskProcessor`, `ScheduledTaskRunner`, and `TaskResult` to use generics (`<T, I>`). This ensures type safety for both the items being processed and their identifiers, removing the need for manual casting.
- **Stateless Singleton Runner**: Updated `ScheduledTaskRunner` to singleton scope. The component is functionally stateless, and this change reduces bean creation overhead while maintaining thread safety.
- **Improved Task Result Abstraction**: Introduced `TaskResult` and `ListTaskResult` to provide a consistent interface for search results across different scheduler implementations.

#### 2. Backpressure & Observability
- **Cumulative Delay Tracking**: Enhanced `ScheduledTaskOutcome` and `ScheduledTaskProcessor` to track the total time spent in backpressure delays during a job run.
- **Telemetry Enhancements**: Updated `ScheduledEventTracker` to report `cumulativeDelay` in both `jobCompleted` and `jobAborted` events, providing better visibility into performance bottlenecks in production.
- **Backpressure Logic Refinement**: Refactored `ScheduledTaskBackPressure` to use idiomatic `Duration` comparisons and ensured a safe recovery floor by capping the minimum delay at the `initialDelay` configuration.

#### 3. Code Quality Improvements
- **Atomic State Management**: Updated `ScheduledTaskProcessor` to use `AtomicInteger`, `AtomicLong`, and `AtomicReference` for mutable state within lambda expressions, replacing the previous single-element array pattern.
- **Optimized Date Handling**: Removed redundant `ZonedDateTime` string-to-object conversions in `JudgementBufferExpiredQueryProvider` to improve efficiency.
- **Cleanup**: Aligned test configuration naming in `JudgementBufferSchedulerIT` and updated documentation in the `README.md` to reflect the framework changes.

#### 4. Testing
- Added `ScheduledTaskBackPressureTest` to verify backpressure behavior under failure and success conditions.
- Updated existing tests (`ScheduledTaskProcessorTest`, `ScheduledTaskRunnerTest`, `ScheduledEventTrackerTest`) to cover the new observability fields and generic types.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
