### PR TITLE
CCD-8039 Upgrade BEFTA framework to 9.2.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -490,7 +490,7 @@ dependencies {
   implementation "org.springframework.retry:spring-retry"
   implementation "com.github.hmcts.java-logging:logging:8.0.0"
   implementation "com.microsoft.azure:applicationinsights-web:3.7.8"
-  implementation "com.github.hmcts:befta-fw:9.2.7"
+  implementation "com.github.hmcts:befta-fw:9.2.8"
   implementation "commons-lang:commons-lang:2.6"
   implementation "com.github.hmcts:core-case-data-store-client:5.2.0"
   implementation "com.github.hmcts:document-management-client:7.0.1"


### PR DESCRIPTION
## Change

Upgrade `com.github.hmcts:befta-fw` from `9.2.7` to the stable `9.2.8` release containing the new CCD import-job polling flow.

`civil-ccd-definition` already received the same stable update in PR #6710, so no additional PR is required there.

## Verification

- `./gradlew dependencyInsight --dependency befta-fw --configuration runtimeClasspath` resolved `9.2.8`
- `./gradlew check` — BUILD SUCCESSFUL
- `git diff --check`