### PR TITLE
DTSCCI-5695 Fix GA document upload notification missing template fields

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/ga/service/DocUploadNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/ga/service/DocUploadNotificationService.java
@@ -3,24 +3,31 @@ package uk.gov.hmcts.reform.civil.ga.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
 import uk.gov.hmcts.reform.civil.ga.handler.callback.camunda.notification.NotificationDataGA;
 import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
+import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.model.common.Element;
 import uk.gov.hmcts.reform.civil.notify.NotificationException;
 import uk.gov.hmcts.reform.civil.notify.NotificationService;
 import uk.gov.hmcts.reform.civil.notify.NotificationsSignatureConfiguration;
 import uk.gov.hmcts.reform.civil.notify.NotificationsProperties;
-import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
-import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
+import uk.gov.hmcts.reform.civil.prd.model.Organisation;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
+import uk.gov.hmcts.reform.civil.service.FeatureToggleService;
+import uk.gov.hmcts.reform.civil.service.OrganisationService;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Objects.nonNull;
 import static uk.gov.hmcts.reform.civil.enums.YesOrNo.NO;
 import static uk.gov.hmcts.reform.civil.ga.utils.EmailFooterUtils.addAllFooterItems;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.CASEMAN_REF;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.UPLOADED_DOCUMENTS;
 
 @Slf4j
 @Service
@@ -31,12 +38,13 @@ public class DocUploadNotificationService implements NotificationDataGA {
     private final NotificationsProperties notificationProperties;
     private static final String REFERENCE_TEMPLATE_DOC_UPLOAD = "general-apps-notice-of-document-upload-%s";
     private static final String EMPTY_SOLICITOR_REFERENCES_1V1 = "Claimant Reference: Not provided - Defendant Reference: Not provided";
+    private static final String NOT_PROVIDED = "Not provided";
     private final GaForLipService gaForLipService;
-    private final Map<String, String> customProps = new HashMap<>();
     private final CoreCaseDataService coreCaseDataService;
     private final CaseDetailsConverter caseDetailsConverter;
     private final FeatureToggleService featureToggleService;
     private final NotificationsSignatureConfiguration configuration;
+    private final OrganisationService organisationService;
 
     public void notifyApplicantEvidenceUpload(GeneralApplicationCaseData caseData) throws NotificationException {
         log.info("Starting applicant evidence upload notification for Case ID: {}", caseData.getCcdCaseReference());
@@ -48,7 +56,9 @@ public class DocUploadNotificationService implements NotificationDataGA {
                     email,
                     gaForLipService.isLipApp(caseData) ? getLiPApplicantTemplate(caseData)
                         : notificationProperties.getEvidenceUploadTemplate(),
-                    addProperties(caseData, civilCaseData),
+                    addProperties(caseData, civilCaseData, getLegalOrganisationName(
+                        caseData.getGeneralAppApplnSolicitor().getOrganisationIdentifier()
+                    )),
                     format(
                             REFERENCE_TEMPLATE_DOC_UPLOAD,
                             caseData.getCcdCaseReference()
@@ -71,7 +81,9 @@ public class DocUploadNotificationService implements NotificationDataGA {
                             gaForLipService.isLipResp(caseData)
                                 ? getLiPRespondentTemplate(caseData)
                                 : notificationProperties.getEvidenceUploadTemplate(),
-                            addProperties(caseData, civilCaseData),
+                            addProperties(caseData, civilCaseData, getLegalOrganisationName(
+                                respondentSolicitor.getValue().getOrganisationIdentifier()
+                            )),
                             format(
                                     REFERENCE_TEMPLATE_DOC_UPLOAD,
                                     caseData.getCcdCaseReference()
@@ -94,6 +106,15 @@ public class DocUploadNotificationService implements NotificationDataGA {
 
     @Override
     public Map<String, String> addProperties(GeneralApplicationCaseData caseData, GeneralApplicationCaseData mainCaseData) {
+        return addProperties(caseData, mainCaseData, getLegalOrganisationName(
+            caseData.getGeneralAppApplnSolicitor().getOrganisationIdentifier()
+        ));
+    }
+
+    private Map<String, String> addProperties(GeneralApplicationCaseData caseData,
+                                              GeneralApplicationCaseData mainCaseData,
+                                              String legalOrganisationName) {
+        Map<String, String> customProps = new HashMap<>();
 
         if (gaForLipService.isGaForLip(caseData)) {
             String caseTitle = getAllPartyNames(caseData);
@@ -124,6 +145,9 @@ public class DocUploadNotificationService implements NotificationDataGA {
         customProps.put(PARTY_REFERENCE,
                         Objects.requireNonNull(getSolicitorReferences(caseData.getEmailPartyReference())));
         customProps.put(GENAPP_REFERENCE, String.valueOf(Objects.requireNonNull(caseData.getCcdCaseReference())));
+        customProps.put(CASEMAN_REF, Objects.requireNonNullElse(mainCaseData.getLegacyCaseReference(), NOT_PROVIDED));
+        customProps.put(CLAIM_LEGAL_ORG_NAME_SPEC, legalOrganisationName);
+        customProps.put(UPLOADED_DOCUMENTS, getUploadedDocuments(caseData));
         addAllFooterItems(caseData, mainCaseData, customProps, configuration,
                            featureToggleService.isPublicQueryManagementEnabledGa(caseData));
         return customProps;
@@ -145,6 +169,30 @@ public class DocUploadNotificationService implements NotificationDataGA {
         } else {
             return EMPTY_SOLICITOR_REFERENCES_1V1;
         }
+    }
+
+    private String getLegalOrganisationName(String organisationIdentifier) {
+        if (organisationIdentifier != null) {
+            return organisationService.findOrganisationById(organisationIdentifier)
+                .map(Organisation::getName)
+                .orElse(NOT_PROVIDED);
+        }
+        return NOT_PROVIDED;
+    }
+
+    private String getUploadedDocuments(GeneralApplicationCaseData caseData) {
+        if (caseData.getGaAddlDoc() == null || caseData.getGaAddlDoc().isEmpty()) {
+            return NOT_PROVIDED;
+        }
+
+        String uploadedDocuments = caseData.getGaAddlDoc().stream()
+            .map(Element::getValue)
+            .filter(Objects::nonNull)
+            .map(CaseDocument::getDocumentName)
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining("\n"));
+
+        return uploadedDocuments.isEmpty() ? NOT_PROVIDED : uploadedDocuments;
     }
 
     public String getSurname(GeneralApplicationCaseData caseData) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/ga/service/DocUploadNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/ga/service/DocUploadNotificationServiceTest.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -269,6 +270,58 @@ public class DocUploadNotificationServiceTest {
                 getNotificationDataMapForLip(NO, YES),
                 "general-apps-notice-of-document-upload-" + CASE_REFERENCE
             );
+        }
+
+        @Test
+        void shouldUseNotProvidedWhenApplicantOrganisationIdentifierIsMissing() {
+            GeneralApplicationCaseData caseData = getCaseData(true, NO, NO).copy()
+                .generalAppApplnSolicitor(new GASolicitorDetailsGAspec().setId("id").setEmail(DUMMY_EMAIL))
+                .build();
+
+            Map<String, String> properties = docUploadNotificationService.addProperties(caseData, parentCaseData());
+
+            assertThat(properties)
+                .containsEntry(NotificationDataGA.CLAIM_LEGAL_ORG_NAME_SPEC, "Not provided")
+                .containsEntry(NotificationData.UPLOADED_DOCUMENTS, UPLOADED_DOCUMENT_NAMES);
+        }
+
+        @Test
+        void shouldUseNotProvidedWhenApplicantOrganisationCannotBeFound() {
+            GeneralApplicationCaseData caseData = getCaseData(true, NO, NO).copy()
+                .generalAppApplnSolicitor(new GASolicitorDetailsGAspec().setId("id")
+                                              .setEmail(DUMMY_EMAIL).setOrganisationIdentifier("missing-org"))
+                .build();
+            when(organisationService.findOrganisationById("missing-org")).thenReturn(Optional.empty());
+
+            Map<String, String> properties = docUploadNotificationService.addProperties(caseData, parentCaseData());
+
+            assertThat(properties).containsEntry(NotificationDataGA.CLAIM_LEGAL_ORG_NAME_SPEC, "Not provided");
+        }
+
+        @Test
+        void shouldUseNotProvidedWhenCaseHasNoUploadedDocumentsOrLegacyReference() {
+            GeneralApplicationCaseData caseData = getCaseData(true, NO, NO).gaAddlDoc(null);
+            GeneralApplicationCaseData mainCaseData = new GeneralApplicationCaseData()
+                .ccdState(CaseState.CASE_PROGRESSION)
+                .build();
+
+            Map<String, String> properties = docUploadNotificationService.addProperties(caseData, mainCaseData);
+
+            assertThat(properties)
+                .containsEntry(NotificationData.CASEMAN_REF, "Not provided")
+                .containsEntry(NotificationData.UPLOADED_DOCUMENTS, "Not provided");
+        }
+
+        @Test
+        void shouldUseNotProvidedWhenUploadedDocumentsHaveNoNames() {
+            GeneralApplicationCaseData caseData = getCaseData(true, NO, NO).gaAddlDoc(List.of(
+                element(new CaseDocument()),
+                new Element<>()
+            ));
+
+            Map<String, String> properties = docUploadNotificationService.addProperties(caseData, parentCaseData());
+
+            assertThat(properties).containsEntry(NotificationData.UPLOADED_DOCUMENTS, "Not provided");
         }
 
         private Map<String, String> getNotificationDataMapForLip(YesOrNo isLipAppln, YesOrNo isLipRespondent) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/ga/service/DocUploadNotificationServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/ga/service/DocUploadNotificationServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.hmcts.reform.ccd.model.Organisation;
 import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.CaseDocument;
 import uk.gov.hmcts.reform.civil.ga.handler.callback.camunda.notification.NotificationDataGA;
 import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.notify.NotificationService;
@@ -30,6 +31,7 @@ import uk.gov.hmcts.reform.civil.model.genapplication.GARespondentOrderAgreement
 import uk.gov.hmcts.reform.civil.model.genapplication.GASolicitorDetailsGAspec;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAUrgencyRequirement;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
+import uk.gov.hmcts.reform.civil.service.OrganisationService;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -38,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -74,13 +77,18 @@ public class DocUploadNotificationServiceTest {
     @Mock
     private NotificationsSignatureConfiguration configuration;
 
+    @Mock
+    private OrganisationService organisationService;
+
     private static final Long CASE_REFERENCE = 111111L;
     private static final String PROCESS_INSTANCE_ID = "1";
     private static final String DUMMY_EMAIL = "hmcts.civil@gmail.com";
     private static final String PARTY_REFERENCE = "Claimant Reference: Not provided - Defendant Reference: Not provided";
     private static final String CUSTOM_PARTY_REFERENCE = "Claimant Reference: ABC Ltd - Defendant Reference: Defendant Ltd";
-
-    private final Map<String, String> customProp = new HashMap<>();
+    private static final String LEGACY_CASE_REFERENCE = "000MC001";
+    private static final String APPLICANT_ORG_NAME = "Applicant Organisation";
+    private static final String RESPONDENT_ORG_NAME = "Respondent Organisation";
+    private static final String UPLOADED_DOCUMENT_NAMES = "applicant evidence.pdf\nrespondent evidence.pdf";
 
     @Nested
     class AboutToSubmitCallback {
@@ -97,6 +105,18 @@ public class DocUploadNotificationServiceTest {
             when(configuration.getWelshPhoneContact()).thenReturn("Ffôn: 0300 303 5174");
             when(configuration.getWelshOpeningHours()).thenReturn(
                 "Dydd Llun i ddydd Iau, 9am – 5pm, dydd Gwener, 9am – 4.30pm");
+            lenient().when(organisationService.findOrganisationById("1"))
+                .thenReturn(Optional.of(
+                    new uk.gov.hmcts.reform.civil.prd.model.Organisation().setName(APPLICANT_ORG_NAME)
+                ));
+            lenient().when(organisationService.findOrganisationById("2"))
+                .thenReturn(Optional.of(
+                    new uk.gov.hmcts.reform.civil.prd.model.Organisation().setName(RESPONDENT_ORG_NAME)
+                ));
+            lenient().when(organisationService.findOrganisationById("3"))
+                .thenReturn(Optional.of(
+                    new uk.gov.hmcts.reform.civil.prd.model.Organisation().setName(RESPONDENT_ORG_NAME)
+                ));
         }
 
         @Test
@@ -104,8 +124,7 @@ public class DocUploadNotificationServiceTest {
             when(notificationsProperties.getEvidenceUploadTemplate())
                 .thenReturn("general-apps-notice-of-document-template-id");
             GeneralApplicationCaseData caseData = getCaseData(true, NO, NO);
-            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(new GeneralApplicationCaseData().ccdState(
-                CaseState.CASE_PROGRESSION).build());
+            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(parentCaseData());
             docUploadNotificationService.notifyApplicantEvidenceUpload(caseData);
             verify(notificationService, times(1)).sendMail(
                 DUMMY_EMAIL,
@@ -120,8 +139,7 @@ public class DocUploadNotificationServiceTest {
             when(notificationsProperties.getEvidenceUploadTemplate())
                 .thenReturn("general-apps-notice-of-document-template-id");
             GeneralApplicationCaseData caseData = getCaseData(false, NO, NO);
-            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(new GeneralApplicationCaseData().ccdState(
-                CaseState.CASE_PROGRESSION).build());
+            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(parentCaseData());
             docUploadNotificationService.notifyApplicantEvidenceUpload(caseData);
             verify(notificationService, times(1)).sendMail(
                 DUMMY_EMAIL,
@@ -135,8 +153,7 @@ public class DocUploadNotificationServiceTest {
         void respNotificationShouldSendTwice1V2() {
             when(notificationsProperties.getEvidenceUploadTemplate())
                 .thenReturn("general-apps-notice-of-document-template-id");
-            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(new GeneralApplicationCaseData().ccdState(
-                CaseState.CASE_PROGRESSION).build());
+            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(parentCaseData());
             when(configuration.getSpecUnspecContact()).thenReturn(
                 "Email for Specified Claims: contactocmc@justice.gov.uk "
                     + "\n Email for Damages Claims: damagesclaims@justice.gov.uk");
@@ -160,7 +177,7 @@ public class DocUploadNotificationServiceTest {
             when(gaForLipService.isGaForLip(any())).thenReturn(true);
             when(gaForLipService.isLipApp(any())).thenReturn(true);
             GeneralApplicationCaseData caseData = getCaseData(true, YES, NO);
-            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(new GeneralApplicationCaseData().build());
+            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(parentCaseData());
             docUploadNotificationService.notifyApplicantEvidenceUpload(caseData);
             verify(notificationService, times(1)).sendMail(
                 DUMMY_EMAIL,
@@ -183,7 +200,8 @@ public class DocUploadNotificationServiceTest {
                 getCaseData(true, YES, NO).copy().applicantBilingualLanguagePreference(YES).build();
             GeneralApplicationCaseData claimantClaimIssueFlag = new GeneralApplicationCaseData().applicantBilingualLanguagePreference(
                     YES)
-                .claimantBilingualLanguagePreference("WELSH").build();
+                .claimantBilingualLanguagePreference("WELSH")
+                .legacyCaseReference(LEGACY_CASE_REFERENCE).build();
             when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(claimantClaimIssueFlag);
             docUploadNotificationService.notifyApplicantEvidenceUpload(caseData);
             verify(notificationService, times(1)).sendMail(
@@ -212,7 +230,7 @@ public class DocUploadNotificationServiceTest {
 
             GeneralApplicationCaseData caseData = getCaseData(true, NO, YES).copy()
                 .generalAppRespondentSolicitors(respondentSols).build();
-            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(new GeneralApplicationCaseData().build());
+            when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(parentCaseData());
             docUploadNotificationService.notifyRespondentEvidenceUpload(caseData);
             verify(notificationService, times(1)).sendMail(
                 DUMMY_EMAIL,
@@ -241,7 +259,8 @@ public class DocUploadNotificationServiceTest {
             GeneralApplicationCaseData caseData = getCaseData(true, NO, YES).copy()
                 .generalAppRespondentSolicitors(respondentSols).respondentBilingualLanguagePreference(YES).build();
             GeneralApplicationCaseData claimantClaimIssueFlag = new GeneralApplicationCaseData().respondentBilingualLanguagePreference(YES)
-                .respondent1LiPResponse(new RespondentLiPResponse().setRespondent1ResponseLanguage(Language.BOTH.toString())).build();
+                .respondent1LiPResponse(new RespondentLiPResponse().setRespondent1ResponseLanguage(Language.BOTH.toString()))
+                .legacyCaseReference(LEGACY_CASE_REFERENCE).build();
             when(caseDetailsConverter.toGeneralApplicationCaseData(any())).thenReturn(claimantClaimIssueFlag);
             docUploadNotificationService.notifyRespondentEvidenceUpload(caseData);
             verify(notificationService, times(1)).sendMail(
@@ -254,10 +273,17 @@ public class DocUploadNotificationServiceTest {
 
         private Map<String, String> getNotificationDataMapForLip(YesOrNo isLipAppln, YesOrNo isLipRespondent) {
 
+            Map<String, String> customProp = new HashMap<>();
             customProp.put(NotificationDataGA.CASE_REFERENCE, CASE_REFERENCE.toString());
             customProp.put(NotificationDataGA.GENAPP_REFERENCE, CASE_REFERENCE.toString());
             customProp.put(NotificationDataGA.CASE_TITLE, "CL v DEF");
             customProp.put(NotificationDataGA.PARTY_REFERENCE, PARTY_REFERENCE);
+            customProp.put(NotificationData.CASEMAN_REF, LEGACY_CASE_REFERENCE);
+            customProp.put(
+                NotificationDataGA.CLAIM_LEGAL_ORG_NAME_SPEC,
+                isLipRespondent == YES ? RESPONDENT_ORG_NAME : APPLICANT_ORG_NAME
+            );
+            customProp.put(NotificationData.UPLOADED_DOCUMENTS, UPLOADED_DOCUMENT_NAMES);
             customProp.put(NotificationDataGA.WELSH_CONTACT, "E-bost: ymholiadaucymraeg@justice.gov.uk");
             customProp.put(
                 NotificationDataGA.WELSH_HMCTS_SIGNATURE,
@@ -302,6 +328,12 @@ public class DocUploadNotificationServiceTest {
                 properties.put(NotificationDataGA.PARTY_REFERENCE, PARTY_REFERENCE);
             }
             properties.put(NotificationDataGA.WELSH_CONTACT, "E-bost: ymholiadaucymraeg@justice.gov.uk");
+            properties.put(NotificationData.CASEMAN_REF, LEGACY_CASE_REFERENCE);
+            properties.put(
+                NotificationDataGA.CLAIM_LEGAL_ORG_NAME_SPEC,
+                isLipCase ? RESPONDENT_ORG_NAME : APPLICANT_ORG_NAME
+            );
+            properties.put(NotificationData.UPLOADED_DOCUMENTS, UPLOADED_DOCUMENT_NAMES);
             properties.put(
                 NotificationDataGA.WELSH_HMCTS_SIGNATURE,
                 "Hawliadau am Arian yn y Llys Sifil Ar-lein \n Gwasanaeth Llysoedd a Thribiwnlysoedd EF"
@@ -329,6 +361,13 @@ public class DocUploadNotificationServiceTest {
             return properties;
         }
 
+        private GeneralApplicationCaseData parentCaseData() {
+            return new GeneralApplicationCaseData()
+                .ccdState(CaseState.CASE_PROGRESSION)
+                .legacyCaseReference(LEGACY_CASE_REFERENCE)
+                .build();
+        }
+
         private GeneralApplicationCaseData getCaseData(boolean isMet, YesOrNo isGaApplicantLip, YesOrNo isGaRespondentOneLip) {
 
             List<Element<GASolicitorDetailsGAspec>> respondentSols = new ArrayList<>();
@@ -344,7 +383,7 @@ public class DocUploadNotificationServiceTest {
 
             if (isMet) {
 
-                return new GeneralApplicationCaseDataBuilder()
+                GeneralApplicationCaseData caseData = new GeneralApplicationCaseDataBuilder()
                     .generalAppApplnSolicitor(new GASolicitorDetailsGAspec().setId("id")
                                                   .setEmail(DUMMY_EMAIL).setOrganisationIdentifier("1"))
                     .generalAppRespondentSolicitors(respondentSols)
@@ -367,8 +406,9 @@ public class DocUploadNotificationServiceTest {
                     .respondent2OrganisationPolicy(new OrganisationPolicy().setOrganisation(new Organisation().setOrganisationID("3")))
                     .ccdCaseReference(CASE_REFERENCE)
                     .build();
+                return caseData.gaAddlDoc(uploadedDocuments());
             } else {
-                return new GeneralApplicationCaseDataBuilder()
+                GeneralApplicationCaseData caseData = new GeneralApplicationCaseDataBuilder()
                     .emailPartyReference("Claimant Reference: ABC Ltd - Defendant Reference: Defendant Ltd")
                     .generalAppApplnSolicitor(new GASolicitorDetailsGAspec().setId("id")
                                                   .setEmail(DUMMY_EMAIL).setOrganisationIdentifier("1"))
@@ -392,7 +432,15 @@ public class DocUploadNotificationServiceTest {
                     .respondent2OrganisationPolicy(new OrganisationPolicy().setOrganisation(new Organisation().setOrganisationID("3")))
                     .ccdCaseReference(CASE_REFERENCE)
                     .build();
+                return caseData.gaAddlDoc(uploadedDocuments());
             }
+        }
+
+        private List<Element<CaseDocument>> uploadedDocuments() {
+            return List.of(
+                element(new CaseDocument().setDocumentName("applicant evidence.pdf")),
+                element(new CaseDocument().setDocumentName("respondent evidence.pdf"))
+            );
         }
     }
 }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5965

### Change description ###

The fix adds the required template fields in DocUploadNotificationService:

  - casemanRef from the parent case legacy reference
  - legalOrgName from PRD organisation lookup
  - uploaded documents from the GA uploaded document collection

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
