### PR TITLE
fix: set INFRA_VAULT_NAME=prod before loading prod vault secrets

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -206,7 +206,9 @@ withPipeline(type, product, component) {
     createBpmnGithubRelease()
     uploadBpmnDiagrams('aat')
     withSubscription('prod') {
-      loadVaultSecrets(secretsProd)
+      withEnv(['INFRA_VAULT_NAME=prod']) {
+        loadVaultSecrets(secretsProd)
+      }
       uploadBpmnDiagrams('prod')
     }
   }

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -205,11 +205,9 @@ withPipeline(type, product, component) {
   afterSuccess('functionalTest:aat') {
     createBpmnGithubRelease()
     uploadBpmnDiagrams('aat')
-    withSubscription('prod') {
-      withEnv(['INFRA_VAULT_NAME=prod']) {
-        loadVaultSecrets(secretsProd)
-      }
-      uploadBpmnDiagrams('prod')
+    withSubscription('prod', product, 'prod') {
+    loadVaultSecrets(secretsProd)
+    uploadBpmnDiagrams('prod')
     }
   }
 


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-33257

### Change description ###

fix: set INFRA_VAULT_NAME=prod before loading prod vault secrets

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
