### PR TITLE
DTSCCI-5905: Verify hearing notice attendee names against CCD

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/AsyncCaseMigrationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/AsyncCaseMigrationService.java
@@ -67,6 +67,10 @@ public class AsyncCaseMigrationService {
                     batchCount++;
                 }
                 log.info("Migrating case with ID: {}", caseReference);
+                if (task.isReadOnly()) {
+                    verifyReadOnly(task, caseReference, isGA);
+                    continue;
+                }
                 CaseData caseData;
                 StartEventResponse startEventResponse;
                 if (isGA) {
@@ -109,6 +113,19 @@ public class AsyncCaseMigrationService {
                 RequestContextHolder.resetRequestAttributes();
             }
         }
+    }
+
+    private <T extends CaseReference> void verifyReadOnly(MigrationTask<T> task, T caseReference, boolean isGA) {
+        CaseDetails caseDetails = coreCaseDataService.getCase(Long.valueOf(caseReference.getCaseReference()));
+        if (isGA) {
+            CaseData caseData = caseDetailsConverter.toGACaseData(caseDetails);
+            GeneralApplicationCaseData gaCaseData = caseDetailsConverter.toGeneralApplicationCaseData(caseDetails);
+            task.migrateGeneralApplicationCaseData(caseData, gaCaseData, caseReference);
+        } else {
+            CaseData caseData = caseDetailsConverter.toCaseData(caseDetails);
+            task.migrateCaseData(caseData, caseReference);
+        }
+        log.info("Read-only verification completed for case ID: {}", caseReference.getCaseReference());
     }
 
     protected CaseDataContent buildCaseDataContent(StartEventResponse startEventResponse, CaseData caseData, MigrationTask<?> task) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrationTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/MigrationTask.java
@@ -37,6 +37,15 @@ public abstract class MigrationTask<T extends CaseReference> {
         return Collections.emptyList();
     }
 
+    /**
+     * Read-only tasks inspect a case and report without changing it. When true,
+     * {@link AsyncCaseMigrationService} fetches the case without starting or submitting a CCD
+     * event, so no entry is written to the case history.
+     */
+    public boolean isReadOnly() {
+        return false;
+    }
+
     protected Class<T> getType() {
         return type;
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
@@ -1,0 +1,182 @@
+package uk.gov.hmcts.reform.civil.handler.migration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReference;
+import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.Party;
+import uk.gov.hmcts.reform.civil.model.common.Element;
+import uk.gov.hmcts.reform.civil.service.UserService;
+import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentDownloadService;
+import uk.gov.hmcts.reform.civil.utils.PartyUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Read-only reporting migration task.
+ *
+ * <p>Hearing notice party names are rendered from CCD CaseData at generation time
+ * ({@code HearingNoticeHmcGenerator}), so with CCD as the source of truth a notice is
+ * correct if its printed names still match the current case. This task downloads each
+ * HMC hearing notice PDF from CDAM and checks that the current CCD claimant/defendant
+ * names appear in the document text. A notice whose text no longer contains a current
+ * name is a stale notice that should be reissued.</p>
+ *
+ * <p>The task makes no changes to CaseData; it returns the case unchanged and emits one
+ * structured log line per notice document (prefix {@code VERIFY_HEARING_NOTICE}) so
+ * results can be filtered from App Insights.</p>
+ */
+@Component
+@Slf4j
+public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
+
+    private static final String LOG_PREFIX = "VERIFY_HEARING_NOTICE";
+    private static final String DOWNLOAD_ERROR = "VERIFY_HEARING_NOTICE download failed for case {}";
+
+    private final DocumentDownloadService documentDownloadService;
+    private final UserService userService;
+    private final SystemUpdateUserConfiguration userConfig;
+
+    public VerifyHearingNoticeNamesTask(DocumentDownloadService documentDownloadService,
+                                        UserService userService,
+                                        SystemUpdateUserConfiguration userConfig) {
+        super(CaseReference.class);
+        this.documentDownloadService = documentDownloadService;
+        this.userService = userService;
+        this.userConfig = userConfig;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    protected String getTaskName() {
+        return "VerifyHearingNoticeNamesTask";
+    }
+
+    @Override
+    protected String getEventSummary() {
+        return "Verify hearing notice attendee names against CCD";
+    }
+
+    @Override
+    protected String getEventDescription() {
+        return "Read-only check that generated hearing notices carry the current CCD party names";
+    }
+
+    @Override
+    protected CaseData migrateCaseData(CaseData caseData, CaseReference caseReference) {
+        if (caseData == null || caseReference == null || caseReference.getCaseReference() == null) {
+            throw new IllegalArgumentException("CaseData and CaseReference must not be null");
+        }
+
+        String caseId = caseReference.getCaseReference();
+        List<String> expectedNames = expectedNames(caseData);
+        List<CaseDocument> notices = hearingNoticeDocuments(caseData);
+
+        if (notices.isEmpty()) {
+            log.info("{} case={} result=NO_NOTICE expectedNames={}", LOG_PREFIX, caseId, expectedNames);
+            return caseData;
+        }
+
+        String authorisation = getSystemUserToken();
+
+        for (CaseDocument notice : notices) {
+            verifyNotice(caseData, caseId, notice, expectedNames, authorisation);
+        }
+
+        return caseData;
+    }
+
+    private void verifyNotice(CaseData caseData, String caseId, CaseDocument notice,
+                              List<String> expectedNames, String authorisation) {
+        String fileName = notice.getDocumentLink() != null ? notice.getDocumentLink().getDocumentFileName() : null;
+        try {
+            byte[] content = documentDownloadService.downloadDocument(
+                notice, authorisation, caseId, DOWNLOAD_ERROR);
+            String noticeText = normalise(extractText(content));
+
+            List<String> missing = new ArrayList<>();
+            for (String name : expectedNames) {
+                if (!noticeText.contains(normalise(name))) {
+                    missing.add(name);
+                }
+            }
+
+            String result = missing.isEmpty() ? "MATCH" : "STALE";
+            log.info("{} case={} document=\"{}\" result={} expectedNames={} missingNames={}",
+                     LOG_PREFIX, caseId, fileName, result, expectedNames, missing);
+        } catch (Exception e) {
+            log.error("{} case={} document=\"{}\" result=ERROR message={}",
+                      LOG_PREFIX, caseId, fileName, e.getMessage(), e);
+        }
+    }
+
+    private List<CaseDocument> hearingNoticeDocuments(CaseData caseData) {
+        List<CaseDocument> documents = new ArrayList<>();
+        addAll(documents, caseData.getHearingDocuments());
+        addAll(documents, caseData.getHearingDocumentsWelsh());
+        return documents;
+    }
+
+    private void addAll(List<CaseDocument> target, List<Element<CaseDocument>> source) {
+        if (source != null) {
+            source.stream()
+                .filter(nonNullElement -> nonNullElement != null && nonNullElement.getValue() != null)
+                .forEach(element -> target.add(element.getValue()));
+        }
+    }
+
+    /**
+     * Builds the party names exactly as {@code HearingNoticeHmcGenerator} renders them onto the notice:
+     * minors are shown with their litigation friend, everyone else by party name.
+     */
+    private List<String> expectedNames(CaseData caseData) {
+        List<String> names = new ArrayList<>();
+        addName(names, claimantName(caseData.getApplicant1(), caseData.getApplicant1LitigationFriend()));
+        addName(names, claimantName(caseData.getApplicant2(), caseData.getApplicant2LitigationFriend()));
+        addName(names, caseData.getRespondent1() != null ? caseData.getRespondent1().getPartyName() : null);
+        addName(names, caseData.getRespondent2() != null ? caseData.getRespondent2().getPartyName() : null);
+        return names;
+    }
+
+    private String claimantName(Party party, uk.gov.hmcts.reform.civil.model.LitigationFriend litigationFriend) {
+        if (party == null) {
+            return null;
+        }
+        return PartyUtils.isMinor(party)
+            ? PartyUtils.getPartyNameWithLitigiousFriend(party, litigationFriend)
+            : party.getPartyName();
+    }
+
+    private void addName(List<String> names, String name) {
+        if (name != null && !name.isBlank()) {
+            names.add(name);
+        }
+    }
+
+    private String extractText(byte[] content) throws java.io.IOException {
+        try (PDDocument document = Loader.loadPDF(content)) {
+            return new PDFTextStripper().getText(document);
+        }
+    }
+
+    private String normalise(String value) {
+        if (value == null) {
+            return "";
+        }
+        return value.toLowerCase().replaceAll("\\s+", " ").trim();
+    }
+
+    private String getSystemUserToken() {
+        return userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
@@ -38,6 +38,10 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
 
     private static final String LOG_PREFIX = "VERIFY_HEARING_NOTICE";
     private static final String DOWNLOAD_ERROR = "VERIFY_HEARING_NOTICE download failed for case {}";
+    private static final String TASK_NAME = "VerifyHearingNoticeNamesTask";
+    private static final String EVENT_SUMMARY = "Verify hearing notice attendee names against CCD";
+    private static final String EVENT_DESCRIPTION =
+        "Read-only check that generated hearing notices carry the current CCD party names";
 
     private final DocumentDownloadService documentDownloadService;
     private final UserService userService;
@@ -59,17 +63,17 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
 
     @Override
     protected String getTaskName() {
-        return "VerifyHearingNoticeNamesTask";
+        return TASK_NAME;
     }
 
     @Override
     protected String getEventSummary() {
-        return "Verify hearing notice attendee names against CCD";
+        return EVENT_SUMMARY;
     }
 
     @Override
     protected String getEventDescription() {
-        return "Read-only check that generated hearing notices carry the current CCD party names";
+        return EVENT_DESCRIPTION;
     }
 
     @Override

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/AsyncCaseMigrationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/AsyncCaseMigrationServiceTest.java
@@ -306,4 +306,46 @@ class AsyncCaseMigrationServiceTest {
         assertEquals("b", contentData.get("a"));
         assertNull(contentData.get("caseDismissedHearingFeeDueDate"));
     }
+
+    @Test
+    void shouldFetchWithoutSubmittingEvent_whenTaskIsReadOnly() {
+        @SuppressWarnings("unchecked")
+        MigrationTask<CaseReference> readOnlyTask = mock(MigrationTask.class);
+        when(readOnlyTask.isReadOnly()).thenReturn(true);
+
+        CaseDetails caseDetails = mock(CaseDetails.class);
+        CaseData caseData = mock(CaseData.class);
+        when(coreCaseDataService.getCase(12345L)).thenReturn(caseDetails);
+        when(caseDetailsConverter.toCaseData(caseDetails)).thenReturn(caseData);
+
+        CaseReference caseReference = new CaseReference("12345");
+        asyncCaseMigrationService.migrateCasesAsync(readOnlyTask, List.of(caseReference), null, false);
+
+        verify(coreCaseDataService).getCase(12345L);
+        verify(readOnlyTask).migrateCaseData(caseData, caseReference);
+        verify(coreCaseDataService, times(0)).startUpdate(ArgumentMatchers.anyString(), ArgumentMatchers.any(CaseEvent.class));
+        verify(coreCaseDataService, times(0)).submitUpdate(ArgumentMatchers.anyString(), ArgumentMatchers.any(CaseDataContent.class));
+    }
+
+    @Test
+    void shouldFetchGaCaseWithoutSubmittingEvent_whenReadOnlyTaskIsGA() {
+        @SuppressWarnings("unchecked")
+        MigrationTask<CaseReference> readOnlyTask = mock(MigrationTask.class);
+        when(readOnlyTask.isReadOnly()).thenReturn(true);
+
+        CaseDetails caseDetails = mock(CaseDetails.class);
+        CaseData caseData = mock(CaseData.class);
+        GeneralApplicationCaseData gaCaseData = mock(GeneralApplicationCaseData.class);
+        when(coreCaseDataService.getCase(67890L)).thenReturn(caseDetails);
+        when(caseDetailsConverter.toGACaseData(caseDetails)).thenReturn(caseData);
+        when(caseDetailsConverter.toGeneralApplicationCaseData(caseDetails)).thenReturn(gaCaseData);
+
+        CaseReference caseReference = new CaseReference("67890");
+        asyncCaseMigrationService.migrateCasesAsync(readOnlyTask, List.of(caseReference), null, true);
+
+        verify(coreCaseDataService).getCase(67890L);
+        verify(readOnlyTask).migrateGeneralApplicationCaseData(caseData, gaCaseData, caseReference);
+        verify(coreCaseDataService, times(0)).startGeneralApplicationUpdate(ArgumentMatchers.anyString(), ArgumentMatchers.any(CaseEvent.class));
+        verify(coreCaseDataService, times(0)).submitGeneralApplicationUpdate(ArgumentMatchers.anyString(), ArgumentMatchers.any(CaseDataContent.class));
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
@@ -1,0 +1,152 @@
+package uk.gov.hmcts.reform.civil.handler.migration;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReference;
+import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.Document;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.Party;
+import uk.gov.hmcts.reform.civil.service.UserService;
+import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentDownloadService;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.civil.utils.ElementUtils.wrapElements;
+
+class VerifyHearingNoticeNamesTaskTest {
+
+    private DocumentDownloadService documentDownloadService;
+    private UserService userService;
+    private SystemUpdateUserConfiguration userConfig;
+    private VerifyHearingNoticeNamesTask task;
+
+    private final Party claimant = new Party()
+        .setType(Party.Type.INDIVIDUAL).setIndividualFirstName("John").setIndividualLastName("Smith");
+    private final Party defendant = new Party()
+        .setType(Party.Type.INDIVIDUAL).setIndividualFirstName("Jane").setIndividualLastName("Doe");
+
+    @BeforeEach
+    void setUp() {
+        documentDownloadService = mock(DocumentDownloadService.class);
+        userService = mock(UserService.class);
+        userConfig = mock(SystemUpdateUserConfiguration.class);
+        task = new VerifyHearingNoticeNamesTask(documentDownloadService, userService, userConfig);
+
+        when(userConfig.getUserName()).thenReturn("system-user");
+        when(userConfig.getPassword()).thenReturn("pass");
+        when(userService.getAccessToken("system-user", "pass")).thenReturn("Bearer token");
+    }
+
+    @Test
+    void shouldReportMatch_whenNoticeContainsCurrentNames() throws Exception {
+        byte[] pdf = pdfContaining(claimant.getPartyName() + " v " + defendant.getPartyName());
+        when(documentDownloadService.downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString()))
+            .thenReturn(pdf);
+        CaseData caseData = caseWithNotice();
+
+        CaseData result = task.migrateCaseData(caseData, caseReference("123"));
+
+        assertEquals(caseData, result, "task must return the case unchanged");
+        verify(documentDownloadService, times(1))
+            .downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString());
+        verify(userService, times(1)).getAccessToken("system-user", "pass");
+    }
+
+    @Test
+    void shouldReportStale_whenNoticeMissesACurrentName() throws Exception {
+        byte[] pdf = pdfContaining("Old Claimant v Jane Doe");
+        when(documentDownloadService.downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString()))
+            .thenReturn(pdf);
+        CaseData caseData = caseWithNotice();
+
+        CaseData result = task.migrateCaseData(caseData, caseReference("123"));
+
+        assertEquals(caseData, result, "task must not mutate the case even when the notice is stale");
+        verify(documentDownloadService, times(1))
+            .downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void shouldSkipDownload_whenCaseHasNoHearingNotice() {
+        CaseData caseData = CaseData.builder().applicant1(claimant).respondent1(defendant).build();
+
+        CaseData result = task.migrateCaseData(caseData, caseReference("123"));
+
+        assertEquals(caseData, result);
+        verify(documentDownloadService, never())
+            .downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    void shouldSwallowDownloadFailure_andReturnCaseUnchanged() {
+        when(documentDownloadService.downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString()))
+            .thenThrow(new RuntimeException("CDAM unavailable"));
+        CaseData caseData = caseWithNotice();
+
+        CaseData result = assertDoesNotThrow(() -> task.migrateCaseData(caseData, caseReference("123")));
+
+        assertEquals(caseData, result);
+    }
+
+    @Test
+    void shouldThrow_whenCaseReferenceIsNull() {
+        CaseData caseData = caseWithNotice();
+
+        Exception exception = assertThrows(IllegalArgumentException.class,
+                                           () -> task.migrateCaseData(caseData, null));
+
+        assertEquals("CaseData and CaseReference must not be null", exception.getMessage());
+    }
+
+    private CaseData caseWithNotice() {
+        CaseDocument notice = new CaseDocument()
+            .setDocumentLink(new Document(
+                "http://dm-store/documents/abc123", "http://dm-store/documents/abc123/binary",
+                "hearing-notice.pdf", "hash", null, null));
+        return CaseData.builder()
+            .applicant1(claimant)
+            .respondent1(defendant)
+            .hearingDocuments(wrapElements(notice))
+            .build();
+    }
+
+    private CaseReference caseReference(String ref) {
+        CaseReference caseReference = new CaseReference();
+        caseReference.setCaseReference(ref);
+        return caseReference;
+    }
+
+    private byte[] pdfContaining(String text) throws Exception {
+        try (PDDocument document = new PDDocument()) {
+            PDPage page = new PDPage();
+            document.addPage(page);
+            try (PDPageContentStream stream = new PDPageContentStream(document, page)) {
+                stream.beginText();
+                stream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                stream.newLineAtOffset(50, 700);
+                stream.showText(text);
+                stream.endText();
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            document.save(out);
+            return out.toByteArray();
+        }
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5905

### Change description ###

Adds an automated, read-only way to verify that generated HMC hearing notices carry the correct party (attendee) names, so we do not have to eyeball 200+ cases by hand.

**Why**

Hearing notice party names are rendered from CCD CaseData at generation time (`HearingNoticeHmcGenerator`). With CCD as the source of truth, a notice is only incorrect if it is *stale* - generated before a name was corrected in CCD. This task detects those stale notices.

**What**

- `VerifyHearingNoticeNamesTask` - a read-only migration task. For each case it builds the expected names exactly as the generator does (minor -> litigation friend, otherwise party name; applicant1/2 + respondent1/2), downloads the notice PDFs from CDAM (`getHearingDocuments()` / `getHearingDocumentsWelsh()`) via the existing `DocumentDownloadService`, extracts the text with PDFBox, and logs one structured line per document: `VERIFY_HEARING_NOTICE case=.. document=.. result=MATCH|STALE|NO_NOTICE|ERROR missingNames=..`. Results are read back from App Insights. The task returns CaseData unchanged.

- Read-only support in the migration framework so verification tasks do **not** write to case history:
  - `MigrationTask.isReadOnly()` (default `false`) is the opt-in.
  - `AsyncCaseMigrationService` fetches the case via `CoreCaseDataService.getCase(..)` (a plain read - no state constraint, case-type agnostic) and skips `startUpdate`/`submitUpdate` entirely, so no `UPDATE_CASE_DATA` event is recorded.

**Tests**

- `VerifyHearingNoticeNamesTaskTest` (match, stale, no-notice, download failure, null reference) - builds real in-memory PDFs with PDFBox.
- `AsyncCaseMigrationServiceTest` - 2 new tests asserting the read-only path calls `getCase` and never calls start/submit (civil + GA).

The mutating migration path is unchanged; the new behaviour only triggers when a task opts in via `isReadOnly()`.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```