### PR TITLE
DTSCCI-6009: migration task to hard-remove orphaned document from doc store

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReference.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReference.java
@@ -1,0 +1,22 @@
+package uk.gov.hmcts.reform.civil.bulkupdate.csv;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@Data
+@EqualsAndHashCode(callSuper = true)
+@JsonPropertyOrder(value = {"caseReference", "documentId"})
+@AllArgsConstructor
+@NoArgsConstructor
+@SuppressWarnings("java:S1700")
+public class DocumentPurgeReference extends CaseReference {
+
+    @JsonProperty
+    private String documentId;
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReference.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReference.java
@@ -22,6 +22,9 @@ public class DocumentPurgeReference extends CaseReference implements ExcelMappab
     @JsonProperty
     private String documentId;
 
+    @JsonProperty
+    private String incidentId;
+
     @Override
     public void fromExcelRow(Map<String, Object> rowValues) throws Exception {
         if (rowValues.containsKey("caseReference")) {
@@ -29,6 +32,9 @@ public class DocumentPurgeReference extends CaseReference implements ExcelMappab
         }
         if (rowValues.containsKey("documentId")) {
             setDocumentId(asString(rowValues.get("documentId")));
+        }
+        if (rowValues.containsKey("incidentId")) {
+            setIncidentId(asString(rowValues.get("incidentId")));
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReference.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReference.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
+import java.util.Map;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -15,8 +17,22 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @SuppressWarnings("java:S1700")
-public class DocumentPurgeReference extends CaseReference {
+public class DocumentPurgeReference extends CaseReference implements ExcelMappable {
 
     @JsonProperty
     private String documentId;
+
+    @Override
+    public void fromExcelRow(Map<String, Object> rowValues) throws Exception {
+        if (rowValues.containsKey("caseReference")) {
+            setCaseReference(asString(rowValues.get("caseReference")));
+        }
+        if (rowValues.containsKey("documentId")) {
+            setDocumentId(asString(rowValues.get("documentId")));
+        }
+    }
+
+    private String asString(Object value) {
+        return value != null ? value.toString() : null;
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/PurgeDocStoreDocumentTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/PurgeDocStoreDocumentTask.java
@@ -1,0 +1,92 @@
+package uk.gov.hmcts.reform.civil.handler.migration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.hmcts.reform.civil.bulkupdate.csv.DocumentPurgeReference;
+import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.civil.documentmanagement.DocumentManagementService;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.service.UserService;
+
+/**
+ * One-off remediation migration task that hard-deletes an orphaned document binary from the
+ * document store (CDAM / dm-store) by id.
+ *
+ * <p>It is used to purge documents that were removed from a case via the {@code REMOVE_DOCUMENT}
+ * event while {@code DOCSTORE_DOC_REMOVAL_ENABLED} was off, so the document reference was detached
+ * from the case data but the binary was never deleted from the store.</p>
+ *
+ * <p>The task is {@link #isReadOnly() read-only with respect to the case}: it makes no change to
+ * CaseData and writes no CCD event / case-history entry. Its only side effect is the permanent
+ * deletion of the target binary from the document store, delegated to
+ * {@link DocumentManagementService#deleteDocument} (which calls CDAM with the permanent flag).
+ * It emits one structured log line per document (prefix {@code PURGE_DOCSTORE_DOCUMENT}) for
+ * filtering in App Insights.</p>
+ *
+ * <p>Trigger via the CSV path with columns {@code caseReference,documentId} (see
+ * {@code DocumentPurgeReference}); the {@code documentId} is the document store id (UUID).</p>
+ */
+@Component
+@Slf4j
+public class PurgeDocStoreDocumentTask extends MigrationTask<DocumentPurgeReference> {
+
+    private static final String LOG_PREFIX = "PURGE_DOCSTORE_DOCUMENT";
+    private static final String TASK_NAME = "PurgeDocStoreDocumentTask";
+    private static final String EVENT_SUMMARY = "Purge orphaned document from the document store";
+    private static final String EVENT_DESCRIPTION =
+        "Read-only remediation task that hard-deletes an orphaned document binary from the document store by id";
+
+    private final DocumentManagementService documentManagementService;
+    private final UserService userService;
+    private final SystemUpdateUserConfiguration userConfig;
+
+    public PurgeDocStoreDocumentTask(DocumentManagementService documentManagementService,
+                                     UserService userService,
+                                     SystemUpdateUserConfiguration userConfig) {
+        super(DocumentPurgeReference.class);
+        this.documentManagementService = documentManagementService;
+        this.userService = userService;
+        this.userConfig = userConfig;
+    }
+
+    @Override
+    public boolean isReadOnly() {
+        return true;
+    }
+
+    @Override
+    protected CaseData migrateCaseData(CaseData caseData, DocumentPurgeReference reference) {
+        if (reference == null || reference.getCaseReference() == null
+            || reference.getDocumentId() == null || reference.getDocumentId().isBlank()) {
+            throw new IllegalArgumentException("CaseReference and documentId must not be null or blank");
+        }
+
+        String caseId = reference.getCaseReference();
+        String documentId = reference.getDocumentId().trim();
+
+        String authorisation = getSystemUserToken();
+        documentManagementService.deleteDocument(authorisation, documentId);
+        log.info("{} case={} documentId={} result=DELETED", LOG_PREFIX, caseId, documentId);
+
+        return caseData;
+    }
+
+    @Override
+    protected String getTaskName() {
+        return TASK_NAME;
+    }
+
+    @Override
+    protected String getEventSummary() {
+        return EVENT_SUMMARY;
+    }
+
+    @Override
+    protected String getEventDescription() {
+        return EVENT_DESCRIPTION;
+    }
+
+    private String getSystemUserToken() {
+        return userService.getAccessToken(userConfig.getUserName(), userConfig.getPassword());
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/PurgeDocStoreDocumentTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/PurgeDocStoreDocumentTask.java
@@ -63,10 +63,11 @@ public class PurgeDocStoreDocumentTask extends MigrationTask<DocumentPurgeRefere
 
         String caseId = reference.getCaseReference();
         String documentId = reference.getDocumentId().trim();
+        String incidentId = reference.getIncidentId();
 
         String authorisation = getSystemUserToken();
         documentManagementService.deleteDocument(authorisation, documentId);
-        log.info("{} case={} documentId={} result=DELETED", LOG_PREFIX, caseId, documentId);
+        log.info("{} case={} documentId={} incidentId={} result=DELETED", LOG_PREFIX, caseId, documentId, incidentId);
 
         return caseData;
     }

--- a/src/main/resources/purge_docstore_document_csv/purge_docstore_document.csv
+++ b/src/main/resources/purge_docstore_document_csv/purge_docstore_document.csv
@@ -1,0 +1,2 @@
+caseReference,documentId
+1770925621123458,6c6403c1-ad61-4c60-9ffa-852ea0b25a7e

--- a/src/main/resources/purge_docstore_document_csv/purge_docstore_document.csv
+++ b/src/main/resources/purge_docstore_document_csv/purge_docstore_document.csv
@@ -1,2 +1,0 @@
-caseReference,documentId
-1770925621123458,6c6403c1-ad61-4c60-9ffa-852ea0b25a7e

--- a/src/test/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReferenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReferenceTest.java
@@ -23,11 +23,13 @@ class DocumentPurgeReferenceTest {
         Map<String, Object> rowValues = new HashMap<>();
         rowValues.put("caseReference", "1234567890123456");
         rowValues.put("documentId", "6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+        rowValues.put("incidentId", "INC-12345");
 
         caseReference.fromExcelRow(rowValues);
 
         assertThat(caseReference.getCaseReference()).isEqualTo("1234567890123456");
         assertThat(caseReference.getDocumentId()).isEqualTo("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+        assertThat(caseReference.getIncidentId()).isEqualTo("INC-12345");
     }
 
     @Test
@@ -36,11 +38,13 @@ class DocumentPurgeReferenceTest {
         Map<String, Object> rowValues = new HashMap<>();
         rowValues.put("caseReference", 1234567890123456L);
         rowValues.put("documentId", documentId);
+        rowValues.put("incidentId", 12345);
 
         caseReference.fromExcelRow(rowValues);
 
         assertThat(caseReference.getCaseReference()).isEqualTo("1234567890123456");
         assertThat(caseReference.getDocumentId()).isEqualTo("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+        assertThat(caseReference.getIncidentId()).isEqualTo("12345");
     }
 
     @Test
@@ -48,21 +52,25 @@ class DocumentPurgeReferenceTest {
         Map<String, Object> rowValues = new HashMap<>();
         rowValues.put("caseReference", null);
         rowValues.put("documentId", null);
+        rowValues.put("incidentId", null);
 
         caseReference.fromExcelRow(rowValues);
 
         assertThat(caseReference.getCaseReference()).isNull();
         assertThat(caseReference.getDocumentId()).isNull();
+        assertThat(caseReference.getIncidentId()).isNull();
     }
 
     @Test
     void shouldIgnoreMissingFields() throws Exception {
         caseReference.setCaseReference("1234567890123456");
         caseReference.setDocumentId("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+        caseReference.setIncidentId("INC-12345");
 
         caseReference.fromExcelRow(Map.of());
 
         assertThat(caseReference.getCaseReference()).isEqualTo("1234567890123456");
         assertThat(caseReference.getDocumentId()).isEqualTo("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+        assertThat(caseReference.getIncidentId()).isEqualTo("INC-12345");
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReferenceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/bulkupdate/csv/DocumentPurgeReferenceTest.java
@@ -1,0 +1,68 @@
+package uk.gov.hmcts.reform.civil.bulkupdate.csv;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DocumentPurgeReferenceTest {
+
+    private DocumentPurgeReference caseReference;
+
+    @BeforeEach
+    void setUp() {
+        caseReference = new DocumentPurgeReference();
+    }
+
+    @Test
+    void shouldPopulateFieldsFromExcelRow() throws Exception {
+        Map<String, Object> rowValues = new HashMap<>();
+        rowValues.put("caseReference", "1234567890123456");
+        rowValues.put("documentId", "6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+
+        caseReference.fromExcelRow(rowValues);
+
+        assertThat(caseReference.getCaseReference()).isEqualTo("1234567890123456");
+        assertThat(caseReference.getDocumentId()).isEqualTo("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+    }
+
+    @Test
+    void shouldConvertNonStringValuesFromExcelRow() throws Exception {
+        UUID documentId = UUID.fromString("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+        Map<String, Object> rowValues = new HashMap<>();
+        rowValues.put("caseReference", 1234567890123456L);
+        rowValues.put("documentId", documentId);
+
+        caseReference.fromExcelRow(rowValues);
+
+        assertThat(caseReference.getCaseReference()).isEqualTo("1234567890123456");
+        assertThat(caseReference.getDocumentId()).isEqualTo("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+    }
+
+    @Test
+    void shouldSetFieldsToNullWhenValuesAreNull() throws Exception {
+        Map<String, Object> rowValues = new HashMap<>();
+        rowValues.put("caseReference", null);
+        rowValues.put("documentId", null);
+
+        caseReference.fromExcelRow(rowValues);
+
+        assertThat(caseReference.getCaseReference()).isNull();
+        assertThat(caseReference.getDocumentId()).isNull();
+    }
+
+    @Test
+    void shouldIgnoreMissingFields() throws Exception {
+        caseReference.setCaseReference("1234567890123456");
+        caseReference.setDocumentId("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+
+        caseReference.fromExcelRow(Map.of());
+
+        assertThat(caseReference.getCaseReference()).isEqualTo("1234567890123456");
+        assertThat(caseReference.getDocumentId()).isEqualTo("6c6403c1-ad61-4c60-9ffa-852ea0b25a7e");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/PurgeDocStoreDocumentTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/PurgeDocStoreDocumentTaskTest.java
@@ -1,0 +1,95 @@
+package uk.gov.hmcts.reform.civil.handler.migration;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.bulkupdate.csv.DocumentPurgeReference;
+import uk.gov.hmcts.reform.civil.config.SystemUpdateUserConfiguration;
+import uk.gov.hmcts.reform.civil.documentmanagement.DocumentManagementService;
+import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.service.UserService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class PurgeDocStoreDocumentTaskTest {
+
+    private static final String CASE_ID = "1770925621123458";
+    private static final String DOC_ID = "6c6403c1-ad61-4c60-9ffa-852ea0b25a7e";
+
+    private DocumentManagementService documentManagementService;
+    private UserService userService;
+    private SystemUpdateUserConfiguration userConfig;
+    private PurgeDocStoreDocumentTask task;
+
+    @BeforeEach
+    void setUp() {
+        documentManagementService = mock(DocumentManagementService.class);
+        userService = mock(UserService.class);
+        userConfig = mock(SystemUpdateUserConfiguration.class);
+        task = new PurgeDocStoreDocumentTask(documentManagementService, userService, userConfig);
+    }
+
+    private DocumentPurgeReference reference(String caseId, String documentId) {
+        DocumentPurgeReference ref = new DocumentPurgeReference();
+        ref.setCaseReference(caseId);
+        ref.setDocumentId(documentId);
+        return ref;
+    }
+
+    @Test
+    void shouldReturnCorrectTaskName() {
+        assertThat(task.getTaskName()).isEqualTo("PurgeDocStoreDocumentTask");
+    }
+
+    @Test
+    void shouldReturnCorrectEventSummary() {
+        assertThat(task.getEventSummary()).isEqualTo("Purge orphaned document from the document store");
+    }
+
+    @Test
+    void shouldReturnEventDescription() {
+        assertThat(task.getEventDescription()).contains("hard-deletes an orphaned document");
+    }
+
+    @Test
+    void shouldBeReadOnly() {
+        assertThat(task.isReadOnly()).isTrue();
+    }
+
+    @Test
+    void shouldDeleteDocumentUsingSystemUserToken() {
+        when(userConfig.getUserName()).thenReturn("system-user");
+        when(userConfig.getPassword()).thenReturn("pass");
+        when(userService.getAccessToken("system-user", "pass")).thenReturn("Bearer token");
+        CaseData caseData = CaseData.builder().build();
+
+        CaseData result = task.migrateCaseData(caseData, reference(CASE_ID, DOC_ID));
+
+        verify(documentManagementService).deleteDocument("Bearer token", DOC_ID);
+        assertThat(result).isSameAs(caseData);
+    }
+
+    @Test
+    void shouldTrimDocumentIdBeforeDeleting() {
+        when(userConfig.getUserName()).thenReturn("system-user");
+        when(userConfig.getPassword()).thenReturn("pass");
+        when(userService.getAccessToken("system-user", "pass")).thenReturn("token");
+
+        task.migrateCaseData(CaseData.builder().build(), reference(CASE_ID, "  " + DOC_ID + "  "));
+
+        verify(documentManagementService).deleteDocument("token", DOC_ID);
+    }
+
+    @Test
+    void shouldThrowAndNotDeleteWhenDocumentIdMissing() {
+        assertThatThrownBy(() -> task.migrateCaseData(CaseData.builder().build(), reference(CASE_ID, null)))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> task.migrateCaseData(CaseData.builder().build(), reference(CASE_ID, "  ")))
+            .isInstanceOf(IllegalArgumentException.class);
+        verifyNoInteractions(documentManagementService);
+    }
+}


### PR DESCRIPTION
## What
Adds `PurgeDocStoreDocumentTask` — a read-only migration task that permanently deletes an orphaned document binary from the document store (CDAM / dm-store) by id.

## Why
On the `REMOVE_DOCUMENT` event, civil-service only hard-deletes the binary when `DOCSTORE_DOC_REMOVAL_ENABLED` is on. It has been off in prod, so removed documents were unlinked from case data but their binaries persisted in the store. This task remediates such orphaned binaries — specifically the confidential-address document from the incident behind DTSCCI-6009.

(Related: DTSCCI-6007 / cnp-flux-config#46492 enables hard-delete going forward; this task cleans up files orphaned before that change.)

## How it works
- `PurgeDocStoreDocumentTask extends MigrationTask<DocumentPurgeReference>`, `isReadOnly() = true`, so `AsyncCaseMigrationService` fetches the case and runs the task **without** starting/submitting a CCD event — no CaseData change, no case-history entry.
- It obtains a system-user token and calls `DocumentManagementService.deleteDocument(auth, documentId)`, which performs the CDAM permanent (`true`) delete. One structured log line per document (prefix `PURGE_DOCSTORE_DOCUMENT`).
- `DocumentPurgeReference` is a CSV reference type (`caseReference`, `documentId`); the CSV loader maps it generically via `csvMapper.typedSchemaFor(type)`, so no extra registration is needed.

## Running it
Trigger the migration external task with:
- `taskName = PurgeDocStoreDocumentTask`
- `csvFileName = purge_docstore_document_csv/purge_docstore_document.csv`

The bundled CSV targets the single incident document (`1770925621123458`, `6c6403c1-...`).

## Verification (per DTSCCI-6009 acceptance)
- After the run, `GET /cases/documents/6c6403c1-...` returns **404** (binary gone).
- CDAM `DELETE` visible in telemetry at run time.
- No change to case data or other documents.

## Tests
`PurgeDocStoreDocumentTaskTest` — task metadata, `isReadOnly`, delete call with the system token, id trimming, and validation (throws + no delete when id missing). `./gradlew test --tests "*PurgeDocStoreDocumentTaskTest"` passes.

Jira: DTSCCI-6009

🤖 Generated with [Claude Code](https://claude.com/claude-code)