### PR TITLE
Move uploadBpmnDiagrams after infra prod success

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -205,6 +205,9 @@ withPipeline(type, product, component) {
   afterSuccess('functionalTest:aat') {
     createBpmnGithubRelease()
     uploadBpmnDiagrams('aat')
+  }
+
+  afterSuccess('buildinfra:prod') {
     withAzureKeyvault(
       azureKeyVaultSecrets: secretsProd['civil-prod'],
       keyVaultURLOverride: 'https://civil-prod.vault.azure.net/'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-33257

### Change description ###
Attempting to fix error in master build by moving the `uploadBpmnDiagrams` step to run in the prod context

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
