### PR TITLE
DTSCCI-5479 Support GA dashboard retrigger migrations

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DashboardNotificationTaskCaseReference.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DashboardNotificationTaskCaseReference.java
@@ -22,4 +22,7 @@ public class DashboardNotificationTaskCaseReference extends CaseReference {
 
     @JsonProperty
     private String dashboardProcessInstanceId;
+
+    @JsonProperty
+    private String dashboardCaseType;
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/AsyncCaseMigrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/AsyncCaseMigrationService.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReference;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
@@ -72,6 +73,8 @@ public class AsyncCaseMigrationService {
                     startEventResponse = coreCaseDataService.startGeneralApplicationUpdate(caseReference.getCaseReference(), CaseEvent.UPDATE_CASE_DATA);
                     CaseDetails caseDetails = startEventResponse.getCaseDetails();
                     caseData = caseDetailsConverter.toGACaseData(caseDetails);
+                    GeneralApplicationCaseData gaCaseData = caseDetailsConverter.toGeneralApplicationCaseData(caseDetails);
+                    caseData = task.migrateGeneralApplicationCaseData(caseData, gaCaseData, caseReference);
                 } else {
                     startEventResponse = coreCaseDataService.startUpdate(
                         caseReference.getCaseReference(),
@@ -79,8 +82,8 @@ public class AsyncCaseMigrationService {
                     );
                     CaseDetails caseDetails = startEventResponse.getCaseDetails();
                     caseData = caseDetailsConverter.toCaseData(caseDetails);
+                    caseData = task.migrateCaseData(caseData, caseReference);
                 }
-                caseData = task.migrateCaseData(caseData, caseReference);
                 Optional<String> updatedState = task.getUpdatedState(state);
                 if (updatedState.isPresent()) {
                     String newState = updatedState.get();

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandler.java
@@ -38,6 +38,7 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
     private static final String DASHBOARD_TASK_ID = "dashboardTaskId";
     private static final String DASHBOARD_PROCESS_INSTANCE_ID = "dashboardProcessInstanceId";
     private static final String DASHBOARD_PROCESS_INSTANCE_IDS = "dashboardProcessInstanceIds";
+    private static final String DASHBOARD_CASE_TYPE = "dashboardCaseType";
     private static final String NOTIFICATION_CAMUNDA_PROCESS_IDENTIFIER = "notificationCamundaProcessIdentifier";
     private static final String CASE_NOTE_ELEMENT_ID = "caseNoteElementId";
     private static final String NOTIFY_EVENT_ID = "notifyEventId";
@@ -117,6 +118,7 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
             externalTask.getVariable(DASHBOARD_TASK_ID),
             externalTask.getVariable(DASHBOARD_PROCESS_INSTANCE_ID),
             externalTask.getVariable(DASHBOARD_PROCESS_INSTANCE_IDS),
+            externalTask.getVariable(DASHBOARD_CASE_TYPE),
             externalTask.getVariable(NOTIFICATION_CAMUNDA_PROCESS_IDENTIFIER),
             externalTask.getVariable(CASE_NOTE_ELEMENT_ID),
             externalTask.getVariable(NOTIFY_EVENT_ID)
@@ -202,7 +204,8 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
             return type.cast(buildDashboardNotificationTaskCaseReference(
                 caseId,
                 variables.dashboardTaskId(),
-                variables.dashboardProcessInstanceId()
+                variables.dashboardProcessInstanceId(),
+                variables.dashboardCaseType()
             ));
         }
         if (variables.camundaProcessIdentifier() != null) {
@@ -220,12 +223,14 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
     private DashboardNotificationTaskCaseReference buildDashboardNotificationTaskCaseReference(
         String caseId,
         String dashboardTaskId,
-        String dashboardProcessInstanceId
+        String dashboardProcessInstanceId,
+        String dashboardCaseType
     ) {
         DashboardNotificationTaskCaseReference caseReference = new DashboardNotificationTaskCaseReference();
         caseReference.setCaseReference(caseId);
         caseReference.setDashboardTaskId(dashboardTaskId);
         caseReference.setDashboardProcessInstanceId(dashboardProcessInstanceId);
+        caseReference.setDashboardCaseType(dashboardCaseType);
         return caseReference;
     }
 
@@ -287,6 +292,7 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
         String dashboardTaskId,
         String dashboardProcessInstanceId,
         String dashboardProcessInstanceIds,
+        String dashboardCaseType,
         String camundaProcessIdentifier,
         String caseNoteElementId,
         String notifyEventId
@@ -303,6 +309,7 @@ public class MigrateCasesEventHandler extends BaseExternalTaskHandler {
                 dashboardTaskId,
                 processInstanceId,
                 dashboardProcessInstanceIds,
+                dashboardCaseType,
                 camundaProcessIdentifier,
                 caseNoteElementId,
                 notifyEventId

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrationTask.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.reform.civil.handler.migration;
 
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReference;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
+import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 
 import java.util.Collections;
@@ -23,6 +24,14 @@ public abstract class MigrationTask<T extends CaseReference> {
     protected abstract String getEventDescription();
 
     protected abstract CaseData migrateCaseData(CaseData caseData, T caseReference);
+
+    protected CaseData migrateGeneralApplicationCaseData(
+        CaseData caseData,
+        GeneralApplicationCaseData gaCaseData,
+        T caseReference
+    ) {
+        return migrateCaseData(caseData, caseReference);
+    }
 
     protected List<String> getFieldsToNullify() {
         return Collections.emptyList();

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTask.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardNotificationRegistry;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardTaskContext;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardWorkflowTask;
+import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.UserService;
@@ -77,7 +78,8 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
         dashboardCaseData.setBusinessProcess(businessProcessForDashboardTask(caseData, dashboardReference));
 
         String dashboardTaskId = dashboardReference.getDashboardTaskId();
-        List<DashboardWorkflowTask> workflows = registry.workflowsFor(dashboardTaskId, DashboardCaseType.CIVIL);
+        DashboardCaseType dashboardCaseType = dashboardCaseType(dashboardReference);
+        List<DashboardWorkflowTask> workflows = registry.workflowsFor(dashboardTaskId, dashboardCaseType);
 
         if (workflows.isEmpty()) {
             throw new IllegalArgumentException("No dashboard notification handlers registered for: " + dashboardTaskId);
@@ -86,7 +88,8 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
         String authToken = userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
         DashboardTaskContext context = DashboardTaskContext.from(new CallbackParams()
             .caseData(dashboardCaseData)
-            .isCivilCaseType(true)
+            .isCivilCaseType(dashboardCaseType == DashboardCaseType.CIVIL)
+            .isGeneralApplicationCaseType(dashboardCaseType == DashboardCaseType.GENERAL_APPLICATION)
             .params(Map.of(BEARER_TOKEN, authToken)));
 
         log.info("Retriggering dashboard task {} for case {}", dashboardTaskId, dashboardReference.getCaseReference());
@@ -98,12 +101,61 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
         return caseData;
     }
 
+    @Override
+    protected CaseData migrateGeneralApplicationCaseData(
+        CaseData caseData,
+        GeneralApplicationCaseData gaCaseData,
+        DashboardNotificationTaskCaseReference dashboardReference
+    ) {
+        validateDashboardReference(dashboardReference);
+
+        GeneralApplicationCaseData dashboardCaseData = gaCaseData.copy();
+        dashboardCaseData.businessProcess(businessProcessForDashboardTask(gaCaseData.getBusinessProcess(), dashboardReference));
+
+        String dashboardTaskId = dashboardReference.getDashboardTaskId();
+        List<DashboardWorkflowTask> workflows = registry.workflowsFor(dashboardTaskId, DashboardCaseType.GENERAL_APPLICATION);
+
+        if (workflows.isEmpty()) {
+            throw new IllegalArgumentException("No dashboard notification handlers registered for: " + dashboardTaskId);
+        }
+
+        String authToken = userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+        DashboardTaskContext context = DashboardTaskContext.from(new CallbackParams()
+            .caseData(dashboardCaseData)
+            .isCivilCaseType(false)
+            .isGeneralApplicationCaseType(true)
+            .params(Map.of(BEARER_TOKEN, authToken)));
+
+        log.info("Retriggering GA dashboard task {} for case {}", dashboardTaskId, dashboardReference.getCaseReference());
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> {
+            entityManager.joinTransaction();
+            workflows.forEach(task -> task.execute(context));
+            entityManager.flush();
+        });
+        return caseData;
+    }
+
+    private void validateDashboardReference(DashboardNotificationTaskCaseReference dashboardReference) {
+        if (dashboardReference == null
+            || StringUtils.isBlank(dashboardReference.getCaseReference())
+            || StringUtils.isBlank(dashboardReference.getDashboardTaskId())) {
+            throw new IllegalArgumentException("Case reference and dashboardTaskId must not be blank");
+        }
+    }
+
     private BusinessProcess businessProcessForDashboardTask(
         CaseData caseData,
         DashboardNotificationTaskCaseReference caseReference
     ) {
-        BusinessProcess businessProcess = caseData.getBusinessProcess() != null
-            ? caseData.getBusinessProcess().copy()
+        return businessProcessForDashboardTask(caseData.getBusinessProcess(), caseReference);
+    }
+
+    private BusinessProcess businessProcessForDashboardTask(
+        BusinessProcess existingBusinessProcess,
+        DashboardNotificationTaskCaseReference caseReference
+    ) {
+        BusinessProcess businessProcess = existingBusinessProcess != null
+            ? existingBusinessProcess.copy()
             : new BusinessProcess();
 
         businessProcess.updateActivityId(caseReference.getDashboardTaskId());
@@ -112,5 +164,12 @@ public class RetriggerDashboardNotificationTask extends MigrationTask<DashboardN
         }
 
         return businessProcess;
+    }
+
+    private DashboardCaseType dashboardCaseType(DashboardNotificationTaskCaseReference dashboardReference) {
+        if (StringUtils.isBlank(dashboardReference.getDashboardCaseType())) {
+            return DashboardCaseType.CIVIL;
+        }
+        return DashboardCaseType.valueOf(dashboardReference.getDashboardCaseType().trim());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/AsyncCaseMigrationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/AsyncCaseMigrationServiceTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReference;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReferenceCsvLoader;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
@@ -79,11 +80,18 @@ class AsyncCaseMigrationServiceTest {
         when(startEventResponse.getCaseDetails()).thenReturn(caseDetails);
 
         CaseData caseData = mock(CaseData.class);
+        GeneralApplicationCaseData gaCaseData = mock(GeneralApplicationCaseData.class);
+        when(caseData.toMap(ArgumentMatchers.any())).thenReturn(Map.of());
 
-        List<CaseReference> mockReferences = List.of(new CaseReference("12345"), new CaseReference("67890"));
+        final List<CaseReference> mockReferences = List.of(new CaseReference("12345"), new CaseReference("67890"));
 
         when(caseDetailsConverter.toGACaseData(startEventResponse.getCaseDetails())).thenReturn(caseData);
-        when(migrationTask.migrateCaseData(ArgumentMatchers.any(CaseData.class), ArgumentMatchers.any(CaseReference.class))).thenReturn(caseData);
+        when(caseDetailsConverter.toGeneralApplicationCaseData(startEventResponse.getCaseDetails())).thenReturn(gaCaseData);
+        when(migrationTask.migrateGeneralApplicationCaseData(
+            ArgumentMatchers.any(CaseData.class),
+            ArgumentMatchers.any(GeneralApplicationCaseData.class),
+            ArgumentMatchers.any(CaseReference.class)
+        )).thenReturn(caseData);
 
         asyncCaseMigrationService.migrateCasesAsync(migrationTask, mockReferences, null, true);
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/MigrateCasesEventHandlerTest.java
@@ -138,6 +138,7 @@ class MigrateCasesEventHandlerTest {
         when(externalTask.getVariable("dashboardTaskId")).thenReturn("GenerateDashboardNotificationsHearingScheduledHmc");
         when(externalTask.getVariable("dashboardProcessInstanceId")).thenReturn("process-123");
         when(externalTask.getVariable("dashboardProcessInstanceIds")).thenReturn(null);
+        when(externalTask.getVariable("dashboardCaseType")).thenReturn("GENERAL_APPLICATION");
         when(externalTask.getVariable("notificationCamundaProcessIdentifier")).thenReturn(null);
         when(externalTask.getVariable("caseNoteElementId")).thenReturn(null);
         when(externalTask.getVariable("notifyEventId")).thenReturn(null);
@@ -164,6 +165,7 @@ class MigrateCasesEventHandlerTest {
         assertEquals("456", references.get(1).getCaseReference());
         assertEquals("GenerateDashboardNotificationsHearingScheduledHmc", references.get(0).getDashboardTaskId());
         assertEquals("process-123", references.get(0).getDashboardProcessInstanceId());
+        assertEquals("GENERAL_APPLICATION", references.get(0).getDashboardCaseType());
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/RetriggerDashboardNotificationTaskTest.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.support.SimpleTransactionStatus;
 import uk.gov.hmcts.reform.civil.bulkupdate.csv.DashboardNotificationTaskCaseReference;
 import uk.gov.hmcts.reform.civil.callback.CallbackParams;
 import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardCaseType;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardNotificationRegistry;
 import uk.gov.hmcts.reform.civil.handler.callback.camunda.dashboardnotifications.DashboardTaskContext;
@@ -93,6 +94,33 @@ class RetriggerDashboardNotificationTaskTest {
         verify(entityManager).joinTransaction();
         verify(entityManager).flush();
         verify(transactionManager).commit(any());
+    }
+
+    @Test
+    void migrateGeneralApplicationCaseDataShouldRunGeneralApplicationDashboardWorkflow() {
+        AtomicReference<DashboardTaskContext> contextReference = new AtomicReference<>();
+        DashboardWorkflowTask workflow = new DashboardWorkflowTask() {
+            @Override
+            public void execute(DashboardTaskContext context) {
+                contextReference.set(context);
+            }
+        };
+
+        when(registry.workflowsFor(DASHBOARD_TASK_ID, DashboardCaseType.GENERAL_APPLICATION)).thenReturn(List.of(workflow));
+        when(userService.getAccessToken("system-user", "password")).thenReturn(AUTH_TOKEN);
+
+        CaseData caseData = CaseData.builder().build();
+        GeneralApplicationCaseData gaCaseData = new GeneralApplicationCaseData();
+        gaCaseData.setCcdCaseReference(Long.valueOf(CASE_REFERENCE));
+        DashboardNotificationTaskCaseReference caseReference = caseReference();
+        caseReference.setDashboardCaseType(DashboardCaseType.GENERAL_APPLICATION.name());
+
+        task.migrateGeneralApplicationCaseData(caseData, gaCaseData, caseReference);
+
+        verify(registry).workflowsFor(DASHBOARD_TASK_ID, DashboardCaseType.GENERAL_APPLICATION);
+        assertEquals(DashboardCaseType.GENERAL_APPLICATION, contextReference.get().caseType());
+        assertEquals(Long.valueOf(CASE_REFERENCE), contextReference.get().generalApplicationCaseData().getCcdCaseReference());
+        assertEquals(DASHBOARD_TASK_ID, contextReference.get().generalApplicationCaseData().getBusinessProcess().getActivityId());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add dashboardCaseType support to dashboard notification migration references
- route dashboard retriggers to the GA dashboard workflow registry when requested
- pass full GeneralApplicationCaseData into GA dashboard workflow tasks during migration

## Testing
- ./gradlew test --tests uk.gov.hmcts.reform.civil.handler.migration.RetriggerDashboardNotificationTaskTest --tests uk.gov.hmcts.reform.civil.handler.migration.MigrateCasesEventHandlerTest
- ./gradlew compileJava checkstyleMain
- ./gradlew checkstyleTest