### PR TITLE
DTSPO-33365 Allow environment agents to read SendGrid secrets

### DIFF
--- a/infrastructure/state.tf
+++ b/infrastructure/state.tf
@@ -17,8 +17,14 @@ terraform {
 }
 
 provider "azurerm" {
-  alias           = "send-grid"
-  subscription_id = var.send_grid_subscription
+  alias                           = "send-grid"
+  subscription_id                 = var.send_grid_subscription
+  resource_provider_registrations = "none"
+
+  enhanced_validation {
+    resource_providers = false
+  }
+
   features {}
 }
 

--- a/infrastructure/tf-kv-secrets-send-grid.tf
+++ b/infrastructure/tf-kv-secrets-send-grid.tf
@@ -1,15 +1,14 @@
 
-data "azurerm_key_vault" "send_grid" {
-  provider = azurerm.send-grid
-
-  name                = var.env != "prod" ? "sendgridnonprod" : "sendgridprod"
-  resource_group_name = var.env != "prod" ? "SendGrid-nonprod" : "SendGrid-prod"
+locals {
+  send_grid_key_vault_name                = var.env != "prod" ? "sendgridnonprod" : "sendgridprod"
+  send_grid_key_vault_resource_group_name = var.env != "prod" ? "SendGrid-nonprod" : "SendGrid-prod"
+  send_grid_key_vault_id                  = "/subscriptions/${var.send_grid_subscription}/resourceGroups/${local.send_grid_key_vault_resource_group_name}/providers/Microsoft.KeyVault/vaults/${local.send_grid_key_vault_name}"
 }
 
 data "azurerm_key_vault_secret" "send_grid_api_key" {
   provider = azurerm.send-grid
 
-  key_vault_id = data.azurerm_key_vault.send_grid.id
+  key_vault_id = local.send_grid_key_vault_id
   name         = "hmcts-civil-api-key"
 }
 
@@ -20,7 +19,7 @@ resource "azurerm_key_vault_secret" "sendgrid_api_key" {
 
   content_type = "secret"
   tags = merge(var.common_tags, {
-    "source" : "Vault ${data.azurerm_key_vault.send_grid.name}"
+    "source" : "Vault ${local.send_grid_key_vault_name}"
   })
 
   depends_on = [


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-33436

### Change description ###

Allow demo, ithc and perftest environment agents to read the shared SendGrid secret without requiring DEV subscription

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
