### PR TITLE
DTSCCI-5814 CUI GA submit can pass invalid application type to CCD causing 500

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/cases/CasesControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/cases/CasesControllerTest.java
@@ -13,6 +13,7 @@ import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.BaseIntegrationTest;
 import uk.gov.hmcts.reform.civil.exceptions.CaseDataInvalidException;
 import uk.gov.hmcts.reform.civil.exceptions.CaseNotFoundException;
+import uk.gov.hmcts.reform.civil.exceptions.InvalidGeneralApplicationTypeException;
 import uk.gov.hmcts.reform.civil.exceptions.UserNotFoundOnCaseException;
 import uk.gov.hmcts.reform.civil.ga.service.GaCoreCaseDataService;
 import uk.gov.hmcts.reform.civil.ga.service.events.GaCaseEventService;
@@ -43,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
@@ -232,6 +234,24 @@ public class CasesControllerTest extends BaseIntegrationTest {
             "123"
         ).andExpect(content().json(toJson(expectedCaseDetails)))
             .andExpect(status().isOk());
+    }
+
+    @Test
+    @SneakyThrows
+    void shouldReturnBadRequestWhenGeneralApplicationTypePayloadIsInvalid() {
+        when(caseEventService.submitEvent(any()))
+            .thenThrow(new InvalidGeneralApplicationTypeException(1, Set.of("UI_ONLY_OTHER_OPTION")));
+
+        doPost(
+            BEARER_TOKEN,
+            new EventDto()
+                .setEvent(CaseEvent.INITIATE_GENERAL_APPLICATION)
+                .setCaseDataUpdate(Map.of("generalAppType", Map.of("types", List.of("OTHER_OPTION")))),
+            SUBMIT_EVENT_URL,
+            "123",
+            "123"
+        ).andExpect(content().string("Invalid general application type"))
+            .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/reform/civil/advice/ControllerExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/advice/ControllerExceptionHandler.java
@@ -17,6 +17,7 @@ import org.springframework.web.context.request.WebRequest;
 import uk.gov.hmcts.reform.civil.documentmanagement.DocumentUploadException;
 import uk.gov.hmcts.reform.civil.exceptions.CaseDataInvalidException;
 import uk.gov.hmcts.reform.civil.exceptions.CaseNotFoundException;
+import uk.gov.hmcts.reform.civil.exceptions.InvalidGeneralApplicationTypeException;
 import uk.gov.hmcts.reform.civil.exceptions.MissingFieldsUpdatedException;
 import uk.gov.hmcts.reform.civil.exceptions.UserNotFoundOnCaseException;
 import uk.gov.hmcts.reform.civil.service.pininpost.exception.PinNotMatchException;
@@ -116,6 +117,22 @@ public class ControllerExceptionHandler extends ResponseEntityExceptionHandler {
             new HttpHeaders(),
             HttpStatus.UNPROCESSABLE_ENTITY
         );
+    }
+
+    @ExceptionHandler(InvalidGeneralApplicationTypeException.class)
+    public ResponseEntity<Object> invalidGeneralApplicationTypeException(
+        InvalidGeneralApplicationTypeException exception,
+        ContentCachingRequestWrapper contentCachingRequestWrapper) {
+        String errorMessage = "Invalid general application type payload for field %s with invalid count %s "
+            + "and reasons %s for case %s run by user %s";
+        log.error(errorMessage.formatted(
+            InvalidGeneralApplicationTypeException.FIELD_PATH,
+            exception.getInvalidValueCount(),
+            exception.getReasonCategories(),
+            getCaseId(contentCachingRequestWrapper),
+            getUserId(contentCachingRequestWrapper)
+        ));
+        return new ResponseEntity<>("Invalid general application type", new HttpHeaders(), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(UserNotFoundOnCaseException.class)

--- a/src/main/java/uk/gov/hmcts/reform/civil/exceptions/InvalidGeneralApplicationTypeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/exceptions/InvalidGeneralApplicationTypeException.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.civil.exceptions;
+
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+public class InvalidGeneralApplicationTypeException extends RuntimeException {
+
+    public static final String FIELD_PATH = "generalAppType.types";
+    private static final String ERROR_MESSAGE = "Invalid general application type";
+
+    private final int invalidValueCount;
+    private final Set<String> reasonCategories;
+
+    public InvalidGeneralApplicationTypeException(int invalidValueCount, Set<String> reasonCategories) {
+        super(ERROR_MESSAGE);
+        this.invalidValueCount = invalidValueCount;
+        this.reasonCategories = Set.copyOf(reasonCategories);
+    }
+
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/events/CaseEventService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/events/CaseEventService.java
@@ -10,13 +10,16 @@ import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.exceptions.InvalidGeneralApplicationTypeException;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
 import uk.gov.hmcts.reform.civil.model.caseflags.Flags;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import static uk.gov.hmcts.reform.civil.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.civil.CaseDefinitionConstants.JURISDICTION;
@@ -27,6 +30,11 @@ import static uk.gov.hmcts.reform.civil.utils.CaseDataContentConverter.caseDataC
 @Slf4j
 @SuppressWarnings("unchecked")
 public class CaseEventService {
+
+    private static final Set<CaseEvent> GENERAL_APPLICATION_CREATION_EVENTS = EnumSet.of(
+        CaseEvent.INITIATE_GENERAL_APPLICATION,
+        CaseEvent.INITIATE_GENERAL_APPLICATION_COSC
+    );
 
     private final CoreCaseDataApi coreCaseDataApi;
     private final AuthTokenGenerator authTokenGenerator;
@@ -58,6 +66,7 @@ public class CaseEventService {
     }
 
     public CaseDetails submitEventForClaim(EventSubmissionParams params, boolean includeEventSummary) {
+        validateGeneralApplicationSubmit(params);
         StartEventResponse eventResponse = startEvent(
             params.getAuthorisation(),
             params.getUserId(),
@@ -116,5 +125,25 @@ public class CaseEventService {
             return submitEventForNewClaim(params);
         }
         return submitEventForClaim(params, false);
+    }
+
+    private void validateGeneralApplicationSubmit(EventSubmissionParams params) {
+        if (!GENERAL_APPLICATION_CREATION_EVENTS.contains(params.getEvent())) {
+            return;
+        }
+
+        try {
+            GeneralApplicationTypeValidator.validate(params.getUpdates());
+        } catch (InvalidGeneralApplicationTypeException exception) {
+            log.warn(
+                "Rejected GA submit payload for case {}, event {}, field {}, invalidCount={}, reasons={}",
+                params.getCaseId(),
+                params.getEvent(),
+                InvalidGeneralApplicationTypeException.FIELD_PATH,
+                exception.getInvalidValueCount(),
+                exception.getReasonCategories()
+            );
+            throw exception;
+        }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/events/GeneralApplicationTypeFieldValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/events/GeneralApplicationTypeFieldValidator.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.reform.civil.service.citizen.events;
+
+import uk.gov.hmcts.reform.civil.exceptions.InvalidGeneralApplicationTypeException;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+record GeneralApplicationTypeFieldValidator(
+    Set<String> allowedTypeCodes,
+    Set<String> unsupportedTypeCodes,
+    Map<String, String> invalidCodeReasons
+) {
+
+    private static final String TYPES = "types";
+
+    private static final String NULL_VALUE = "NULL_VALUE";
+    private static final String NON_STRING_VALUE = "NON_STRING_VALUE";
+    private static final String BLANK_VALUE = "BLANK_VALUE";
+    private static final String CUI_UNSUPPORTED_TYPE = "CUI_UNSUPPORTED_TYPE";
+    private static final String UNKNOWN_CODE = "UNKNOWN_CODE";
+
+    GeneralApplicationTypeFieldValidator(
+            Set<String> allowedTypeCodes,
+            Set<String> unsupportedTypeCodes,
+            Map<String, String> invalidCodeReasons
+    ) {
+        this.allowedTypeCodes = Set.copyOf(allowedTypeCodes);
+        this.unsupportedTypeCodes = Set.copyOf(unsupportedTypeCodes);
+        this.invalidCodeReasons = Map.copyOf(invalidCodeReasons);
+    }
+
+    void validate(Object fieldValue) {
+        InvalidTypeValues invalidTypeValues = invalidTypeValues(typeValues(fieldValue));
+        if (invalidTypeValues.hasInvalidValues()) {
+            throw invalid(invalidTypeValues.invalidValueCount(), invalidTypeValues.reasons());
+        }
+    }
+
+    private Collection<?> typeValues(Object fieldValue) {
+        Collection<?> typeValues = typeValuesFrom(typeFieldObject(fieldValue));
+        requireNonEmpty(typeValues);
+        return typeValues;
+    }
+
+    private Map<?, ?> typeFieldObject(Object fieldValue) {
+        if (!(fieldValue instanceof Map<?, ?> fieldValueMap)) {
+            throw invalid("GENERAL_APP_TYPE_NOT_OBJECT");
+        }
+        return fieldValueMap;
+    }
+
+    private Collection<?> typeValuesFrom(Map<?, ?> fieldValueMap) {
+        Object types = fieldValueMap.get(TYPES);
+        if (!(types instanceof Collection<?> typeValues)) {
+            throw invalid(typeValuesError(types));
+        }
+        return typeValues;
+    }
+
+    private String typeValuesError(Object types) {
+        return types == null ? "MISSING_TYPES" : "TYPES_NOT_ARRAY";
+    }
+
+    private void requireNonEmpty(Collection<?> typeValues) {
+        if (typeValues.isEmpty()) {
+            throw invalid("EMPTY_TYPES");
+        }
+    }
+
+    private InvalidTypeValues invalidTypeValues(Collection<?> typeValues) {
+        Set<String> reasons = new LinkedHashSet<>();
+        int invalidValueCount = 0;
+        for (Object typeValue : typeValues) {
+            String reason = invalidReason(typeValue);
+            if (reason != null) {
+                invalidValueCount++;
+                reasons.add(reason);
+            }
+        }
+        return new InvalidTypeValues(invalidValueCount, reasons);
+    }
+
+    private String invalidReason(Object typeValue) {
+        return typeValue instanceof String typeCode ? invalidTypeCodeReason(typeCode) : nonStringReason(typeValue);
+    }
+
+    private String nonStringReason(Object typeValue) {
+        return typeValue == null ? NULL_VALUE : NON_STRING_VALUE;
+    }
+
+    private String invalidTypeCodeReason(String typeCode) {
+        String fixedReason = fixedInvalidTypeCodeReason(typeCode);
+        return fixedReason != null ? fixedReason : policyInvalidTypeCodeReason(typeCode);
+    }
+
+    private String fixedInvalidTypeCodeReason(String typeCode) {
+        if (typeCode.isBlank()) {
+            return BLANK_VALUE;
+        }
+
+        return invalidCodeReasons.get(typeCode);
+    }
+
+    private String policyInvalidTypeCodeReason(String typeCode) {
+        if (unsupportedTypeCodes.contains(typeCode)) {
+            return CUI_UNSUPPORTED_TYPE;
+        }
+
+        if (!allowedTypeCodes.contains(typeCode)) {
+            return UNKNOWN_CODE;
+        }
+
+        return null;
+    }
+
+    private static InvalidGeneralApplicationTypeException invalid(String reason) {
+        return invalid(0, Set.of(reason));
+    }
+
+    private static InvalidGeneralApplicationTypeException invalid(int invalidValueCount, Set<String> reasons) {
+        return new InvalidGeneralApplicationTypeException(invalidValueCount, reasons);
+    }
+
+    private record InvalidTypeValues(int invalidValueCount, Set<String> reasons) {
+
+        private boolean hasInvalidValues() {
+            return invalidValueCount > 0;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/events/GeneralApplicationTypeValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/events/GeneralApplicationTypeValidator.java
@@ -1,0 +1,106 @@
+package uk.gov.hmcts.reform.civil.service.citizen.events;
+
+import uk.gov.hmcts.reform.civil.enums.dq.GeneralApplicationTypes;
+import uk.gov.hmcts.reform.civil.enums.dq.GeneralApplicationTypesLR;
+import uk.gov.hmcts.reform.civil.exceptions.InvalidGeneralApplicationTypeException;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+final class GeneralApplicationTypeValidator {
+
+    private static final String GENERAL_APP_TYPE = "generalAppType";
+    private static final String GENERAL_APP_TYPE_LR = "generalAppTypeLR";
+
+    private static final String OTHER_OPTION = "OTHER_OPTION";
+    private static final String SUMMARY_JUDGMENT = "SUMMARY_JUDGMENT";
+
+    private static final Set<String> CUI_ALLOWED_TYPES = Set.of(
+        GeneralApplicationTypes.STRIKE_OUT.name(),
+        GeneralApplicationTypes.SUMMARY_JUDGEMENT.name(),
+        GeneralApplicationTypes.STAY_THE_CLAIM.name(),
+        GeneralApplicationTypes.EXTEND_TIME.name(),
+        GeneralApplicationTypes.AMEND_A_STMT_OF_CASE.name(),
+        GeneralApplicationTypes.RELIEF_FROM_SANCTIONS.name(),
+        GeneralApplicationTypes.SET_ASIDE_JUDGEMENT.name(),
+        GeneralApplicationTypes.SETTLE_BY_CONSENT.name(),
+        GeneralApplicationTypes.VARY_ORDER.name(),
+        GeneralApplicationTypes.ADJOURN_HEARING.name(),
+        GeneralApplicationTypes.UNLESS_ORDER.name(),
+        GeneralApplicationTypes.OTHER.name(),
+        GeneralApplicationTypes.VARY_PAYMENT_TERMS_OF_JUDGMENT.name(),
+        GeneralApplicationTypes.CONFIRM_CCJ_DEBT_PAID.name()
+    );
+    private static final Set<String> LR_ALLOWED_TYPES = Arrays.stream(GeneralApplicationTypesLR.values())
+        .map(GeneralApplicationTypesLR::name)
+        .collect(Collectors.toUnmodifiableSet());
+    private static final Set<String> ALL_CCD_TYPE_CODES = Arrays.stream(GeneralApplicationTypes.values())
+        .map(GeneralApplicationTypes::name)
+        .collect(Collectors.toUnmodifiableSet());
+    private static final Set<String> CUI_UNSUPPORTED_TYPES = ALL_CCD_TYPE_CODES.stream()
+        .filter(typeCode -> !CUI_ALLOWED_TYPES.contains(typeCode))
+        .collect(Collectors.toUnmodifiableSet());
+
+    private static final Map<String, String> INVALID_CODE_REASONS = invalidCodeReasons();
+    private static final List<TypeField> TYPE_FIELDS = List.of(
+        new TypeField(
+            GENERAL_APP_TYPE,
+            new GeneralApplicationTypeFieldValidator(CUI_ALLOWED_TYPES, CUI_UNSUPPORTED_TYPES, INVALID_CODE_REASONS)
+        ),
+        new TypeField(
+            GENERAL_APP_TYPE_LR,
+            new GeneralApplicationTypeFieldValidator(LR_ALLOWED_TYPES, Set.of(), INVALID_CODE_REASONS)
+        )
+    );
+
+    private GeneralApplicationTypeValidator() {
+    }
+
+    static void validate(Map<String, Object> caseDataUpdate) {
+        presentTypeFieldsOrThrow(requireCaseDataUpdate(caseDataUpdate))
+            .forEach(typeField -> typeField.validator().validate(caseDataUpdate.get(typeField.name())));
+    }
+
+    private static Map<String, Object> requireCaseDataUpdate(Map<String, Object> caseDataUpdate) {
+        if (caseDataUpdate == null) {
+            throw invalid("MISSING_CASE_DATA_UPDATE");
+        }
+        return caseDataUpdate;
+    }
+
+    private static List<TypeField> presentTypeFieldsOrThrow(Map<String, Object> caseDataUpdate) {
+        List<TypeField> presentTypeFields = presentTypeFields(caseDataUpdate);
+        if (presentTypeFields.isEmpty()) {
+            throw invalid("MISSING_GENERAL_APP_TYPE");
+        }
+        return presentTypeFields;
+    }
+
+    private static List<TypeField> presentTypeFields(Map<String, Object> caseDataUpdate) {
+        return TYPE_FIELDS.stream()
+            .filter(typeField -> caseDataUpdate.containsKey(typeField.name()))
+            .toList();
+    }
+
+    private static Map<String, String> invalidCodeReasons() {
+        return Stream.concat(
+            Stream.of(
+                Map.entry(OTHER_OPTION, "UI_ONLY_OTHER_OPTION"),
+                Map.entry(SUMMARY_JUDGMENT, "STALE_CODE")
+            ),
+            Arrays.stream(GeneralApplicationTypes.values())
+                .map(type -> Map.entry(type.getDisplayedValue(), "DISPLAY_LABEL"))
+        ).collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    private static InvalidGeneralApplicationTypeException invalid(String reason) {
+        return new InvalidGeneralApplicationTypeException(0, Set.of(reason));
+    }
+
+    private record TypeField(String name, GeneralApplicationTypeFieldValidator validator) {
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/citizen/events/GeneralApplicationTypeValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/citizen/events/GeneralApplicationTypeValidatorTest.java
@@ -1,0 +1,132 @@
+package uk.gov.hmcts.reform.civil.service.citizen.events;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.exceptions.InvalidGeneralApplicationTypeException;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class GeneralApplicationTypeValidatorTest {
+
+    @Test
+    void shouldAllowValidGeneralApplicationTypes() {
+        assertDoesNotThrow(() -> GeneralApplicationTypeValidator.validate(
+            generalApplicationTypeUpdates("EXTEND_TIME", "STRIKE_OUT", "OTHER", "CONFIRM_CCJ_DEBT_PAID")
+        ));
+    }
+
+    @Test
+    void shouldAllowValidGeneralApplicationTypeLrTypes() {
+        assertDoesNotThrow(() -> GeneralApplicationTypeValidator.validate(
+            generalApplicationTypeLrUpdates("EXTEND_TIME", "STRIKE_OUT", "OTHER", "PROCEEDS_IN_HERITAGE")
+        ));
+    }
+
+    @Test
+    void shouldRejectMissingCaseDataUpdate() {
+        assertInvalidPayload(null, 0, "MISSING_CASE_DATA_UPDATE");
+    }
+
+    @Test
+    void shouldRejectMissingGeneralApplicationType() {
+        assertInvalidPayload(Map.of(), 0, "MISSING_GENERAL_APP_TYPE");
+    }
+
+    @Test
+    void shouldRejectGeneralApplicationTypeThatIsNotAnObject() {
+        assertInvalidPayload(Map.of("generalAppType", "EXTEND_TIME"), 0, "GENERAL_APP_TYPE_NOT_OBJECT");
+    }
+
+    @Test
+    void shouldRejectGeneralApplicationTypeThatIsNull() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("generalAppType", null);
+
+        assertInvalidPayload(payload, 0, "GENERAL_APP_TYPE_NOT_OBJECT");
+    }
+
+    @Test
+    void shouldRejectMissingGeneralApplicationTypes() {
+        assertInvalidPayload(Map.of("generalAppType", Map.of()), 0, "MISSING_TYPES");
+    }
+
+    @Test
+    void shouldRejectGeneralApplicationTypesThatAreNotAnArray() {
+        assertInvalidPayload(Map.of("generalAppType", Map.of("types", "EXTEND_TIME")), 0, "TYPES_NOT_ARRAY");
+    }
+
+    @Test
+    void shouldRejectEmptyGeneralApplicationTypes() {
+        assertInvalidPayload(Map.of("generalAppType", Map.of("types", List.of())), 0, "EMPTY_TYPES");
+    }
+
+    @Test
+    void shouldRejectOtherOptionAsUiOnlyValue() {
+        assertInvalidPayload(generalApplicationTypeUpdates("OTHER_OPTION"), 1, "UI_ONLY_OTHER_OPTION");
+    }
+
+    @Test
+    void shouldRejectStaleSummaryJudgmentCode() {
+        assertInvalidPayload(generalApplicationTypeUpdates("SUMMARY_JUDGMENT"), 1, "STALE_CODE");
+    }
+
+    @Test
+    void shouldRejectDisplayLabel() {
+        assertInvalidPayload(generalApplicationTypeUpdates("Summary judgment"), 1, "DISPLAY_LABEL");
+    }
+
+    @Test
+    void shouldRejectUnsupportedCuiGeneralApplicationType() {
+        assertInvalidPayload(generalApplicationTypeUpdates("PROCEEDS_IN_HERITAGE"), 1, "CUI_UNSUPPORTED_TYPE");
+    }
+
+    @Test
+    void shouldRejectUnknownCode() {
+        assertInvalidPayload(generalApplicationTypeUpdates("NOT_A_REAL_TYPE"), 1, "UNKNOWN_CODE");
+    }
+
+    @Test
+    void shouldRejectBlankNullAndNonStringValues() {
+        assertInvalidPayload(
+            generalApplicationTypeUpdates("", null, 123),
+            3,
+            "BLANK_VALUE",
+            "NULL_VALUE",
+            "NON_STRING_VALUE"
+        );
+    }
+
+    @Test
+    void shouldRejectInvalidGeneralApplicationTypeLrType() {
+        assertInvalidPayload(generalApplicationTypeLrUpdates("OTHER_OPTION"), 1, "UI_ONLY_OTHER_OPTION");
+    }
+
+    private Map<String, Object> generalApplicationTypeUpdates(Object... typeValues) {
+        return Map.of("generalAppType", Map.of("types", Arrays.asList(typeValues)));
+    }
+
+    private Map<String, Object> generalApplicationTypeLrUpdates(Object... typeValues) {
+        return Map.of("generalAppTypeLR", Map.of("types", Arrays.asList(typeValues)));
+    }
+
+    private void assertInvalidPayload(
+        Map<String, Object> payload,
+        int invalidValueCount,
+        String... reasonCategories
+    ) {
+        InvalidGeneralApplicationTypeException exception = assertThrows(
+            InvalidGeneralApplicationTypeException.class,
+            () -> GeneralApplicationTypeValidator.validate(payload)
+        );
+
+        assertThat(exception.getMessage()).isEqualTo("Invalid general application type");
+        assertThat(exception.getInvalidValueCount()).isEqualTo(invalidValueCount);
+        assertThat(exception.getReasonCategories()).containsExactlyInAnyOrder(reasonCategories);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/citizenui/CaseEventServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/citizenui/CaseEventServiceTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.ccd.client.CoreCaseDataApi;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.exceptions.InvalidGeneralApplicationTypeException;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.Party;
@@ -23,15 +24,18 @@ import uk.gov.hmcts.reform.civil.sampledata.CaseDetailsBuilder;
 import uk.gov.hmcts.reform.civil.service.citizen.events.CaseEventService;
 import uk.gov.hmcts.reform.civil.service.citizen.events.EventSubmissionParams;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static uk.gov.hmcts.reform.civil.CaseDefinitionConstants.CASE_TYPE;
 import static uk.gov.hmcts.reform.civil.CaseDefinitionConstants.JURISDICTION;
 import static uk.gov.hmcts.reform.civil.utils.CaseDataContentConverter.caseDataContentFromStartEventResponse;
@@ -111,6 +115,186 @@ public class CaseEventServiceTest {
     }
 
     @Test
+    void shouldSubmitValidSingleGeneralApplicationTypeSuccessfully() {
+        Map<String, Object> updates = generalApplicationTypeUpdates("EXTEND_TIME");
+        InOrder orderVerifier = inOrder(coreCaseDataApi);
+
+        CaseDetails caseDetails = caseEventService.submitEvent(initiateGeneralApplicationParams(updates));
+
+        assertThat(caseDetails).isEqualTo(CASE_DETAILS);
+        orderVerifier.verify(coreCaseDataApi).startEventForCitizen(
+            AUTHORISATION,
+            EVENT_TOKEN,
+            USER_ID,
+            JURISDICTION,
+            CASE_TYPE,
+            CASE_ID,
+            CaseEvent.INITIATE_GENERAL_APPLICATION.name()
+        );
+        orderVerifier.verify(coreCaseDataApi).submitEventForCitizen(
+            AUTHORISATION,
+            EVENT_TOKEN,
+            USER_ID,
+            JURISDICTION,
+            CASE_TYPE,
+            CASE_ID,
+            true,
+            caseDataContentFromStartEventResponse(RESPONSE, updates)
+        );
+    }
+
+    @Test
+    void shouldSubmitValidMultiGeneralApplicationTypesSuccessfully() {
+        Map<String, Object> updates = generalApplicationTypeUpdates("EXTEND_TIME", "STRIKE_OUT", "OTHER");
+        InOrder orderVerifier = inOrder(coreCaseDataApi);
+
+        CaseDetails caseDetails = caseEventService.submitEvent(initiateGeneralApplicationParams(updates));
+
+        assertThat(caseDetails).isEqualTo(CASE_DETAILS);
+        orderVerifier.verify(coreCaseDataApi).startEventForCitizen(
+            AUTHORISATION,
+            EVENT_TOKEN,
+            USER_ID,
+            JURISDICTION,
+            CASE_TYPE,
+            CASE_ID,
+            CaseEvent.INITIATE_GENERAL_APPLICATION.name()
+        );
+        orderVerifier.verify(coreCaseDataApi).submitEventForCitizen(
+            AUTHORISATION,
+            EVENT_TOKEN,
+            USER_ID,
+            JURISDICTION,
+            CASE_TYPE,
+            CASE_ID,
+            true,
+            caseDataContentFromStartEventResponse(RESPONSE, updates)
+        );
+    }
+
+    @Test
+    void shouldSubmitValidGeneralApplicationTypeLrSuccessfully() {
+        Map<String, Object> updates = generalApplicationTypeLrUpdates("EXTEND_TIME", "STRIKE_OUT", "OTHER");
+        InOrder orderVerifier = inOrder(coreCaseDataApi);
+
+        CaseDetails caseDetails = caseEventService.submitEvent(initiateGeneralApplicationParams(updates));
+
+        assertThat(caseDetails).isEqualTo(CASE_DETAILS);
+        orderVerifier.verify(coreCaseDataApi).startEventForCitizen(
+            AUTHORISATION,
+            EVENT_TOKEN,
+            USER_ID,
+            JURISDICTION,
+            CASE_TYPE,
+            CASE_ID,
+            CaseEvent.INITIATE_GENERAL_APPLICATION.name()
+        );
+        orderVerifier.verify(coreCaseDataApi).submitEventForCitizen(
+            AUTHORISATION,
+            EVENT_TOKEN,
+            USER_ID,
+            JURISDICTION,
+            CASE_TYPE,
+            CASE_ID,
+            true,
+            caseDataContentFromStartEventResponse(RESPONSE, updates)
+        );
+    }
+
+    @Test
+    void shouldSubmitValidCoscGeneralApplicationTypeSuccessfully() {
+        Map<String, Object> updates = generalApplicationTypeUpdates("CONFIRM_CCJ_DEBT_PAID");
+        InOrder orderVerifier = inOrder(coreCaseDataApi);
+
+        CaseDetails caseDetails = caseEventService.submitEvent(
+            initiateGeneralApplicationParams(updates, CaseEvent.INITIATE_GENERAL_APPLICATION_COSC)
+        );
+
+        assertThat(caseDetails).isEqualTo(CASE_DETAILS);
+        orderVerifier.verify(coreCaseDataApi).startEventForCitizen(
+            AUTHORISATION,
+            EVENT_TOKEN,
+            USER_ID,
+            JURISDICTION,
+            CASE_TYPE,
+            CASE_ID,
+            CaseEvent.INITIATE_GENERAL_APPLICATION_COSC.name()
+        );
+        orderVerifier.verify(coreCaseDataApi).submitEventForCitizen(
+            AUTHORISATION,
+            EVENT_TOKEN,
+            USER_ID,
+            JURISDICTION,
+            CASE_TYPE,
+            CASE_ID,
+            true,
+            caseDataContentFromStartEventResponse(RESPONSE, updates)
+        );
+    }
+
+    @Test
+    void shouldRejectOtherOptionBeforeSubmittingToCcd() {
+        assertInvalidGaPayloadRejected(
+            generalApplicationTypeUpdates("EXTEND_TIME", "OTHER_OPTION"),
+            1,
+            "UI_ONLY_OTHER_OPTION"
+        );
+    }
+
+    @Test
+    void shouldRejectStaleSummaryJudgmentCodeBeforeSubmittingToCcd() {
+        assertInvalidGaPayloadRejected(generalApplicationTypeUpdates("SUMMARY_JUDGMENT"), 1, "STALE_CODE");
+    }
+
+    @Test
+    void shouldRejectInvalidGeneralApplicationTypeLrBeforeSubmittingToCcd() {
+        assertInvalidGaPayloadRejected(
+            generalApplicationTypeLrUpdates("EXTEND_TIME", "OTHER_OPTION"),
+            1,
+            "UI_ONLY_OTHER_OPTION"
+        );
+    }
+
+    @Test
+    void shouldRejectProceedsInHeritageBecauseCuiCannotInitiateThatGeneralApplicationType() {
+        assertInvalidGaPayloadRejected(generalApplicationTypeUpdates("PROCEEDS_IN_HERITAGE"), 1, "CUI_UNSUPPORTED_TYPE");
+    }
+
+    @Test
+    void shouldRejectInvalidCoscGeneralApplicationTypeBeforeSubmittingToCcd() {
+        assertInvalidGaPayloadRejected(
+            generalApplicationTypeUpdates("OTHER_OPTION"),
+            1,
+            "UI_ONLY_OTHER_OPTION",
+            CaseEvent.INITIATE_GENERAL_APPLICATION_COSC
+        );
+    }
+
+    @Test
+    void shouldRejectDisplayLabelsBeforeSubmittingToCcd() {
+        assertInvalidGaPayloadRejected(generalApplicationTypeUpdates("Summary judgment"), 1, "DISPLAY_LABEL");
+    }
+
+    @Test
+    void shouldRejectBlankNullAndNonStringTypesBeforeSubmittingToCcd() {
+        assertInvalidGaPayloadRejected(generalApplicationTypeUpdates("", null, 123), 3, "BLANK_VALUE");
+    }
+
+    @Test
+    void shouldRejectInvalidThirdApplicationTypeBeforeSubmittingToCcd() {
+        assertInvalidGaPayloadRejected(
+            generalApplicationTypeUpdates("EXTEND_TIME", "STRIKE_OUT", "OTHER_OPTION"),
+            1,
+            "UI_ONLY_OTHER_OPTION"
+        );
+    }
+
+    @Test
+    void shouldRejectMissingGeneralApplicationTypesBeforeSubmittingToCcd() {
+        assertInvalidGaPayloadRejected(Map.of("generalAppType", Map.of()), 0, "MISSING_TYPES");
+    }
+
+    @Test
     void shouldSubmitEventForNewClaimSuccessfully() {
         InOrder orderVerifier = inOrder(coreCaseDataApi);
         CaseDetails caseDetails = caseEventService.submitEvent(new EventSubmissionParams()
@@ -167,5 +351,47 @@ public class CaseEventServiceTest {
                                                                    .setUserId(USER_ID)
                                                                    .setAuthorisation(AUTHORISATION));
         assertThat(response).isEqualTo(CASE_DETAILS);
+    }
+
+    private EventSubmissionParams initiateGeneralApplicationParams(Map<String, Object> updates) {
+        return initiateGeneralApplicationParams(updates, CaseEvent.INITIATE_GENERAL_APPLICATION);
+    }
+
+    private EventSubmissionParams initiateGeneralApplicationParams(Map<String, Object> updates, CaseEvent event) {
+        return new EventSubmissionParams()
+            .setUpdates(updates)
+            .setEvent(event)
+            .setCaseId(CASE_ID)
+            .setUserId(USER_ID)
+            .setAuthorisation(AUTHORISATION);
+    }
+
+    private Map<String, Object> generalApplicationTypeUpdates(Object... typeValues) {
+        return Map.of("generalAppType", Map.of("types", Arrays.asList(typeValues)));
+    }
+
+    private Map<String, Object> generalApplicationTypeLrUpdates(Object... typeValues) {
+        return Map.of("generalAppTypeLR", Map.of("types", Arrays.asList(typeValues)));
+    }
+
+    private void assertInvalidGaPayloadRejected(Map<String, Object> updates, int invalidCount, String expectedReason) {
+        assertInvalidGaPayloadRejected(updates, invalidCount, expectedReason, CaseEvent.INITIATE_GENERAL_APPLICATION);
+    }
+
+    private void assertInvalidGaPayloadRejected(
+        Map<String, Object> updates,
+        int invalidCount,
+        String expectedReason,
+        CaseEvent event
+    ) {
+        InvalidGeneralApplicationTypeException exception = assertThrows(
+            InvalidGeneralApplicationTypeException.class,
+            () -> caseEventService.submitEvent(initiateGeneralApplicationParams(updates, event))
+        );
+
+        assertThat(exception.getMessage()).isEqualTo("Invalid general application type");
+        assertThat(exception.getInvalidValueCount()).isEqualTo(invalidCount);
+        assertThat(exception.getReasonCategories()).contains(expectedReason);
+        verifyNoInteractions(coreCaseDataApi, authTokenGenerator);
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSCCI-5814

## Summary

This work adds civil-service defence-in-depth validation for General Application type values before citizen GA creation events are submitted to CCD, complementing the CUI validation that blocks invalid draft GA values before save/submit.

CUI was able to send invalid draft GA type values, such as `OTHER_OPTION`, display labels, stale codes, empty values or arbitrary strings, through to civil-service. Civil-service then submitted `INITIATE_GENERAL_APPLICATION` to CCD, where CCD rejected `generalApplications.0.generalAppType.types` with a 422 validation error.

Civil-service now rejects malformed or unsupported `generalAppType.types` payloads before CCD start/submit is called. The valid GA submit paths are retained, including single type, multiple type, CoSC and existing `generalAppTypeLR` payloads.

## Changes

- Added validation for citizen GA creation payloads before CCD start/submit.
- Added allowed type policies for `generalAppType` and `generalAppTypeLR`.
- Rejected invalid GA type values including `OTHER_OPTION`, display labels, stale `SUMMARY_JUDGMENT`, blank/null/non-string values and unknown codes.
- Added a controlled `400 Bad Request` response for invalid GA type payloads.
- Added safe logging for invalid GA type submissions without logging full case data or request payloads.
- Added regression coverage proving invalid GA type payloads do not call CCD.
- Added coverage for valid single, multiple, CoSC and `generalAppTypeLR` GA submit paths.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
