### PR TITLE
DTSCCI-5913 Upgrade LaunchDarkly Java SDK to 7.x

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -114,8 +114,6 @@ withPipeline(type, product, component) {
   env.DMN_DEFINITION_BRANCH = dmnBranch
   env.WIREMOCK_MAPPINGS_BRANCH = wiremockMappingsBranch
   env.UNASSIGN_CASES = true
-  env.BEFTA_FORCE_IMPORT_RETRY = 'true'
-
   loadVaultSecrets(secrets)
 
   onPR {

--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ be found in the Azure key store.
 | `LAUNCH_DARKLY_OFFLINE_MODE` | Sets LaunchDarkly to use local values for flags rather than connecting to the service | `true` |
 | `SPRING_PROFILES_ACTIVE` | Sets the active Spring profile | `local` |
 
+Civil Service uses LaunchDarkly Java server SDK 7.x contexts for feature-flag evaluation. The default context has the
+`user` kind and `civil-service` key, with `environment` and `timestamp` attributes; location-aware evaluations also
+include `location`. The SDK client is a singleton Spring bean and is closed during application shutdown. When the SDK
+is offline or LaunchDarkly is unavailable, each evaluation returns the default value supplied by the caller. Local
+development can use the flag files configured in `application-dev.yaml` with offline mode enabled. No proxy or custom
+network timeout overrides are configured, so the SDK defaults apply.
+
 
 #### Create a Docker image
 

--- a/build.gradle
+++ b/build.gradle
@@ -527,7 +527,7 @@ dependencies {
   implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.5"
   implementation "org.glassfish.jaxb:jaxb-runtime:4.0.9"
   implementation "javax.xml.bind:jaxb-api:2.3.1"
-  implementation "com.launchdarkly:launchdarkly-java-server-sdk:6.3.0"
+  implementation "com.launchdarkly:launchdarkly-java-server-sdk:7.15.0"
   implementation "com.azure:azure-core:1.58.1"
   implementation "com.azure:azure-messaging-servicebus:7.17.18"
   implementation "org.apache.pdfbox:pdfbox:${versions.pdfbox}"

--- a/build.gradle
+++ b/build.gradle
@@ -490,7 +490,7 @@ dependencies {
   implementation "org.springframework.retry:spring-retry"
   implementation "com.github.hmcts.java-logging:logging:8.0.0"
   implementation "com.microsoft.azure:applicationinsights-web:3.7.8"
-  implementation "com.github.hmcts:befta-fw:9.2.8"
+  implementation "com.github.hmcts:befta-fw:9.2.9"
   implementation "commons-lang:commons-lang:2.6"
   implementation "com.github.hmcts:core-case-data-store-client:5.2.0"
   implementation "com.github.hmcts:document-management-client:7.0.1"

--- a/src/main/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleApi.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleApi.java
@@ -1,6 +1,8 @@
 package uk.gov.hmcts.reform.civil.launchdarkly;
 
-import com.launchdarkly.sdk.LDUser;
+import com.launchdarkly.sdk.ContextBuilder;
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.LDValue;
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,25 +26,25 @@ public class FeatureToggleApi {
     }
 
     public boolean isFeatureEnabled(String feature) {
-        return internalClient.boolVariation(feature, createLDUser().build(), false);
+        return internalClient.boolVariation(feature, createLDContext().build(), false);
     }
 
     public boolean isFeatureEnabled(String feature, boolean defaultValue) {
-        return internalClient.boolVariation(feature, createLDUser().build(), defaultValue);
+        return internalClient.boolVariation(feature, createLDContext().build(), defaultValue);
     }
 
-    public boolean isFeatureEnabled(String feature, LDUser user) {
-        return internalClient.boolVariation(feature, user, false);
+    public boolean isFeatureEnabled(String feature, LDContext context) {
+        return internalClient.boolVariation(feature, context, false);
     }
 
-    public boolean isFeatureEnabled(String feature, LDUser user, boolean defaultValue) {
-        return internalClient.boolVariation(feature, user, defaultValue);
+    public boolean isFeatureEnabled(String feature, LDContext context, boolean defaultValue) {
+        return internalClient.boolVariation(feature, context, defaultValue);
     }
 
-    public LDUser.Builder createLDUser() {
-        return new LDUser.Builder("civil-service")
-            .custom("timestamp", String.valueOf(System.currentTimeMillis()))
-            .custom("environment", environment);
+    public ContextBuilder createLDContext() {
+        return LDContext.builder("civil-service")
+            .set("timestamp", String.valueOf(System.currentTimeMillis()))
+            .set("environment", environment);
     }
 
     private void close() {
@@ -54,10 +56,14 @@ public class FeatureToggleApi {
     }
 
     public boolean isFeatureEnabledForLocation(String feature, String location, boolean defaultValue) {
-        return internalClient.boolVariation(feature, createLDUser().custom("location", location).build(), defaultValue);
+        return internalClient.boolVariation(feature, createLDContext().set("location", location).build(), defaultValue);
     }
 
     public boolean isFeatureEnabledForDate(String feature, Long date, boolean defaultValue) {
-        return internalClient.boolVariation(feature, createLDUser().custom("timestamp", date).build(), defaultValue);
+        return internalClient.boolVariation(
+            feature,
+            createLDContext().set("timestamp", LDValue.of(date)).build(),
+            defaultValue
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/config/LaunchDarklyConfigurationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/config/LaunchDarklyConfigurationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.civil.config;
 
+import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.LDClient;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -15,36 +16,53 @@ public class LaunchDarklyConfigurationTest {
      * LDClient build test without flag files.
      */
     @Test
-    public void streamingLD() {
+    public void streamingLD() throws Exception {
         String key = "sdkkey";
         boolean offline = false;
-        LDClient client = configuration.ldClient(key, offline, null);
-        Assertions.assertEquals(client.isOffline(), offline);
+        try (LDClient client = configuration.ldClient(key, offline, null)) {
+            Assertions.assertEquals(client.isOffline(), offline);
+        }
 
-        client = configuration.ldClient(key, offline, new String[0]);
-        Assertions.assertEquals(client.isOffline(), offline);
+        try (LDClient client = configuration.ldClient(key, offline, new String[0])) {
+            Assertions.assertEquals(client.isOffline(), offline);
+        }
     }
 
     @Test
-    public void unexistentFiles() {
+    public void unexistentFiles() throws Exception {
         String key = "sdkkey";
         boolean offline = false;
-        LDClient client = configuration.ldClient(key, offline, new String[]{
+        try (LDClient client = configuration.ldClient(key, offline, new String[]{
             "AFileThatDoesNotExist"
-        });
-        Assertions.assertEquals(client.isOffline(), offline);
+        })) {
+            Assertions.assertEquals(client.isOffline(), offline);
+        }
     }
 
     @Test
-    public void withFlags() {
+    public void withFlags() throws Exception {
         String path = "./bin/utils/launchdarkly-flags.json";
         if (Files.exists(Paths.get(path))) {
             String key = "sdkkey";
             boolean offline = false;
-            LDClient client = configuration.ldClient(key, offline, new String[]{
-                "AFileThatDoesNotExist"
-            });
-            Assertions.assertEquals(client.isOffline(), offline);
+            try (LDClient client = configuration.ldClient(key, offline, new String[]{path})) {
+                Assertions.assertEquals(client.isOffline(), offline);
+                Assertions.assertFalse(client.boolVariation(
+                    "general_applications_enabled",
+                    LDContext.create("civil-service"),
+                    true
+                ));
+            }
+        }
+    }
+
+    @Test
+    public void returnsSuppliedDefaultsWhenOffline() throws Exception {
+        try (LDClient client = configuration.ldClient("sdkkey", true, null)) {
+            LDContext context = LDContext.create("civil-service");
+
+            Assertions.assertTrue(client.boolVariation("unknown-flag", context, true));
+            Assertions.assertFalse(client.boolVariation("unknown-flag", context, false));
         }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleApiTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleApiTest.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.civil.launchdarkly;
 
-import com.google.common.collect.ImmutableList;
-import com.launchdarkly.sdk.LDUser;
+import com.launchdarkly.sdk.ContextKind;
+import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ class FeatureToggleApiTest {
     private LDClientInterface ldClient;
 
     @Captor
-    private ArgumentCaptor<LDUser> ldUserArgumentCaptor;
+    private ArgumentCaptor<LDContext> ldContextArgumentCaptor;
 
     private FeatureToggleApi featureToggleApi;
 
@@ -45,16 +45,16 @@ class FeatureToggleApiTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void shouldReturnCorrectState_whenUserIsProvided(Boolean toggleState) {
-        LDUser ldUSer = new LDUser.Builder("civil-service")
-            .custom("timestamp", String.valueOf(System.currentTimeMillis()))
-            .custom("environment", FAKE_ENVIRONMENT).build();
+        LDContext context = LDContext.builder("civil-service")
+            .set("timestamp", String.valueOf(System.currentTimeMillis()))
+            .set("environment", FAKE_ENVIRONMENT).build();
         givenToggle(FAKE_FEATURE, toggleState);
 
-        assertThat(featureToggleApi.isFeatureEnabled(FAKE_FEATURE, ldUSer)).isEqualTo(toggleState);
+        assertThat(featureToggleApi.isFeatureEnabled(FAKE_FEATURE, context)).isEqualTo(toggleState);
 
         verify(ldClient).boolVariation(
             FAKE_FEATURE,
-            ldUSer,
+            context,
             false
         );
     }
@@ -74,17 +74,17 @@ class FeatureToggleApiTest {
         givenToggle(FAKE_FEATURE, true, toggleState);
 
         assertThat(featureToggleApi.isFeatureEnabled(FAKE_FEATURE, true)).isEqualTo(toggleState);
-        verify(ldClient).boolVariation(eq(FAKE_FEATURE), any(LDUser.class), eq(true));
+        verify(ldClient).boolVariation(eq(FAKE_FEATURE), any(LDContext.class), eq(true));
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void shouldHonourProvidedDefaultValueForCustomUser(boolean toggleState) {
-        LDUser user = new LDUser.Builder("custom").build();
-        when(ldClient.boolVariation(FAKE_FEATURE, user, true)).thenReturn(toggleState);
+        LDContext context = LDContext.create("custom");
+        when(ldClient.boolVariation(FAKE_FEATURE, context, true)).thenReturn(toggleState);
 
-        assertThat(featureToggleApi.isFeatureEnabled(FAKE_FEATURE, user, true)).isEqualTo(toggleState);
-        verify(ldClient).boolVariation(FAKE_FEATURE, user, true);
+        assertThat(featureToggleApi.isFeatureEnabled(FAKE_FEATURE, context, true)).isEqualTo(toggleState);
+        verify(ldClient).boolVariation(FAKE_FEATURE, context, true);
     }
 
     @Test
@@ -93,10 +93,8 @@ class FeatureToggleApiTest {
 
         featureToggleApi.isFeatureEnabledForLocation(FAKE_FEATURE, "LON", true);
 
-        verify(ldClient).boolVariation(eq(FAKE_FEATURE), ldUserArgumentCaptor.capture(), eq(true));
-        assertThat(ImmutableList.copyOf(ldUserArgumentCaptor.getValue().getCustomAttributes()))
-            .extracting("name")
-            .contains("location");
+        verify(ldClient).boolVariation(eq(FAKE_FEATURE), ldContextArgumentCaptor.capture(), eq(true));
+        assertThat(ldContextArgumentCaptor.getValue().getValue("location").stringValue()).isEqualTo("LON");
     }
 
     @Test
@@ -105,10 +103,8 @@ class FeatureToggleApiTest {
 
         featureToggleApi.isFeatureEnabledForDate(FAKE_FEATURE, 123L, false);
 
-        verify(ldClient).boolVariation(eq(FAKE_FEATURE), ldUserArgumentCaptor.capture(), eq(false));
-        assertThat(ImmutableList.copyOf(ldUserArgumentCaptor.getValue().getCustomAttributes()))
-            .extracting("name")
-            .contains("timestamp");
+        verify(ldClient).boolVariation(eq(FAKE_FEATURE), ldContextArgumentCaptor.capture(), eq(false));
+        assertThat(ldContextArgumentCaptor.getValue().getValue("timestamp").longValue()).isEqualTo(123L);
     }
 
     @Test
@@ -122,43 +118,55 @@ class FeatureToggleApiTest {
     }
 
     private void givenToggle(String feature, boolean state) {
-        when(ldClient.boolVariation(eq(feature), any(LDUser.class), anyBoolean()))
+        when(ldClient.boolVariation(eq(feature), any(LDContext.class), anyBoolean()))
             .thenReturn(state);
     }
 
     private void givenToggle(String feature, boolean defaultValue, boolean state) {
-        when(ldClient.boolVariation(eq(feature), any(LDUser.class), eq(defaultValue))).thenReturn(state);
+        when(ldClient.boolVariation(eq(feature), any(LDContext.class), eq(defaultValue))).thenReturn(state);
     }
 
     private void verifyBoolVariationCalled(String feature, List<String> customAttributesKeys) {
         verify(ldClient).boolVariation(
             eq(feature),
-            ldUserArgumentCaptor.capture(),
+            ldContextArgumentCaptor.capture(),
             eq(false)
         );
 
-        var capturedLdUser = ldUserArgumentCaptor.getValue();
-        assertThat(capturedLdUser.getKey()).isEqualTo("civil-service");
-        assertThat(ImmutableList.copyOf(capturedLdUser.getCustomAttributes())).extracting("name")
-            .containsOnlyOnceElementsOf(customAttributesKeys);
+        var capturedContext = ldContextArgumentCaptor.getValue();
+        assertThat(capturedContext.getKey()).isEqualTo("civil-service");
+        assertThat(capturedContext.getKind()).isEqualTo(ContextKind.DEFAULT);
+        assertThat(capturedContext.getCustomAttributeNames()).containsExactlyInAnyOrderElementsOf(customAttributesKeys);
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void shouldReturnCorrectState_whenUserWithLocationIsProvided(Boolean toggleState) {
-        LDUser ldUSer = new LDUser.Builder("civil-service")
-            .custom("timestamp", String.valueOf(System.currentTimeMillis()))
-            .custom("environment", FAKE_ENVIRONMENT)
-            .custom("location", "000000")
+        LDContext context = LDContext.builder("civil-service")
+            .set("timestamp", String.valueOf(System.currentTimeMillis()))
+            .set("environment", FAKE_ENVIRONMENT)
+            .set("location", "000000")
             .build();
         givenToggle(FAKE_FEATURE, toggleState);
 
-        assertThat(featureToggleApi.isFeatureEnabled(FAKE_FEATURE, ldUSer)).isEqualTo(toggleState);
+        assertThat(featureToggleApi.isFeatureEnabled(FAKE_FEATURE, context)).isEqualTo(toggleState);
 
         verify(ldClient).boolVariation(
             FAKE_FEATURE,
-            ldUSer,
+            context,
             false
         );
+    }
+
+    @Test
+    void shouldEvaluateFeatureForMultiContext() {
+        LDContext userContext = LDContext.create("civil-service");
+        LDContext organisationContext = LDContext.create(ContextKind.of("organisation"), "hmcts");
+        LDContext multiContext = LDContext.createMulti(userContext, organisationContext);
+        when(ldClient.boolVariation(FAKE_FEATURE, multiContext, false)).thenReturn(true);
+
+        assertThat(featureToggleApi.isFeatureEnabled(FAKE_FEATURE, multiContext)).isTrue();
+
+        verify(ldClient).boolVariation(FAKE_FEATURE, multiContext, false);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleAspectTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/launchdarkly/FeatureToggleAspectTest.java
@@ -1,6 +1,6 @@
 package uk.gov.hmcts.reform.civil.launchdarkly;
 
-import com.launchdarkly.sdk.LDUser;
+import com.launchdarkly.sdk.LDContext;
 import com.launchdarkly.sdk.server.LDClient;
 import lombok.SneakyThrows;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -73,7 +73,7 @@ class FeatureToggleAspectTest {
     }
 
     private void givenToggle(String feature, boolean state) {
-        when(ldClient.boolVariation(eq(feature), any(LDUser.class), anyBoolean()))
+        when(ldClient.boolVariation(eq(feature), any(LDContext.class), anyBoolean()))
             .thenReturn(state);
     }
 }


### PR DESCRIPTION
## Summary

- upgrade `launchdarkly-java-server-sdk` from `6.3.0` to the latest 7.x release, `7.15.0`
- migrate feature evaluations from removed `LDUser` APIs to `LDContext` while preserving the `user` kind, keys and custom targeting attributes
- retain caller-supplied fallback values, file-backed local flags, SDK defaults for event/diagnostic and network configuration, and client shutdown
- add coverage for single and multi-context evaluation, location/date attributes, file-backed flags, offline defaults and shutdown
- document LaunchDarkly context and operational behaviour

## Verification

- `./gradlew check` — BUILD SUCCESSFUL
- focused LaunchDarkly unit/configuration tests — BUILD SUCCESSFUL
- `git diff --check`
- Maven Central metadata confirms `7.15.0` is the latest 7.x release
- OSV query for `com.launchdarkly:launchdarkly-java-server-sdk:7.15.0` returned no known vulnerabilities

The local OWASP task was attempted, but its NVD refresh did not complete without an NVD API key. Repository CI should run the configured dependency checks. GitHub reports one existing high-severity vulnerability on the default branch.

## QA

Lower-environment QA is recommended because flag targeting is externally configured:

1. Deploy to a lower environment with a valid `LAUNCH_DARKLY_SDK_KEY`.
2. Confirm the service starts cleanly and the LaunchDarkly client connects without SDK errors.
3. Exercise one flag in both enabled and disabled states and confirm the application follows each variation.
4. Exercise a location- or date-targeted flag/journey and confirm targeting is unchanged.
5. Temporarily use an invalid/unavailable SDK connection in a controlled environment and confirm journeys use their configured default values without application failure.
6. Confirm LaunchDarkly receives evaluation events/diagnostics for the lower environment.

## Additional update

- Updated BEFTA framework from `9.2.8` to `9.2.9`.
- Verified `9.2.9` resolves on the runtime classpath.
- Re-ran `./gradlew check`: BUILD SUCCESSFUL.