### PR TITLE
DTSCCI-5926 IllegalArgumentException "Unexpected hearing type AAA7-CCM" in DocumentHearingType.getType

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/enums/DocumentHearingType.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/enums/DocumentHearingType.java
@@ -12,7 +12,8 @@ import static uk.gov.hmcts.reform.civil.enums.DocumentContext.TITLE;
 public enum DocumentHearingType {
     TRI("trial", "dreial"),
     DIS("disposal hearing", "wrandawiad gwaredu"),
-    DRH("dispute resolution hearing", "wrandawiad datrys anghydfod");
+    DRH("dispute resolution hearing", "wrandawiad datrys anghydfod"),
+    CCM("case management conference", "cynhadledd rheoli achos");
 
     private final String label;
     private final String labelWelsh;

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/HearingUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/HearingUtils.java
@@ -17,6 +17,7 @@ import java.util.function.Predicate;
 
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.CCM;
 import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.DIS;
 import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.DRH;
 import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.getType;
@@ -145,7 +146,7 @@ public class HearingUtils {
     }
 
     public static boolean hearingFeeRequired(String hearingType) {
-        List<DocumentHearingType> hearingTypesExcludedFromFee = List.of(DIS, DRH);
+        List<DocumentHearingType> hearingTypesExcludedFromFee = List.of(CCM, DIS, DRH);
         return hearingTypesExcludedFromFee.stream().filter(
             type -> getType(hearingType).equals(type)).count() < 1;
     }

--- a/src/test/java/uk/gov/hmcts/reform/civil/enums/DocumentHearingTypeTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/enums/DocumentHearingTypeTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.CCM;
 import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.DIS;
 import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.DRH;
 import static uk.gov.hmcts.reform.civil.enums.DocumentHearingType.TRI;
@@ -55,6 +56,16 @@ public class DocumentHearingTypeTest {
         }
 
         @Test
+        void shouldReturnExpectedType_withCCM() {
+            assertEquals(CCM, DocumentHearingType.getType("AAA7-CCM"));
+        }
+
+        @Test
+        void shouldReturnExpectedType_withCCM_withoutHyphen() {
+            assertEquals(CCM, DocumentHearingType.getType("CCM"));
+        }
+
+        @Test
         void shouldThrowIllegalArgumentException_withInvalidInput() {
             assertThrows(IllegalArgumentException.class, () -> DocumentHearingType.getType("BAD"));
         }
@@ -67,7 +78,9 @@ public class DocumentHearingTypeTest {
         "DRH, SMALL_CLAIM, dispute resolution hearing",
         "DRH, FAST_CLAIM, dispute resolution hearing",
         "DIS, SMALL_CLAIM, disposal hearing",
-        "DIS, FAST_CLAIM, disposal hearing"
+        "DIS, FAST_CLAIM, disposal hearing",
+        "CCM, SMALL_CLAIM, case management conference",
+        "CCM, FAST_CLAIM, case management conference"
     })
     void shouldReturnExpectedTitleText(DocumentHearingType hearingType, AllocatedTrack allocatedTrack, String expected) {
         assertEquals(expected, getTitleText(hearingType, allocatedTrack, false));
@@ -80,7 +93,9 @@ public class DocumentHearingTypeTest {
         "DRH, SMALL_CLAIM, hearing",
         "DRH, FAST_CLAIM, hearing",
         "DIS, SMALL_CLAIM, hearing",
-        "DIS, FAST_CLAIM, hearing"
+        "DIS, FAST_CLAIM, hearing",
+        "CCM, SMALL_CLAIM, hearing",
+        "CCM, FAST_CLAIM, hearing"
     })
     void shouldReturnExpectedContentText(DocumentHearingType hearingType, AllocatedTrack allocatedTrack, String expected) {
         assertEquals(expected, getContentText(hearingType, allocatedTrack, false));
@@ -93,7 +108,9 @@ public class DocumentHearingTypeTest {
         "DRH, SMALL_CLAIM, wrandawiad datrys anghydfod",
         "DRH, FAST_CLAIM, wrandawiad datrys anghydfod",
         "DIS, SMALL_CLAIM, wrandawiad gwaredu",
-        "DIS, FAST_CLAIM, wrandawiad gwaredu"
+        "DIS, FAST_CLAIM, wrandawiad gwaredu",
+        "CCM, SMALL_CLAIM, cynhadledd rheoli achos",
+        "CCM, FAST_CLAIM, cynhadledd rheoli achos"
     })
     void shouldReturnExpectedTitleTextWelsh(DocumentHearingType hearingType, AllocatedTrack allocatedTrack, String expected) {
         assertEquals(expected, getTitleText(hearingType, allocatedTrack, true));
@@ -106,7 +123,9 @@ public class DocumentHearingTypeTest {
         "DRH, SMALL_CLAIM, gwrandawiad",
         "DRH, FAST_CLAIM, gwrandawiad",
         "DIS, SMALL_CLAIM, gwrandawiad",
-        "DIS, FAST_CLAIM, gwrandawiad"
+        "DIS, FAST_CLAIM, gwrandawiad",
+        "CCM, SMALL_CLAIM, gwrandawiad",
+        "CCM, FAST_CLAIM, gwrandawiad"
     })
     void shouldReturnExpectedContentTextWelsh(DocumentHearingType hearingType, AllocatedTrack allocatedTrack, String expected) {
         assertEquals(expected, getContentText(hearingType, allocatedTrack, true));
@@ -116,7 +135,8 @@ public class DocumentHearingTypeTest {
     @CsvSource({
         "TRI, FAST_CLAIM, dreialon",
         "TRI, SMALL_CLAIM, wrandawiadau",
-        "DIS, FAST_CLAIM, wrandawiadau"
+        "DIS, FAST_CLAIM, wrandawiadau",
+        "CCM, FAST_CLAIM, wrandawiadau"
     })
     void shouldReturnExpectedPluralTypeTextWelsh(DocumentHearingType hearingType, AllocatedTrack allocatedTrack, String expected) {
         assertEquals(expected, getPluralTypeTextWelsh(hearingType, allocatedTrack));

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/HearingUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/HearingUtilsTest.java
@@ -193,6 +193,7 @@ class HearingUtilsTest {
     @CsvSource({
         "AAA7-DIS,false",
         "AAA7-DRH,false",
+        "AAA7-CCM,false",
         "AAA7-TRI,true"
     })
     void shouldReturnCorrectValue_whenHearingTypeIs(String hearingType, boolean expected) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/HmcDataUtilsTest.java
@@ -1411,6 +1411,7 @@ class HmcDataUtilsTest {
             "TRI, FAST_CLAIM, trial",
             "DRH, SMALL_CLAIM, dispute resolution hearing",
             "DIS, SMALL_CLAIM, disposal hearing",
+            "CCM, SMALL_CLAIM, case management conference",
         })
         void shouldReturnExpectedTitle(String hearingType, AllocatedTrack allocatedTrack, String expected) {
             HearingGetResponse hearing = buildHearing(hearingType);
@@ -1428,6 +1429,7 @@ class HmcDataUtilsTest {
             "TRI, FAST_CLAIM, trial",
             "DRH, SMALL_CLAIM, dispute resolution hearing",
             "DIS, SMALL_CLAIM, disposal hearing",
+            "CCM, SMALL_CLAIM, case management conference",
         })
         void shouldReturnExpectedTitle_specClaim(String hearingType, AllocatedTrack allocatedTrack, String expected) {
             HearingGetResponse hearing = buildHearing(hearingType);
@@ -1443,7 +1445,8 @@ class HmcDataUtilsTest {
             "TRI, SMALL_CLAIM, wrandawiad",
             "TRI, FAST_CLAIM, dreial",
             "DRH, SMALL_CLAIM, wrandawiad datrys anghydfod",
-            "DIS, SMALL_CLAIM, wrandawiad gwaredu"
+            "DIS, SMALL_CLAIM, wrandawiad gwaredu",
+            "CCM, SMALL_CLAIM, cynhadledd rheoli achos"
         })
         void shouldReturnExpectedTitleWelsh_specClaim(String hearingType, AllocatedTrack allocatedTrack, String expected) {
             HearingGetResponse hearing = buildHearing(hearingType);
@@ -1464,6 +1467,7 @@ class HmcDataUtilsTest {
             "TRI, FAST_CLAIM, trial",
             "DRH, SMALL_CLAIM, hearing",
             "DIS, SMALL_CLAIM, hearing",
+            "CCM, SMALL_CLAIM, hearing",
         })
         void shouldReturnExpectedText_unspecClaim(String hearingType, AllocatedTrack allocatedTrack, String expected) {
             HearingGetResponse hearing = buildHearing(hearingType);
@@ -1481,6 +1485,7 @@ class HmcDataUtilsTest {
             "TRI, FAST_CLAIM, trial",
             "DRH, SMALL_CLAIM, hearing",
             "DIS, SMALL_CLAIM, hearing",
+            "CCM, SMALL_CLAIM, hearing",
         })
         void shouldReturnExpectedText_specClaim(String hearingType, AllocatedTrack allocatedTrack, String expected) {
             HearingGetResponse hearing = buildHearing(hearingType);
@@ -1497,6 +1502,7 @@ class HmcDataUtilsTest {
             "TRI, FAST_CLAIM, treial",
             "DRH, SMALL_CLAIM, gwrandawiad",
             "DIS, FAST_CLAIM, gwrandawiad",
+            "CCM, SMALL_CLAIM, gwrandawiad",
         })
         void shouldReturnExpectedTextWelsh_specClaim(String hearingType, AllocatedTrack allocatedTrack, String expected) {
             HearingGetResponse hearing = buildHearing(hearingType);
@@ -1513,6 +1519,7 @@ class HmcDataUtilsTest {
             "TRI, FAST_CLAIM, dreialon",
             "DRH, SMALL_CLAIM, wrandawiadau",
             "DIS, SMALL_CLAIM, wrandawiadau",
+            "CCM, SMALL_CLAIM, wrandawiadau",
         })
         void shouldReturnExpectedPluralTextWelsh_specClaim(String hearingType, AllocatedTrack allocatedTrack, String expected) {
             HearingGetResponse hearing = buildHearing(hearingType);


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5926

### Change description ###

Added support for the AAA7-CCM hearing type by mapping it to CCM with English and Welsh labels, and excluding it from hearing fee requirements.
Updated focused tests to cover CCM parsing, document wording, Welsh text, HMC text generation, and fee behaviour.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
