### PR TITLE
DTSCCI-5905: Match sole trader / company / organisation parties in attendee check

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTask.java
@@ -221,7 +221,15 @@ public class VerifyHearingNoticeNamesTask extends MigrationTask<CaseReference> {
     private void addParty(Set<String> names, Party party) {
         if (party != null) {
             add(names, party.getPartyName());
+            // A notice attendee is the plain individual name from the HMC hearing. getPartyName()
+            // does not always yield that: for a sole trader it appends " Trading as ...", and the
+            // individual name fields are only populated for INDIVIDUAL parties. Add the type-specific
+            // name forms so sole trader / company / organisation parties are matched too.
             add(names, joinName(party.getIndividualFirstName(), party.getIndividualLastName()));
+            add(names, joinName(party.getSoleTraderFirstName(), party.getSoleTraderLastName()));
+            add(names, party.getSoleTraderTradingAs());
+            add(names, party.getCompanyName());
+            add(names, party.getOrganisationName());
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/migration/VerifyHearingNoticeNamesTaskTest.java
@@ -175,6 +175,25 @@ class VerifyHearingNoticeNamesTaskTest {
         assertFalse(participants.contains("charlie sansom"), "a foreign name must not be a participant");
     }
 
+    @Test
+    void participantNames_includesSoleTraderPlainName_notJustTradingAsForm() {
+        // Reproduces case 1751912156533775: the defendant is a SOLE_TRADER whose getPartyName()
+        // returns "Mr William Beckett Trading as William beckett", but the notice attendee is the
+        // plain "William Beckett". The plain sole trader name must be a participant so it matches.
+        Party soleTrader = new Party()
+            .setType(Party.Type.SOLE_TRADER)
+            .setSoleTraderTitle("Mr")
+            .setSoleTraderFirstName("William")
+            .setSoleTraderLastName("Beckett")
+            .setSoleTraderTradingAs("William beckett");
+        CaseData caseData = CaseData.builder().applicant1(claimant).respondent1(soleTrader).build();
+
+        var participants = task.participantNames(caseData);
+
+        assertTrue(participants.contains("william beckett"),
+                   "plain sole trader first+last name must be a participant");
+    }
+
     private CaseData caseWithNotice() {
         CaseDocument notice = new CaseDocument()
             .setDocumentLink(new Document(


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5905

### Change description ###

Follow-up: fixes a false-positive class in the hearing notice attendee check.

**Why**

The participant set (used to decide whether a notice attendee is a real case party) was built only from `getPartyName()` plus the individual name fields. That misses non-INDIVIDUAL parties:

- For a **sole trader**, `getPartyName()` returns `"Mr <name> Trading as <name>"` (composed with a trading-as suffix), and `getIndividualFirstName()/getIndividualLastName()` are null (the name is in `soleTrader*`).
- For a **company / organisation**, the individual name fields are null too.

So when the HMC notice lists the plain individual name (e.g. `William Beckett` on case `1751912156533775`, a sole trader), it did not match any participant and was wrongly reported as `INCORRECT_ATTENDEE`.

**What**

`addParty` now also adds, per party: sole trader first+last name, sole trader trading-as name, company name, and organisation name. These are normalised the same way (title/whitespace stripped, lower-cased) so the plain attendee name matches.

**Tests**

- New unit test reproduces the sole-trader case and asserts the plain name (`william beckett`) is a participant.
- Full task suite: 10 passing, checkstyle clean.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```