### PR TITLE
DTSCCI-5813 Users unable to request a CCJ when an extension is granted and a defendant chooses their language preference as Welsh

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/DefaultJudgementSpecHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/DefaultJudgementSpecHandler.java
@@ -80,7 +80,6 @@ public class DefaultJudgementSpecHandler extends CallbackHandler {
     public static final String BREATHING_SPACE = "Default judgment cannot be applied for while claim is in"
         + " breathing space";
     public static final String PARTIAL_PAYMENT_OFFLINE = "This feature is currently not available, please see guidance below";
-    public static final String DJ_NOT_VALID_FOR_THIS_LIP_CLAIM = "The Claim is not eligible for Default Judgment.";
     private static final List<CaseEvent> EVENTS = List.of(DEFAULT_JUDGEMENT_SPEC);
     private static final int DEFAULT_JUDGEMENT_SPEC_DEADLINE_EXTENSION_MONTHS = 36;
     private static final String CASES_CASE_DETAILS_CLAIM_DOCUMENTS = "/cases/case-details/%s#Claim documents";
@@ -192,9 +191,7 @@ public class DefaultJudgementSpecHandler extends CallbackHandler {
 
         var caseData = callbackParams.getCaseData();
         ArrayList<String> errors = new ArrayList<>();
-        if (caseData.isRespondentResponseBilingual()) {
-            errors.add(DJ_NOT_VALID_FOR_THIS_LIP_CLAIM);
-        } else if (nonNull(caseData.getRespondent1ResponseDeadline())
+        if (nonNull(caseData.getRespondent1ResponseDeadline())
             && caseData.getRespondent1ResponseDeadline().isAfter(LocalDateTime.now())) {
             String formattedDeadline = formatLocalDateTime(caseData.getRespondent1ResponseDeadline(), DATE_TIME_AT);
             errors.add(format(NOT_VALID_DJ, formattedDeadline));

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardClaimMatcher.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdDashboardClaimMatcher.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.List;
@@ -98,7 +99,10 @@ public abstract class CcdDashboardClaimMatcher implements Claim {
 
     public boolean hasResponseDeadlineBeenExtended() {
         return caseData.getRespondent1TimeExtensionDate() != null
-            && caseData.getCcdState() == CaseState.AWAITING_RESPONDENT_ACKNOWLEDGEMENT;
+            && caseData.getCcdState() == CaseState.AWAITING_RESPONDENT_ACKNOWLEDGEMENT
+            && (caseData.getRespondent1ResponseDeadline() == null
+                || !caseData.getRespondent1ResponseDeadline()
+                    .isBefore(LocalDate.now().atTime(LocalTime.of(16, 1))));
     }
 
     protected boolean isDefaultJudgmentGrantedForDashboard() {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/DefaultJudgementSpecHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/DefaultJudgementSpecHandlerTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration;
 import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration;
@@ -188,21 +190,23 @@ public class DefaultJudgementSpecHandlerTest extends BaseCallbackHandlerTest {
                 + "in breathing space");
         }
 
-        @Test
-        void shouldReturnError_WhenAboutToStartInvokeWhenRespondentResponseLanguageIsBilingual() {
+        @ParameterizedTest
+        @ValueSource(strings = {"WELSH", "BOTH"})
+        void shouldNotReturnError_WhenRespondentResponseLanguageIsBilingualAndDeadlinePassed(String responseLanguage) {
             RespondentLiPResponse respondentLiPResponse  = new RespondentLiPResponse();
-            respondentLiPResponse.setRespondent1ResponseLanguage("BOTH");
+            respondentLiPResponse.setRespondent1ResponseLanguage(responseLanguage);
             CaseDataLiP caseDataLiP = new CaseDataLiP();
             caseDataLiP.setRespondent1LiPResponse(respondentLiPResponse);
             CaseData caseData = CaseDataBuilder.builder().atStateClaimDetailsNotified().build();
             caseData.setBreathing(new BreathingSpaceInfo().setLift(null));
             caseData.setCaseDataLiP(caseDataLiP);
+            caseData.setRespondent1ResponseDeadline(LocalDateTime.now().minusDays(1));
 
             CallbackParams params = CallbackParamsBuilder.builder().of(ABOUT_TO_START, caseData).build();
             AboutToStartOrSubmitCallbackResponse response = (AboutToStartOrSubmitCallbackResponse) handler
                 .handle(params);
 
-            assertThat(response.getErrors()).contains("The Claim is not eligible for Default Judgment.");
+            assertThat(response.getErrors()).doesNotContain("The Claim is not eligible for Default Judgment.");
         }
 
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdClaimStatusDashboardFactoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/citizenui/CcdClaimStatusDashboardFactoryTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -47,6 +48,8 @@ import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -297,6 +300,31 @@ class CcdClaimStatusDashboardFactoryTest {
         DashboardClaimStatus status = ccdClaimStatusDashboardFactory.getDashboardClaimStatus(new CcdDashboardDefendantClaimMatcher(
             claim, featureToggleService, Collections.emptyList()));
         assertThat(status).isEqualTo(DashboardClaimStatus.MORE_TIME_REQUESTED);
+    }
+
+    @ParameterizedTest
+    @MethodSource("matchers")
+    void givenExpiredExtendedDeadline_whenGetStatus_thenEligibleForCCJ(
+        Function<CaseData, CcdDashboardClaimMatcher> matcherFactory) {
+
+        CaseData claim = CaseData.builder()
+            .ccdState(CaseState.AWAITING_RESPONDENT_ACKNOWLEDGEMENT)
+            .respondent1ResponseDeadline(LocalDate.now().minusDays(1).atTime(16, 0, 0))
+            .respondent1TimeExtensionDate(LocalDateTime.now().minusDays(10))
+            .build();
+
+        DashboardClaimStatus status =
+            ccdClaimStatusDashboardFactory.getDashboardClaimStatus(matcherFactory.apply(claim));
+
+        assertThat(status).isEqualTo(DashboardClaimStatus.ELIGIBLE_FOR_CCJ);
+    }
+
+    static Stream<Function<CaseData, CcdDashboardClaimMatcher>> matchers() {
+        FeatureToggleService mockFeatureToggleService = Mockito.mock(FeatureToggleService.class);
+        return Stream.of(
+            caseData -> new CcdDashboardDefendantClaimMatcher(caseData, mockFeatureToggleService, Collections.emptyList()),
+            caseData -> new CcdDashboardClaimantClaimMatcher(caseData, mockFeatureToggleService, Collections.emptyList())
+        );
     }
 
     @Test


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5813

### Change description ###
- Removed the default judgment block for Welsh/bilingual defendant response language once the response deadline has passed.
- Changed dashboard status logic so an expired extension no longer shows MORE_TIME_REQUESTED; it can now resolve to ELIGIBLE_FOR_CCJ.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
