### PR TITLE
DTSCCI-5905: Terminate attendee parsing on Notice of Trial documents

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
@@ -51,7 +51,9 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
         "attending in person", "attending by telephone", "attending by video");
     private static final List<String> ATTENDEE_TERMINATORS = List.of(
         "attending in person", "attending by telephone", "attending by video",
-        "the time allocated for the hearing", "hearing fees");
+        // "the time allocated for the {hearing|trial}" ends the attendee block on both
+        // Notice of Hearing and Notice of Trial templates
+        "the time allocated for the", "hearing fees", "trial fees");
     private static final Pattern TITLE_PREFIX = Pattern.compile("^(mr|mrs|ms|miss|mx|dr|prof)\\.?\\s+");
     // Notice header/venue lines that PDFBox interleaves into the attendee run when the list
     // spans a page break; skipped so they are not mistaken for foreign attendees.

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
@@ -150,6 +150,22 @@ class VerifyHearingNoticeNamesTaskTest {
     }
 
     @Test
+    void extractAttendees_stopsAtTheTrialTerminatorOnNoticeOfTrial() {
+        // Notice of Trial says "trial" not "hearing"; without a generalised terminator the
+        // parser runs off the end of the attendee list and sweeps in the whole document body.
+        String text = String.join("\n",
+            "Attending in person",
+            "John Doe",
+            "Jane Doe",
+            "The time allocated for the trial is 1 hour.",
+            "The court usually doesn't hear cases between 1pm and 2pm each day.",
+            "Trial fees",
+            "The trial fee is 619 which must be paid by 30 March 2026.");
+
+        assertEquals(List.of("John Doe", "Jane Doe"), task.extractAttendees(text));
+    }
+
+    @Test
     void participantNames_coversPartiesTitleStripped_butNotAForeignName() {
         var participants = task.participantNames(caseWithNotice());
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5905

### Change description ###

Follow-up from AAT testing (after #8167).

**Why**

Two AAT cases came back as false `INCORRECT_ATTENDEE` where the whole notice body was reported as foreign attendees. They are **Notice of Trial** documents, which say "trial" where a Notice of Hearing says "hearing". The attendee-block terminator only matched `the time allocated for the hearing` / `hearing fees`, so on a trial notice the parser never stopped and collected every paragraph after the attendee list.

Example (`1774537461281555`): real attendees `John Doe, Jane Doe` matched, then `The time allocated for the trial is 1 hour.` and the rest of the document were swept in.

**What**

- Generalise the terminator from `the time allocated for the hearing` to `the time allocated for the` (matches both hearing and trial).
- Add `trial fees` alongside `hearing fees`.

Verified on the AAT run: the two trial cases had all real attendees matched; only the trailing body was foreign, so this makes them `OK`.

**Tests**

- New unit test covers the Notice of Trial wording. Task suite: 9 passing, checkstyle clean.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```