### PR TITLE
DTSCCI-5905: Verify hearing notice attendees against CCD participants

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
@@ -9,28 +9,32 @@ import uk.gov.hmcts.reform.civil.bulkupdate.csv.CaseReference;
 import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
 import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.LitigationFriend;
 import uk.gov.hmcts.reform.civil.model.Party;
+import uk.gov.hmcts.reform.civil.model.PartyFlagStructure;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.service.UserService;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentDownloadService;
-import uk.gov.hmcts.reform.civil.utils.PartyUtils;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 
 /**
  * Read-only reporting migration task.
  *
- * <p>Hearing notice party names are rendered from CCD CaseData at generation time
- * ({@code HearingNoticeHmcGenerator}), so with CCD as the source of truth a notice is
- * correct if its printed names still match the current case. This task downloads each
- * HMC hearing notice PDF from CDAM and checks that the current CCD claimant/defendant
- * names appear in the document text. A notice whose text no longer contains a current
- * name is a stale notice that should be reissued.</p>
+ * <p>A hearing notice is built from two sources: the claimant/defendant header comes from CCD
+ * CaseData, but the "Attending in person / by telephone / by video" section is built from the HMC
+ * hearing party details ({@code HmcDataUtils.getInPersonAttendeeNames}). When an HMC hearing is
+ * linked to the wrong party, the notice header can be correct while the attendee section names
+ * someone from a different case.</p>
  *
- * <p>The task makes no changes to CaseData; it returns the case unchanged and emits one
- * structured log line per notice document (prefix {@code VERIFY_HEARING_NOTICE}) so
- * results can be filtered from App Insights.</p>
+ * <p>With CCD as the source of truth, this task downloads each hearing notice PDF from CDAM, parses
+ * the attendee section, and flags any attendee who is not a current CCD case participant (party,
+ * litigation friend, expert or witness). It makes no changes to CaseData and emits one structured
+ * log line per notice document (prefix {@code VERIFY_HEARING_NOTICE}) for filtering in App Insights.</p>
  */
 @Component
 @Slf4j
@@ -39,9 +43,16 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
     private static final String LOG_PREFIX = "VERIFY_HEARING_NOTICE";
     private static final String DOWNLOAD_ERROR = "VERIFY_HEARING_NOTICE download failed for case {}";
     private static final String TASK_NAME = "VerifyHearingNoticeNamesTask";
-    private static final String EVENT_SUMMARY = "Verify hearing notice attendee names against CCD";
+    private static final String EVENT_SUMMARY = "Verify hearing notice attendees against CCD parties";
     private static final String EVENT_DESCRIPTION =
-        "Read-only check that generated hearing notices carry the current CCD party names";
+        "Read-only check that hearing notice attendee names belong to the current CCD case participants";
+
+    private static final List<String> ATTENDEE_LABELS = List.of(
+        "attending in person", "attending by telephone", "attending by video");
+    private static final List<String> ATTENDEE_TERMINATORS = List.of(
+        "attending in person", "attending by telephone", "attending by video",
+        "the time allocated for the hearing", "hearing fees");
+    private static final Pattern TITLE_PREFIX = Pattern.compile("^(mr|mrs|ms|miss|mx|dr|prof)\\.?\\s+");
 
     private final DocumentDownloadService documentDownloadService;
     private final UserService userService;
@@ -83,41 +94,44 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
         }
 
         String caseId = caseReference.getCaseReference();
-        List<String> expectedNames = expectedNames(caseData);
+        Set<String> participants = participantNames(caseData);
         List<CaseDocument> notices = hearingNoticeDocuments(caseData);
 
         if (notices.isEmpty()) {
-            log.info("{} case={} result=NO_NOTICE expectedNames={}", LOG_PREFIX, caseId, expectedNames);
+            log.info("{} case={} result=NO_NOTICE participants={}", LOG_PREFIX, caseId, participants);
             return caseData;
         }
 
         String authorisation = getSystemUserToken();
 
         for (CaseDocument notice : notices) {
-            verifyNotice(caseData, caseId, notice, expectedNames, authorisation);
+            verifyNotice(caseId, notice, participants, authorisation);
         }
 
         return caseData;
     }
 
-    private void verifyNotice(CaseData caseData, String caseId, CaseDocument notice,
-                              List<String> expectedNames, String authorisation) {
+    private void verifyNotice(String caseId, CaseDocument notice, Set<String> participants, String authorisation) {
         String fileName = notice.getDocumentLink() != null ? notice.getDocumentLink().getDocumentFileName() : null;
         try {
-            byte[] content = documentDownloadService.downloadDocument(
-                notice, authorisation, caseId, DOWNLOAD_ERROR);
-            String noticeText = normalise(extractText(content));
+            byte[] content = documentDownloadService.downloadDocument(notice, authorisation, caseId, DOWNLOAD_ERROR);
+            List<String> attendees = extractAttendees(extractText(content));
 
-            List<String> missing = new ArrayList<>();
-            for (String name : expectedNames) {
-                if (!noticeText.contains(normalise(name))) {
-                    missing.add(name);
+            if (attendees.isEmpty()) {
+                log.info("{} case={} document=\"{}\" result=NO_ATTENDEES", LOG_PREFIX, caseId, fileName);
+                return;
+            }
+
+            List<String> foreign = new ArrayList<>();
+            for (String attendee : attendees) {
+                if (!participants.contains(normalise(attendee))) {
+                    foreign.add(attendee);
                 }
             }
 
-            String result = missing.isEmpty() ? "MATCH" : "STALE";
-            log.info("{} case={} document=\"{}\" result={} expectedNames={} missingNames={}",
-                     LOG_PREFIX, caseId, fileName, result, expectedNames, missing);
+            String result = foreign.isEmpty() ? "OK" : "INCORRECT_ATTENDEE";
+            log.info("{} case={} document=\"{}\" result={} attendees={} foreignAttendees={} participants={}",
+                     LOG_PREFIX, caseId, fileName, result, attendees, foreign, participants);
         } catch (Exception e) {
             log.error("{} case={} document=\"{}\" result=ERROR message={}",
                       LOG_PREFIX, caseId, fileName, e.getMessage(), e);
@@ -126,45 +140,106 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
 
     private List<CaseDocument> hearingNoticeDocuments(CaseData caseData) {
         List<CaseDocument> documents = new ArrayList<>();
-        addAll(documents, caseData.getHearingDocuments());
-        addAll(documents, caseData.getHearingDocumentsWelsh());
+        addDocuments(documents, caseData.getHearingDocuments());
+        addDocuments(documents, caseData.getHearingDocumentsWelsh());
         return documents;
     }
 
-    private void addAll(List<CaseDocument> target, List<Element<CaseDocument>> source) {
+    private void addDocuments(List<CaseDocument> target, List<Element<CaseDocument>> source) {
         if (source != null) {
             source.stream()
-                .filter(nonNullElement -> nonNullElement != null && nonNullElement.getValue() != null)
+                .filter(element -> element != null && element.getValue() != null)
                 .forEach(element -> target.add(element.getValue()));
         }
     }
 
     /**
-     * Builds the party names exactly as {@code HearingNoticeHmcGenerator} renders them onto the notice:
-     * minors are shown with their litigation friend, everyone else by party name.
+     * Extracts the names listed under each "Attending ..." heading, up to the next heading or the
+     * "time allocated" / "hearing fees" line that follows the attendee block.
      */
-    private List<String> expectedNames(CaseData caseData) {
+    List<String> extractAttendees(String text) {
         List<String> names = new ArrayList<>();
-        addName(names, claimantName(caseData.getApplicant1(), caseData.getApplicant1LitigationFriend()));
-        addName(names, claimantName(caseData.getApplicant2(), caseData.getApplicant2LitigationFriend()));
-        addName(names, caseData.getRespondent1() != null ? caseData.getRespondent1().getPartyName() : null);
-        addName(names, caseData.getRespondent2() != null ? caseData.getRespondent2().getPartyName() : null);
+        List<String> lines = new ArrayList<>();
+        for (String raw : text.split("\\R")) {
+            String line = raw.trim();
+            if (!line.isEmpty()) {
+                lines.add(line);
+            }
+        }
+        int i = 0;
+        while (i < lines.size()) {
+            if (startsWithAny(lines.get(i), ATTENDEE_LABELS)) {
+                i++;
+                while (i < lines.size() && !startsWithAny(lines.get(i), ATTENDEE_TERMINATORS)) {
+                    names.add(lines.get(i));
+                    i++;
+                }
+            } else {
+                i++;
+            }
+        }
         return names;
     }
 
-    private String claimantName(Party party, uk.gov.hmcts.reform.civil.model.LitigationFriend litigationFriend) {
-        if (party == null) {
-            return null;
-        }
-        return PartyUtils.isMinor(party)
-            ? PartyUtils.getPartyNameWithLitigiousFriend(party, litigationFriend)
-            : party.getPartyName();
+    private boolean startsWithAny(String line, List<String> prefixes) {
+        String lower = line.toLowerCase();
+        return prefixes.stream().anyMatch(lower::startsWith);
     }
 
-    private void addName(List<String> names, String name) {
-        if (name != null && !name.isBlank()) {
-            names.add(name);
+    /**
+     * Everyone CCD would put on the HMC hearing payload (see {@code HearingsPartyMapper}): parties,
+     * their litigation friends, experts and witnesses. An attendee outside this set is foreign.
+     */
+    Set<String> participantNames(CaseData caseData) {
+        Set<String> names = new HashSet<>();
+        addParty(names, caseData.getApplicant1());
+        addParty(names, caseData.getApplicant2());
+        addParty(names, caseData.getRespondent1());
+        addParty(names, caseData.getRespondent2());
+        addLitigationFriend(names, caseData.getApplicant1LitigationFriend());
+        addLitigationFriend(names, caseData.getApplicant2LitigationFriend());
+        addLitigationFriend(names, caseData.getRespondent1LitigationFriend());
+        addLitigationFriend(names, caseData.getRespondent2LitigationFriend());
+        addFlagStructures(names, caseData.getApplicantExperts());
+        addFlagStructures(names, caseData.getApplicantWitnesses());
+        addFlagStructures(names, caseData.getRespondent1Experts());
+        addFlagStructures(names, caseData.getRespondent1Witnesses());
+        addFlagStructures(names, caseData.getRespondent2Experts());
+        addFlagStructures(names, caseData.getRespondent2Witnesses());
+        return names;
+    }
+
+    private void addParty(Set<String> names, Party party) {
+        if (party != null) {
+            add(names, party.getPartyName());
+            add(names, joinName(party.getIndividualFirstName(), party.getIndividualLastName()));
         }
+    }
+
+    private void addLitigationFriend(Set<String> names, LitigationFriend litigationFriend) {
+        if (litigationFriend != null) {
+            add(names, joinName(litigationFriend.getFirstName(), litigationFriend.getLastName()));
+        }
+    }
+
+    private void addFlagStructures(Set<String> names, List<Element<PartyFlagStructure>> people) {
+        if (people != null) {
+            people.stream()
+                .filter(element -> element != null && element.getValue() != null)
+                .map(Element::getValue)
+                .forEach(person -> add(names, joinName(person.getFirstName(), person.getLastName())));
+        }
+    }
+
+    private void add(Set<String> names, String name) {
+        String normalised = normalise(name);
+        if (!normalised.isEmpty()) {
+            names.add(normalised);
+        }
+    }
+
+    private String joinName(String first, String last) {
+        return ((first == null ? "" : first) + " " + (last == null ? "" : last)).trim();
     }
 
     private String extractText(byte[] content) throws java.io.IOException {
@@ -177,7 +252,8 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
         if (value == null) {
             return "";
         }
-        return value.toLowerCase().replaceAll("\\s+", " ").trim();
+        String lower = value.toLowerCase().replaceAll("\\s+", " ").trim();
+        return TITLE_PREFIX.matcher(lower).replaceFirst("");
     }
 
     private String getSystemUserToken() {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
@@ -17,10 +17,13 @@ import uk.gov.hmcts.reform.civil.service.UserService;
 import uk.gov.hmcts.reform.civil.service.documentmanagement.DocumentDownloadService;
 
 import java.io.ByteArrayOutputStream;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -38,9 +41,10 @@ class VerifyHearingNoticeNamesTaskTest {
     private VerifyHearingNoticeNamesTask task;
 
     private final Party claimant = new Party()
-        .setType(Party.Type.INDIVIDUAL).setIndividualFirstName("John").setIndividualLastName("Smith");
+        .setType(Party.Type.INDIVIDUAL).setIndividualTitle("Mr")
+        .setIndividualFirstName("Aslesh").setIndividualLastName("Narra");
     private final Party defendant = new Party()
-        .setType(Party.Type.INDIVIDUAL).setIndividualFirstName("Jane").setIndividualLastName("Doe");
+        .setType(Party.Type.ORGANISATION).setOrganisationName("IQUW Syndicate Management Limited");
 
     @BeforeEach
     void setUp() {
@@ -55,30 +59,31 @@ class VerifyHearingNoticeNamesTaskTest {
     }
 
     @Test
-    void shouldReportMatch_whenNoticeContainsCurrentNames() throws Exception {
-        byte[] pdf = pdfContaining(claimant.getPartyName() + " v " + defendant.getPartyName());
+    void shouldReportOk_whenAttendeeIsACurrentParty() throws Exception {
+        // notice attendee matches the CCD claimant (title-insensitive)
+        byte[] pdf = noticeWithAttendee("Aslesh Narra");
         when(documentDownloadService.downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString()))
             .thenReturn(pdf);
         CaseData caseData = caseWithNotice();
 
-        CaseData result = task.migrateCaseData(caseData, caseReference("123"));
+        CaseData result = task.migrateCaseData(caseData, caseReference("1732030337525703"));
 
         assertEquals(caseData, result, "task must return the case unchanged");
         verify(documentDownloadService, times(1))
             .downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString());
-        verify(userService, times(1)).getAccessToken("system-user", "pass");
     }
 
     @Test
-    void shouldReportStale_whenNoticeMissesACurrentName() throws Exception {
-        byte[] pdf = pdfContaining("Old Claimant v Jane Doe");
+    void shouldFlagIncorrectAttendee_whenNoticeNamesSomeoneFromAnotherCase() throws Exception {
+        // the real defect: header is the CCD parties but the attendee is a foreign name
+        byte[] pdf = noticeWithAttendee("Charlie Sansom");
         when(documentDownloadService.downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString()))
             .thenReturn(pdf);
         CaseData caseData = caseWithNotice();
 
-        CaseData result = task.migrateCaseData(caseData, caseReference("123"));
+        CaseData result = task.migrateCaseData(caseData, caseReference("1732030337525703"));
 
-        assertEquals(caseData, result, "task must not mutate the case even when the notice is stale");
+        assertEquals(caseData, result, "task must not mutate the case even when an attendee is wrong");
         verify(documentDownloadService, times(1))
             .downloadDocument(any(CaseDocument.class), anyString(), anyString(), anyString());
     }
@@ -115,6 +120,27 @@ class VerifyHearingNoticeNamesTaskTest {
         assertEquals("CaseData and CaseReference must not be null", exception.getMessage());
     }
 
+    @Test
+    void extractAttendees_pullsNamesUnderTheAttendingHeadings() {
+        String text = String.join("\n",
+            "in person",
+            "Attending in person",
+            "Charlie Sansom",
+            "The time allocated for the hearing is 1 hour and 30 minutes.");
+
+        assertEquals(List.of("Charlie Sansom"), task.extractAttendees(text));
+    }
+
+    @Test
+    void participantNames_coversPartiesTitleStripped_butNotAForeignName() {
+        var participants = task.participantNames(caseWithNotice());
+
+        assertTrue(participants.contains("aslesh narra"), "claimant individual name, title stripped");
+        assertTrue(participants.contains("mr aslesh narra".replaceFirst("^mr ", "")));
+        assertTrue(participants.contains("iquw syndicate management limited"), "defendant org name");
+        assertFalse(participants.contains("charlie sansom"), "a foreign name must not be a participant");
+    }
+
     private CaseData caseWithNotice() {
         CaseDocument notice = new CaseDocument()
             .setDocumentLink(new Document(
@@ -133,15 +159,28 @@ class VerifyHearingNoticeNamesTaskTest {
         return caseReference;
     }
 
-    private byte[] pdfContaining(String text) throws Exception {
+    private byte[] noticeWithAttendee(String attendee) throws Exception {
+        List<String> lines = List.of(
+            "Notice of Hearing",
+            "Mr Aslesh Narra 1st Claimant",
+            "IQUW Syndicate Management Limited 1st Defendant",
+            "in person",
+            "Attending in person",
+            attendee,
+            "The time allocated for the hearing is 1 hour and 30 minutes.",
+            "Hearing fees");
         try (PDDocument document = new PDDocument()) {
             PDPage page = new PDPage();
             document.addPage(page);
             try (PDPageContentStream stream = new PDPageContentStream(document, page)) {
+                stream.setLeading(16);
                 stream.beginText();
-                stream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
-                stream.newLineAtOffset(50, 700);
-                stream.showText(text);
+                stream.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 11);
+                stream.newLineAtOffset(50, 750);
+                for (String line : lines) {
+                    stream.showText(line);
+                    stream.newLine();
+                }
                 stream.endText();
             }
             ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5905

### Change description ###

Follow-up to #8161. Corrects what the verification task checks.

**Why**

A hearing notice is built from two sources: the claimant/defendant header comes from CCD CaseData, but the "Attending in person / by telephone / by video" section is built from the HMC hearing party details (`HmcDataUtils.getInPersonAttendeeNames` -> `hearing.getPartyDetails()`). When an HMC hearing is linked to the wrong party, the header can be correct while the attendee names someone from a different case.

A real example (case `1732030337525703`): the notice header correctly shows the CCD parties (`Mr Aslesh Narra` v `IQUW Syndicate Management Limited`), but the "Attending in person" line shows `Charlie Sansom` - a party from the mismatched HMC hearing. The original "are the CCD party names present in the notice?" check returned a false MATCH for exactly this case, because the CCD names *are* present (in the header); the wrong name is an *extra* attendee, not a missing party.

**What**

- Parse the attendee section from the notice PDF (the names under each "Attending ..." heading, up to the next heading or the "time allocated"/"hearing fees" line).
- Build the set of current CCD case participants exactly as `HearingsPartyMapper` does (parties, litigation friends, experts, witnesses), title-insensitive.
- Flag any attendee who is not a participant: `result=INCORRECT_ATTENDEE foreignAttendees=[...]`. `OK` when all attendees are participants; `NO_ATTENDEES` / `NO_NOTICE` / `ERROR` otherwise.

Still read-only (no CCD event; uses the `isReadOnly()` path from #8161). App Insights query unchanged: `AppTraces | where Message has "VERIFY_HEARING_NOTICE"` (filter `result=INCORRECT_ATTENDEE`).

**Tests**

- Unit tests: attendee-is-a-party -> OK; foreign attendee -> flagged; no notice; download failure; null reference; plus direct tests of `extractAttendees` and `participantNames`.
- Validated locally against the real incorrect notice PDF: parser returns `[Charlie Sansom]`, participants `[aslesh narra, iquw syndicate management limited]`, foreign `[Charlie Sansom]`. (That test was throwaway - the notice contains personal data and is not committed.)

**Known residual**: a legitimate non-party individual attendee (e.g. a named solicitor) not present in the CCD participant set would be flagged for manual review. Flagged rows are reported to a human, never auto-actioned.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```