### PR TITLE
DTSCCI-5905: Skip notice header boilerplate when parsing hearing notice attendees

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
@@ -53,6 +53,11 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
         "attending in person", "attending by telephone", "attending by video",
         "the time allocated for the hearing", "hearing fees");
     private static final Pattern TITLE_PREFIX = Pattern.compile("^(mr|mrs|ms|miss|mx|dr|prof)\\.?\\s+");
+    // Notice header/venue lines that PDFBox interleaves into the attendee run when the list
+    // spans a page break; skipped so they are not mistaken for foreign attendees.
+    private static final List<String> BOILERPLATE_PREFIXES = List.of(
+        "in the ", "claim reference", "claim number", "reference number",
+        "date ", "at ", "notice of hearing", "the hearing");
 
     private final DocumentDownloadService documentDownloadService;
     private final UserService userService;
@@ -171,7 +176,9 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
             if (startsWithAny(lines.get(i), ATTENDEE_LABELS)) {
                 i++;
                 while (i < lines.size() && !startsWithAny(lines.get(i), ATTENDEE_TERMINATORS)) {
-                    names.add(lines.get(i));
+                    if (!startsWithAny(lines.get(i), BOILERPLATE_PREFIXES)) {
+                        names.add(lines.get(i));
+                    }
                     i++;
                 }
             } else {

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
@@ -132,6 +132,24 @@ class VerifyHearingNoticeNamesTaskTest {
     }
 
     @Test
+    void extractAttendees_skipsNoticeHeaderBoilerplateInterleavedByPageBreaks() {
+        // reproduces the AAT case: a long attendee list crosses a page break, so PDFBox
+        // interleaves the repeated notice header (court / claim / date) into the run.
+        String text = String.join("\n",
+            "Attending in person",
+            "Claimant1 Individual",
+            "In the county court at Central London",
+            "Claim reference 1782920322477820",
+            "Claim number 008KA010",
+            "Date 07 July 2026",
+            "Defendant2Witness2 Witness",
+            "The time allocated for the hearing is 1 hour.");
+
+        assertEquals(List.of("Claimant1 Individual", "Defendant2Witness2 Witness"),
+                     task.extractAttendees(text));
+    }
+
+    @Test
     void participantNames_coversPartiesTitleStripped_butNotAForeignName() {
         var participants = task.participantNames(caseWithNotice());
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5905

### Change description ###

Follow-up to #8161 / #8162, from AAT testing.

**Why**

Running the attendee check on AAT cases with many attendees produced false `INCORRECT_ATTENDEE` results. The `foreignAttendees` were not people but notice **header** lines:

```
foreignAttendees=[In the county court at Central London, Claim reference 1782920322477820, Claim number 008KA010, Date 07 July 2026]
```

When the "Attending ..." list is long enough to cross a page break, PDFBox emits the repeated page header (court / claim reference / claim number / date) in reading order inside the attendee run, so `extractAttendees` swept those lines in as names.

**What**

- Skip captured lines that start with a known header prefix (`in the`, `claim reference`, `claim number`, `reference number`, `date`, `at`, `notice of hearing`, `the hearing`) while continuing to collect the real names and still stopping at the section terminator.
- A digit-based filter was rejected: valid attendee names in test data (`Claimant1 Individual`, `Defendant2Witness2 Witness`) contain digits.

Verified on AAT before this fix: `OK` for the two short notices, false `INCORRECT_ATTENDEE` for the two multi-page notices. This change makes those two `OK`.

**Tests**

- New unit test reproduces the interleaved-header case and asserts only the real names survive. Full suite for the task: 8 passing, checkstyle clean.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```