### PR TITLE
 DTSCCI-6001 show former solicitor's own reference in NoC off-record …

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/ApplyNoticeOfChangeDecisionCallbackHandler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/handler/callback/user/ApplyNoticeOfChangeDecisionCallbackHandler.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.civil.enums.CaseRole;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.ChangeOfRepresentation;
+import uk.gov.hmcts.reform.civil.model.SolicitorReferences;
 import uk.gov.hmcts.reform.civil.model.common.DynamicList;
 import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
 import uk.gov.hmcts.reform.civil.model.noc.ChangeOrganisationRequest;
@@ -111,7 +112,9 @@ public class ApplyNoticeOfChangeDecisionCallbackHandler extends CallbackHandler 
             .setCaseRole(corFieldBeforeDecision.getCaseRoleId().getValue().getCode())
             .setTimestamp(corFieldBeforeDecision.getRequestTimestamp())
             .setFormerRepresentationEmailAddress(
-                getFormerEmail(corFieldBeforeDecision.getCaseRoleId().getValue().getCode(), caseData));
+                getFormerEmail(corFieldBeforeDecision.getCaseRoleId().getValue().getCode(), caseData))
+            .setFormerRepresentationReference(
+                getFormerReference(corFieldBeforeDecision.getCaseRoleId().getValue().getCode(), caseData));
 
         if (corFieldBeforeDecision.getOrganisationToRemove() != null) {
             changeOfRepresentation.setOrganisationToRemoveID(
@@ -215,6 +218,34 @@ public class ApplyNoticeOfChangeDecisionCallbackHandler extends CallbackHandler 
         }
         if (CaseRole.RESPONDENTSOLICITORTWO.getFormattedName().equals(caseRole)) {
             return caseData.getRespondentSolicitor2EmailAddress();
+        }
+        return null;
+    }
+
+    /** Captures the reference the outgoing legal representative supplied for themselves.
+     * UpdateCaseDetailsAfterNoCHandler nullifies this reference before the parties are notified,
+     * so it has to be kept here in order to be shown in the email telling them they have come off record.
+     *
+     * @param caseRole the case role being replaced
+     * @param caseData caseData
+     * @return the former representative's own reference, or null when they did not provide one
+     */
+    private String getFormerReference(String caseRole, CaseData caseData) {
+        SolicitorReferences solicitorReferences = caseData.getSolicitorReferences();
+        if (CaseRole.APPLICANTSOLICITORONE.getFormattedName().equals(caseRole)) {
+            return Optional.ofNullable(solicitorReferences)
+                .map(SolicitorReferences::getApplicantSolicitor1Reference)
+                .orElse(null);
+        }
+        if (CaseRole.RESPONDENTSOLICITORONE.getFormattedName().equals(caseRole)) {
+            return Optional.ofNullable(solicitorReferences)
+                .map(SolicitorReferences::getRespondentSolicitor1Reference)
+                .orElse(null);
+        }
+        if (CaseRole.RESPONDENTSOLICITORTWO.getFormattedName().equals(caseRole)) {
+            return Optional.ofNullable(solicitorReferences)
+                .map(SolicitorReferences::getRespondentSolicitor2Reference)
+                .orElseGet(caseData::getRespondentSolicitor2Reference);
         }
         return null;
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/ChangeOfRepresentation.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/ChangeOfRepresentation.java
@@ -28,5 +28,7 @@ public class ChangeOfRepresentation {
     private LocalDateTime timestamp;
     @JsonProperty("formerRepresentationEmailAddress")
     private String formerRepresentationEmailAddress;
+    @JsonProperty("formerRepresentationReference")
+    private String formerRepresentationReference;
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCFormerSolicitorEmailDTOGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCFormerSolicitorEmailDTOGenerator.java
@@ -41,7 +41,7 @@ public class NoCFormerSolicitorEmailDTOGenerator extends EmailDTOGenerator {
         properties.putAll(noCHelper.getProperties(caseData, false));
         // the former solicitor's own reference has already been removed from the case by this point,
         // so restore it here to show it back to them in the email subject
-        properties.put(PARTY_REFERENCES, noCHelper.getFormerSolicitorPartyReferences(caseData));
+        properties.put(PARTY_REFERENCES, noCHelper.getNoCPartyReferences(caseData));
         return properties;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCFormerSolicitorEmailDTOGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCFormerSolicitorEmailDTOGenerator.java
@@ -39,6 +39,9 @@ public class NoCFormerSolicitorEmailDTOGenerator extends EmailDTOGenerator {
     @Override
     protected Map<String, String> addCustomProperties(Map<String, String> properties, CaseData caseData) {
         properties.putAll(noCHelper.getProperties(caseData, false));
+        // the former solicitor's own reference has already been removed from the case by this point,
+        // so restore it here to show it back to them in the email subject
+        properties.put(PARTY_REFERENCES, noCHelper.getFormerSolicitorPartyReferences(caseData));
         return properties;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCHelper.java
@@ -5,13 +5,18 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.civil.callback.CallbackException;
 import uk.gov.hmcts.reform.civil.enums.PaymentStatus;
 import uk.gov.hmcts.reform.civil.model.CaseData;
+import uk.gov.hmcts.reform.civil.model.ChangeOfRepresentation;
 import uk.gov.hmcts.reform.civil.model.PaymentDetails;
+import uk.gov.hmcts.reform.civil.model.SolicitorReferences;
 import uk.gov.hmcts.reform.civil.notification.handlers.changeofrepresentation.common.NotificationHelper;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
 
 import java.util.Map;
 import java.util.Optional;
 
+import static uk.gov.hmcts.reform.civil.enums.CaseRole.APPLICANTSOLICITORONE;
+import static uk.gov.hmcts.reform.civil.enums.CaseRole.RESPONDENTSOLICITORONE;
+import static uk.gov.hmcts.reform.civil.enums.CaseRole.RESPONDENTSOLICITORTWO;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.CASE_NAME;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.CCD_REF;
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.CLAIMANT_NAME;
@@ -32,6 +37,7 @@ import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.No
 import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.REFERENCE;
 import static uk.gov.hmcts.reform.civil.helpers.DateFormatHelper.DATE;
 import static uk.gov.hmcts.reform.civil.helpers.DateFormatHelper.formatLocalDate;
+import static uk.gov.hmcts.reform.civil.utils.NotificationUtils.buildPartiesReferencesEmailSubject;
 import static uk.gov.hmcts.reform.civil.utils.NotificationUtils.getApplicantLegalOrganizationName;
 
 @Component
@@ -74,6 +80,47 @@ public class NoCHelper {
             HEARING_FEE, String.valueOf(caseData.getHearingFee().formData()),
             HEARING_DUE_DATE, formatLocalDate(caseData.getHearingDueDate(), DATE)
         );
+    }
+
+    /** Builds the party references for the email telling the former legal representative they have come off record.
+     * Their own reference is removed from the case by UpdateCaseDetailsAfterNoCHandler before the parties are
+     * notified, so it is restored here from the value captured when the NoC decision was applied. Where no
+     * reference was provided the references currently held on the case are used unchanged.
+     *
+     * @param caseData caseData
+     * @return the party references for the email subject
+     */
+    public String getFormerSolicitorPartyReferences(CaseData caseData) {
+        ChangeOfRepresentation changeOfRepresentation = caseData.getChangeOfRepresentation();
+        String formerReference = changeOfRepresentation != null
+            ? changeOfRepresentation.getFormerRepresentationReference() : null;
+
+        if (formerReference == null) {
+            return buildPartiesReferencesEmailSubject(caseData);
+        }
+
+        SolicitorReferences currentReferences = caseData.getSolicitorReferences();
+        SolicitorReferences restoredReferences = new SolicitorReferences();
+        restoredReferences.setApplicantSolicitor1Reference(
+            currentReferences != null ? currentReferences.getApplicantSolicitor1Reference() : null);
+        restoredReferences.setRespondentSolicitor1Reference(
+            currentReferences != null ? currentReferences.getRespondentSolicitor1Reference() : null);
+        restoredReferences.setRespondentSolicitor2Reference(
+            currentReferences != null ? currentReferences.getRespondentSolicitor2Reference() : null);
+
+        String respondentSolicitor2Reference = caseData.getRespondentSolicitor2Reference();
+        String caseRole = changeOfRepresentation.getCaseRole();
+
+        if (APPLICANTSOLICITORONE.getFormattedName().equals(caseRole)) {
+            restoredReferences.setApplicantSolicitor1Reference(formerReference);
+        } else if (RESPONDENTSOLICITORONE.getFormattedName().equals(caseRole)) {
+            restoredReferences.setRespondentSolicitor1Reference(formerReference);
+        } else if (RESPONDENTSOLICITORTWO.getFormattedName().equals(caseRole)) {
+            restoredReferences.setRespondentSolicitor2Reference(formerReference);
+            respondentSolicitor2Reference = formerReference;
+        }
+
+        return buildPartiesReferencesEmailSubject(caseData, restoredReferences, respondentSolicitor2Reference);
     }
 
     public String getOrganisationName(String orgId) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCHelper.java
@@ -82,15 +82,15 @@ public class NoCHelper {
         );
     }
 
-    /** Builds the party references for the email telling the former legal representative they have come off record.
-     * Their own reference is removed from the case by UpdateCaseDetailsAfterNoCHandler before the parties are
-     * notified, so it is restored here from the value captured when the NoC decision was applied. Where no
-     * reference was provided the references currently held on the case are used unchanged.
+    /** Builds the party references for the notice of change emails. The outgoing legal representative's reference
+     * is removed from the case by UpdateCaseDetailsAfterNoCHandler before the parties are notified, so it is
+     * restored here from the value captured when the NoC decision was applied. Where no reference was provided
+     * the references currently held on the case are used unchanged.
      *
      * @param caseData caseData
      * @return the party references for the email subject
      */
-    public String getFormerSolicitorPartyReferences(CaseData caseData) {
+    public String getNoCPartyReferences(CaseData caseData) {
         ChangeOfRepresentation changeOfRepresentation = caseData.getChangeOfRepresentation();
         String formerReference = changeOfRepresentation != null
             ? changeOfRepresentation.getFormerRepresentationReference() : null;

--- a/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCOtherSolicitorOneEmailDTOGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCOtherSolicitorOneEmailDTOGenerator.java
@@ -39,6 +39,9 @@ public class NoCOtherSolicitorOneEmailDTOGenerator extends EmailDTOGenerator {
     @Override
     protected Map<String, String> addCustomProperties(Map<String, String> properties, CaseData caseData) {
         properties.putAll(noCHelper.getProperties(caseData, false));
+        // the outgoing solicitor's reference has already been removed from the case by this point,
+        // so restore it here to keep the email subject consistent with the earlier emails on the claim
+        properties.put(PARTY_REFERENCES, noCHelper.getNoCPartyReferences(caseData));
         return properties;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCOtherSolicitorTwoEmailDTOGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCOtherSolicitorTwoEmailDTOGenerator.java
@@ -41,6 +41,9 @@ public class NoCOtherSolicitorTwoEmailDTOGenerator extends EmailDTOGenerator {
     @Override
     protected Map<String, String> addCustomProperties(Map<String, String> properties, CaseData caseData) {
         properties.putAll(noCHelper.getProperties(caseData, true));
+        // the outgoing solicitor's reference has already been removed from the case by this point,
+        // so restore it here to keep the email subject consistent with the earlier emails on the claim
+        properties.put(PARTY_REFERENCES, noCHelper.getNoCPartyReferences(caseData));
         return properties;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/NocNotificationUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/NocNotificationUtils.java
@@ -199,6 +199,7 @@ public class NocNotificationUtils {
 
     public static CaseData getCaseDataWithoutFormerSolicitorEmail(CaseData caseData) {
         caseData.getChangeOfRepresentation().setFormerRepresentationEmailAddress(null);
+        caseData.getChangeOfRepresentation().setFormerRepresentationReference(null);
         return caseData;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/NotificationUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/NotificationUtils.java
@@ -235,12 +235,30 @@ public class NotificationUtils {
     }
 
     public static String buildPartiesReferencesEmailSubject(CaseData caseData) {
-        SolicitorReferences solicitorReferences = caseData.getSolicitorReferences();
+        return buildPartiesReferencesEmailSubject(
+            caseData,
+            caseData.getSolicitorReferences(),
+            caseData.getRespondentSolicitor2Reference()
+        );
+    }
+
+    /** Builds the party references shown in an email subject from the supplied references rather than the
+     * ones currently held on the case. Used where a reference has since been removed from the case but still
+     * needs to be shown to the party it belonged to, such as the notice of change former solicitor email.
+     *
+     * @param caseData caseData
+     * @param solicitorReferences the references to build the subject from
+     * @param respondentSolicitor2Reference fallback defendant 2 reference
+     * @return the party references for the email subject
+     */
+    public static String buildPartiesReferencesEmailSubject(CaseData caseData,
+                                                            SolicitorReferences solicitorReferences,
+                                                            String respondentSolicitor2Reference) {
         StringBuilder stringBuilder = new StringBuilder();
 
         boolean addRespondent2Reference = ONE_V_TWO_TWO_LEGAL_REP.equals(getMultiPartyScenario(caseData));
 
-        stringBuilder.append(buildClaimantReferenceEmailSubject(caseData));
+        stringBuilder.append(buildClaimantReferenceEmailSubject(solicitorReferences));
 
         if (!stringBuilder.isEmpty()) {
             stringBuilder.append(" - ");
@@ -262,11 +280,11 @@ public class NotificationUtils {
             }
 
             stringBuilder.append("Defendant 2 reference: ");
-            String respondent2Reference = caseData.getSolicitorReferences() != null
-                && caseData.getSolicitorReferences().getRespondentSolicitor2Reference() != null
-                ? caseData.getSolicitorReferences().getRespondentSolicitor2Reference()
-                : caseData.getRespondentSolicitor2Reference() != null
-                ? caseData.getRespondentSolicitor2Reference()
+            String respondent2Reference = solicitorReferences != null
+                && solicitorReferences.getRespondentSolicitor2Reference() != null
+                ? solicitorReferences.getRespondentSolicitor2Reference()
+                : respondentSolicitor2Reference != null
+                ? respondentSolicitor2Reference
                 : REFERENCE_NOT_PROVIDED;
             stringBuilder.append(respondent2Reference);
 
@@ -275,7 +293,10 @@ public class NotificationUtils {
     }
 
     public static String buildClaimantReferenceEmailSubject(CaseData caseData) {
-        SolicitorReferences solicitorReferences = caseData.getSolicitorReferences();
+        return buildClaimantReferenceEmailSubject(caseData.getSolicitorReferences());
+    }
+
+    public static String buildClaimantReferenceEmailSubject(SolicitorReferences solicitorReferences) {
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("Claimant reference: ");
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/noticeofchange/ClearFormerSolicitorInfoAfterNoCHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/camunda/noticeofchange/ClearFormerSolicitorInfoAfterNoCHandlerTest.java
@@ -41,8 +41,9 @@ class ClearFormerSolicitorInfoAfterNoCHandlerTest extends BaseCallbackHandlerTes
 
     @Test
     void shouldUpdateSolicitorDetails_afterNoCSubmittedByRespondentSolicitor1In1v2DiffSolicitorToDiffSolicitor() {
-        // Ensure that the former solicitor email exists before the callback
+        // Ensure that the former solicitor details exist before the callback
         assertNotNull(caseData.getChangeOfRepresentation().getFormerRepresentationEmailAddress());
+        assertNotNull(caseData.getChangeOfRepresentation().getFormerRepresentationReference());
 
         CallbackParams params = callbackParamsOf(caseData, ABOUT_TO_SUBMIT);
 
@@ -51,7 +52,8 @@ class ClearFormerSolicitorInfoAfterNoCHandlerTest extends BaseCallbackHandlerTes
 
         CaseData updatedCaseData = mapper.convertValue(response.getData(), CaseData.class);
 
-        // Assert that the former solicitor email is cleared in the updated case data
+        // Assert that the former solicitor details are cleared in the updated case data
         assertNull(updatedCaseData.getChangeOfRepresentation().getFormerRepresentationEmailAddress());
+        assertNull(updatedCaseData.getChangeOfRepresentation().getFormerRepresentationReference());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ApplyNoticeOfChangeDecisionCallbackHandlerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/handler/callback/user/ApplyNoticeOfChangeDecisionCallbackHandlerTest.java
@@ -290,11 +290,67 @@ class ApplyNoticeOfChangeDecisionCallbackHandlerTest extends BaseCallbackHandler
             return caseDetails;
         }
 
-        private void executeTest(CaseData caseData, String applicantOrRespondentOrgPolicy) {
-            executeTest(caseData, applicantOrRespondentOrgPolicy, "APPLY_NOC_DECISION");
+        @Test
+        void shouldCaptureFormerRepresentationReference_whenInvokedByRespondent1() {
+            AboutToStartOrSubmitCallbackResponse response = executeTest(
+                CaseDataBuilder.builder().atStateClaimIssued()
+                    .changeOrganisationRequestField(false, false, "1234", "QWERTY R", REQUESTER_EMAIL)
+                    .build(),
+                RESPONDENT_ONE_ORG_POLICY
+            );
+
+            assertThat(getChangeOfRepresentation(response).getFormerRepresentationReference()).isEqualTo("6789");
         }
 
-        private void executeTest(CaseData caseData, String applicantOrRespondentOrgPolicy, String camundaEvent) {
+        @Test
+        void shouldCaptureFormerRepresentationReference_whenInvokedByApplicant1() {
+            AboutToStartOrSubmitCallbackResponse response = executeTest(
+                CaseDataBuilder.builder().atStateClaimIssued()
+                    .changeOrganisationRequestField(true, false, "1234", "QWERTY A", REQUESTER_EMAIL)
+                    .build(),
+                APPLICANT_ONE_ORG_POLICY
+            );
+
+            assertThat(getChangeOfRepresentation(response).getFormerRepresentationReference()).isEqualTo("12345");
+        }
+
+        @Test
+        void shouldCaptureFormerRepresentationReference_whenInvokedByRespondent2For1v2DS() {
+            AboutToStartOrSubmitCallbackResponse response = executeTest(
+                CaseDataBuilder.builder().atStateClaimIssued()
+                    .multiPartyClaimTwoDefendantSolicitors()
+                    .changeOrganisationRequestField(false, true, "1234", "QWERTY R2", REQUESTER_EMAIL)
+                    .build(),
+                RESPONDENT_TWO_ORG_POLICY
+            );
+
+            assertThat(getChangeOfRepresentation(response).getFormerRepresentationReference()).isEqualTo("01234");
+        }
+
+        @Test
+        void shouldNotCaptureFormerRepresentationReference_whenNoReferenceProvided() {
+            AboutToStartOrSubmitCallbackResponse response = executeTest(
+                CaseDataBuilder.builder().atStateClaimIssued()
+                    .removeSolicitorReferences()
+                    .changeOrganisationRequestField(false, false, "1234", "QWERTY R", REQUESTER_EMAIL)
+                    .build(),
+                RESPONDENT_ONE_ORG_POLICY
+            );
+
+            assertThat(getChangeOfRepresentation(response).getFormerRepresentationReference()).isNull();
+        }
+
+        private ChangeOfRepresentation getChangeOfRepresentation(AboutToStartOrSubmitCallbackResponse response) {
+            return mapper.convertValue(
+                response.getData().get("changeOfRepresentation"), ChangeOfRepresentation.class);
+        }
+
+        private AboutToStartOrSubmitCallbackResponse executeTest(CaseData caseData,
+                                                                 String applicantOrRespondentOrgPolicy) {
+            return executeTest(caseData, applicantOrRespondentOrgPolicy, "APPLY_NOC_DECISION");
+        }
+
+        private AboutToStartOrSubmitCallbackResponse executeTest(CaseData caseData, String applicantOrRespondentOrgPolicy, String camundaEvent) {
             CallbackParams params = callbackParamsOf(caseData,
                                                      CaseDetails.builder().data(caseData.toMap(mapper)).build(), ABOUT_TO_SUBMIT);
 
@@ -313,6 +369,8 @@ class ApplyNoticeOfChangeDecisionCallbackHandlerTest extends BaseCallbackHandler
             assertChangeOrganisationFieldIsUpdated(response);
             assertOrgIDIsUpdated(response, applicantOrRespondentOrgPolicy);
             assertCamundaEventIsReady(response, camundaEvent);
+
+            return response;
         }
 
         private void assertChangeOrganisationFieldIsUpdated(AboutToStartOrSubmitCallbackResponse response) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCFormerSolicitorEmailDTOGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCFormerSolicitorEmailDTOGeneratorTest.java
@@ -84,7 +84,7 @@ class NoCFormerSolicitorEmailDTOGeneratorTest {
             );
 
             when(noCHelper.getProperties(caseData, false)).thenReturn(Map.of("key", "value"));
-            when(noCHelper.getFormerSolicitorPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
+            when(noCHelper.getNoCPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
 
             EmailDTO emailDTO = generator.buildEmailDTO(caseData, "taskId");
 
@@ -98,7 +98,7 @@ class NoCFormerSolicitorEmailDTOGeneratorTest {
     @Test
     void shouldAddFormerSolicitorPartyReferences() {
         when(noCHelper.getProperties(caseData, false)).thenReturn(Map.of("key", "value"));
-        when(noCHelper.getFormerSolicitorPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
+        when(noCHelper.getNoCPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
 
         Map<String, String> properties = generator.addCustomProperties(new HashMap<>(), caseData);
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCFormerSolicitorEmailDTOGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCFormerSolicitorEmailDTOGeneratorTest.java
@@ -14,11 +14,13 @@ import uk.gov.hmcts.reform.civil.notification.handlers.TemplateCommonPropertiesH
 import uk.gov.hmcts.reform.civil.notification.handlers.changeofrepresentation.common.NotificationHelper;
 import uk.gov.hmcts.reform.civil.notify.NotificationsProperties;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.PARTY_REFERENCES;
 
 @ExtendWith(MockitoExtension.class)
 class NoCFormerSolicitorEmailDTOGeneratorTest {
@@ -26,6 +28,8 @@ class NoCFormerSolicitorEmailDTOGeneratorTest {
     private static final String FORMER_SOLICITOR_EMAIL = "solicitor@example.com";
     private static final String TEMPLATE_ID = "template-id-123";
     private static final String CASE_REFERENCE = "000DC001";
+    private static final String PARTY_REFERENCES_VALUE =
+        "Claimant reference: claimant-ref - Defendant reference: defendant-ref";
 
     @Mock
     private NotificationsProperties notificationsProperties;
@@ -80,6 +84,7 @@ class NoCFormerSolicitorEmailDTOGeneratorTest {
             );
 
             when(noCHelper.getProperties(caseData, false)).thenReturn(Map.of("key", "value"));
+            when(noCHelper.getFormerSolicitorPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
 
             EmailDTO emailDTO = generator.buildEmailDTO(caseData, "taskId");
 
@@ -88,5 +93,15 @@ class NoCFormerSolicitorEmailDTOGeneratorTest {
             assertThat(emailDTO.getReference()).isEqualTo("notice-of-change-" + CASE_REFERENCE);
             assertThat(emailDTO.getParameters()).containsEntry("key", "value");
         }
+    }
+
+    @Test
+    void shouldAddFormerSolicitorPartyReferences() {
+        when(noCHelper.getProperties(caseData, false)).thenReturn(Map.of("key", "value"));
+        when(noCHelper.getFormerSolicitorPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
+
+        Map<String, String> properties = generator.addCustomProperties(new HashMap<>(), caseData);
+
+        assertThat(properties).containsEntry(PARTY_REFERENCES, PARTY_REFERENCES_VALUE);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCHelperTest.java
@@ -122,7 +122,7 @@ class NoCHelperTest {
     }
 
     @Test
-    void getFormerSolicitorPartyReferences_shouldRestoreFormerDefendantSolicitorReference() {
+    void getNoCPartyReferences_shouldRestoreFormerDefendantSolicitorReference() {
         CaseData caseData = baseCaseData.toBuilder()
             .respondent2(null)
             // reference has already been removed from the case by UpdateCaseDetailsAfterNoCHandler
@@ -133,12 +133,12 @@ class NoCHelperTest {
                                         .setFormerRepresentationReference("defendant-ref"))
             .build();
 
-        assertThat(noCHelper.getFormerSolicitorPartyReferences(caseData))
+        assertThat(noCHelper.getNoCPartyReferences(caseData))
             .isEqualTo("Claimant reference: claimant-ref - Defendant reference: defendant-ref");
     }
 
     @Test
-    void getFormerSolicitorPartyReferences_shouldRestoreFormerClaimantSolicitorReference() {
+    void getNoCPartyReferences_shouldRestoreFormerClaimantSolicitorReference() {
         CaseData caseData = baseCaseData.toBuilder()
             .respondent2(null)
             .solicitorReferences(new SolicitorReferences()
@@ -148,12 +148,12 @@ class NoCHelperTest {
                                         .setFormerRepresentationReference("claimant-ref"))
             .build();
 
-        assertThat(noCHelper.getFormerSolicitorPartyReferences(caseData))
+        assertThat(noCHelper.getNoCPartyReferences(caseData))
             .isEqualTo("Claimant reference: claimant-ref - Defendant reference: defendant-ref");
     }
 
     @Test
-    void getFormerSolicitorPartyReferences_shouldRestoreFormerDefendant2SolicitorReference() {
+    void getNoCPartyReferences_shouldRestoreFormerDefendant2SolicitorReference() {
         CaseData caseData = baseCaseData.toBuilder()
             .respondent2SameLegalRepresentative(YesOrNo.NO)
             .respondent2Represented(YesOrNo.YES)
@@ -165,13 +165,13 @@ class NoCHelperTest {
                                         .setFormerRepresentationReference("defendant-2-ref"))
             .build();
 
-        assertThat(noCHelper.getFormerSolicitorPartyReferences(caseData))
+        assertThat(noCHelper.getNoCPartyReferences(caseData))
             .isEqualTo("Claimant reference: claimant-ref - Defendant 1 reference: defendant-1-ref"
                            + " - Defendant 2 reference: defendant-2-ref");
     }
 
     @Test
-    void getFormerSolicitorPartyReferences_shouldFallBackToCaseReferencesWhenNoFormerReferenceProvided() {
+    void getNoCPartyReferences_shouldFallBackToCaseReferencesWhenNoFormerReferenceProvided() {
         CaseData caseData = baseCaseData.toBuilder()
             .respondent2(null)
             .solicitorReferences(new SolicitorReferences()
@@ -180,7 +180,7 @@ class NoCHelperTest {
                                         .setCaseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()))
             .build();
 
-        assertThat(noCHelper.getFormerSolicitorPartyReferences(caseData))
+        assertThat(noCHelper.getNoCPartyReferences(caseData))
             .isEqualTo("Claimant reference: claimant-ref - Defendant reference: Not provided");
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCHelperTest.java
@@ -15,6 +15,7 @@ import uk.gov.hmcts.reform.civil.model.ChangeOfRepresentation;
 import uk.gov.hmcts.reform.civil.model.Fee;
 import uk.gov.hmcts.reform.civil.model.Party;
 import uk.gov.hmcts.reform.civil.model.PaymentDetails;
+import uk.gov.hmcts.reform.civil.model.SolicitorReferences;
 import uk.gov.hmcts.reform.civil.model.common.DynamicList;
 import uk.gov.hmcts.reform.civil.model.common.DynamicListElement;
 import uk.gov.hmcts.reform.civil.prd.model.Organisation;
@@ -118,6 +119,69 @@ class NoCHelperTest {
             .containsEntry(OTHER_SOL_NAME, "App Legal Org")
             .containsEntry(LEGAL_REP_NAME_WITH_SPACE, "New Org")
             .containsEntry(REFERENCE, "1234567890123456");
+    }
+
+    @Test
+    void getFormerSolicitorPartyReferences_shouldRestoreFormerDefendantSolicitorReference() {
+        CaseData caseData = baseCaseData.toBuilder()
+            .respondent2(null)
+            // reference has already been removed from the case by UpdateCaseDetailsAfterNoCHandler
+            .solicitorReferences(new SolicitorReferences()
+                                     .setApplicantSolicitor1Reference("claimant-ref"))
+            .changeOfRepresentation(new ChangeOfRepresentation()
+                                        .setCaseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName())
+                                        .setFormerRepresentationReference("defendant-ref"))
+            .build();
+
+        assertThat(noCHelper.getFormerSolicitorPartyReferences(caseData))
+            .isEqualTo("Claimant reference: claimant-ref - Defendant reference: defendant-ref");
+    }
+
+    @Test
+    void getFormerSolicitorPartyReferences_shouldRestoreFormerClaimantSolicitorReference() {
+        CaseData caseData = baseCaseData.toBuilder()
+            .respondent2(null)
+            .solicitorReferences(new SolicitorReferences()
+                                     .setRespondentSolicitor1Reference("defendant-ref"))
+            .changeOfRepresentation(new ChangeOfRepresentation()
+                                        .setCaseRole(CaseRole.APPLICANTSOLICITORONE.getFormattedName())
+                                        .setFormerRepresentationReference("claimant-ref"))
+            .build();
+
+        assertThat(noCHelper.getFormerSolicitorPartyReferences(caseData))
+            .isEqualTo("Claimant reference: claimant-ref - Defendant reference: defendant-ref");
+    }
+
+    @Test
+    void getFormerSolicitorPartyReferences_shouldRestoreFormerDefendant2SolicitorReference() {
+        CaseData caseData = baseCaseData.toBuilder()
+            .respondent2SameLegalRepresentative(YesOrNo.NO)
+            .respondent2Represented(YesOrNo.YES)
+            .solicitorReferences(new SolicitorReferences()
+                                     .setApplicantSolicitor1Reference("claimant-ref")
+                                     .setRespondentSolicitor1Reference("defendant-1-ref"))
+            .changeOfRepresentation(new ChangeOfRepresentation()
+                                        .setCaseRole(CaseRole.RESPONDENTSOLICITORTWO.getFormattedName())
+                                        .setFormerRepresentationReference("defendant-2-ref"))
+            .build();
+
+        assertThat(noCHelper.getFormerSolicitorPartyReferences(caseData))
+            .isEqualTo("Claimant reference: claimant-ref - Defendant 1 reference: defendant-1-ref"
+                           + " - Defendant 2 reference: defendant-2-ref");
+    }
+
+    @Test
+    void getFormerSolicitorPartyReferences_shouldFallBackToCaseReferencesWhenNoFormerReferenceProvided() {
+        CaseData caseData = baseCaseData.toBuilder()
+            .respondent2(null)
+            .solicitorReferences(new SolicitorReferences()
+                                     .setApplicantSolicitor1Reference("claimant-ref"))
+            .changeOfRepresentation(new ChangeOfRepresentation()
+                                        .setCaseRole(CaseRole.RESPONDENTSOLICITORONE.getFormattedName()))
+            .build();
+
+        assertThat(noCHelper.getFormerSolicitorPartyReferences(caseData))
+            .isEqualTo("Claimant reference: claimant-ref - Defendant reference: Not provided");
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCOtherSolicitorOneEmailDTOGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCOtherSolicitorOneEmailDTOGeneratorTest.java
@@ -19,9 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.PARTY_REFERENCES;
 
 @ExtendWith(MockitoExtension.class)
 class NoCOtherSolicitorOneEmailDTOGeneratorTest {
+
+    private static final String PARTY_REFERENCES_VALUE =
+        "Claimant reference: ClaimantRef - Defendant reference: DefendantRef";
 
     @Mock
     private NotificationsProperties notificationsProperties;
@@ -85,9 +89,21 @@ class NoCOtherSolicitorOneEmailDTOGeneratorTest {
         Map<String, String> additionalProps = Map.of("key", "value");
 
         when(noCHelper.getProperties(caseData, false)).thenReturn(additionalProps);
+        when(noCHelper.getNoCPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
 
         Map<String, String> result = generator.addCustomProperties(initialProps, caseData);
 
         assertEquals("value", result.get("key"));
+    }
+
+    @Test
+    void shouldAddPartyReferencesIncludingTheOutgoingSolicitorReference() {
+        CaseData caseData = mock(CaseData.class);
+        when(noCHelper.getProperties(caseData, false)).thenReturn(Map.of("key", "value"));
+        when(noCHelper.getNoCPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
+
+        Map<String, String> result = generator.addCustomProperties(new HashMap<>(), caseData);
+
+        assertEquals(PARTY_REFERENCES_VALUE, result.get(PARTY_REFERENCES));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCOtherSolicitorTwoEmailDTOGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/notification/handlers/changeofrepresentation/otherflow/NoCOtherSolicitorTwoEmailDTOGeneratorTest.java
@@ -22,9 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.civil.handler.callback.camunda.notification.NotificationData.PARTY_REFERENCES;
 
 @ExtendWith(MockitoExtension.class)
 class NoCOtherSolicitorTwoEmailDTOGeneratorTest {
+
+    private static final String PARTY_REFERENCES_VALUE =
+        "Claimant reference: ClaimantRef - Defendant 1 reference: DefendantRef - Defendant 2 reference: Defendant2Ref";
 
     @Mock
     private NotificationsProperties notificationsProperties;
@@ -110,11 +114,23 @@ class NoCOtherSolicitorTwoEmailDTOGeneratorTest {
 
         Map<String, String> custom = Map.of("customKey", "customValue");
         when(noCHelper.getProperties(caseData, true)).thenReturn(custom);
+        when(noCHelper.getNoCPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
 
         Map<String, String> result = generator.addCustomProperties(existing, caseData);
 
-        assertEquals(2, result.size());
+        assertEquals(3, result.size());
         assertEquals("value", result.get("existing"));
         assertEquals("customValue", result.get("customKey"));
+    }
+
+    @Test
+    void shouldAddPartyReferencesIncludingTheOutgoingSolicitorReference() {
+        CaseData caseData = mock(CaseData.class);
+        when(noCHelper.getProperties(caseData, true)).thenReturn(Map.of("customKey", "customValue"));
+        when(noCHelper.getNoCPartyReferences(caseData)).thenReturn(PARTY_REFERENCES_VALUE);
+
+        Map<String, String> result = generator.addCustomProperties(new HashMap<>(), caseData);
+
+        assertEquals(PARTY_REFERENCES_VALUE, result.get(PARTY_REFERENCES));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/sampledata/CaseDataBuilder.java
@@ -3333,6 +3333,7 @@ public class CaseDataBuilder {
             .setTimestamp(LocalDateTime.now());
         if (formerSolicitorEmail != null) {
             newChange.setFormerRepresentationEmailAddress(formerSolicitorEmail);
+            newChange.setFormerRepresentationReference("previous-solicitor-reference");
         }
         changeOfRepresentation = newChange;
         return this;

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/NotificationUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/NotificationUtilsTest.java
@@ -10,6 +10,7 @@ import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.ccd.model.OrganisationPolicy;
 import uk.gov.hmcts.reform.civil.model.IdamUserDetails;
 import uk.gov.hmcts.reform.civil.model.Party;
+import uk.gov.hmcts.reform.civil.model.SolicitorReferences;
 import uk.gov.hmcts.reform.civil.model.citizenui.CaseDataLiP;
 import uk.gov.hmcts.reform.civil.notify.NotificationsSignatureConfiguration;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
@@ -105,6 +106,76 @@ class NotificationUtilsTest {
             .solicitorReferences(null).build();
 
         String actual = NotificationUtils.buildPartiesReferencesEmailSubject(caseData);
+
+        assertThat(actual).isEqualTo("Claimant reference: Not provided - Defendant 1 reference: Not provided - Defendant 2 reference: Not provided");
+    }
+
+    @Test
+    void shouldReturnSuppliedReferences_whenTheyDifferFromTheOnesOnTheCase() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .atStateApplicantRespondToDefenceAndProceed()
+            .build();
+        SolicitorReferences suppliedReferences = new SolicitorReferences()
+            .setApplicantSolicitor1Reference("restored-claimant-ref")
+            .setRespondentSolicitor1Reference("restored-defendant-ref");
+
+        String actual = NotificationUtils.buildPartiesReferencesEmailSubject(
+            caseData, suppliedReferences, caseData.getRespondentSolicitor2Reference());
+
+        assertThat(actual).isEqualTo("Claimant reference: restored-claimant-ref - Defendant reference: restored-defendant-ref");
+    }
+
+    @Test
+    void shouldUseFallbackRespondent2Reference_when1v2DSSuppliedReferencesAreNull() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .multiPartyClaimTwoDefendantSolicitors()
+            .atStateApplicantRespondToDefenceAndProceed()
+            .build();
+
+        String actual = NotificationUtils.buildPartiesReferencesEmailSubject(caseData, null, "01234");
+
+        assertThat(actual).isEqualTo("Claimant reference: Not provided - Defendant 1 reference: Not provided - Defendant 2 reference: 01234");
+    }
+
+    @Test
+    void shouldUseFallbackRespondent2Reference_when1v2DSSuppliedRespondent2ReferenceIsNull() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .multiPartyClaimTwoDefendantSolicitors()
+            .atStateApplicantRespondToDefenceAndProceed()
+            .build();
+        SolicitorReferences suppliedReferences = new SolicitorReferences()
+            .setApplicantSolicitor1Reference("12345")
+            .setRespondentSolicitor1Reference("6789");
+
+        String actual = NotificationUtils.buildPartiesReferencesEmailSubject(caseData, suppliedReferences, "01234");
+
+        assertThat(actual).isEqualTo("Claimant reference: 12345 - Defendant 1 reference: 6789 - Defendant 2 reference: 01234");
+    }
+
+    @Test
+    void shouldPreferSuppliedRespondent2Reference_when1v2DSFallbackAlsoProvided() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .multiPartyClaimTwoDefendantSolicitors()
+            .atStateApplicantRespondToDefenceAndProceed()
+            .build();
+        SolicitorReferences suppliedReferences = new SolicitorReferences()
+            .setApplicantSolicitor1Reference("12345")
+            .setRespondentSolicitor1Reference("6789")
+            .setRespondentSolicitor2Reference("restored-defendant2-ref");
+
+        String actual = NotificationUtils.buildPartiesReferencesEmailSubject(caseData, suppliedReferences, "01234");
+
+        assertThat(actual).isEqualTo("Claimant reference: 12345 - Defendant 1 reference: 6789 - Defendant 2 reference: restored-defendant2-ref");
+    }
+
+    @Test
+    void shouldReturnNotProvided_when1v2DSSuppliedReferencesAndFallbackAreNull() {
+        CaseData caseData = CaseDataBuilder.builder()
+            .multiPartyClaimTwoDefendantSolicitors()
+            .atStateApplicantRespondToDefenceAndProceed()
+            .build();
+
+        String actual = NotificationUtils.buildPartiesReferencesEmailSubject(caseData, null, null);
 
         assertThat(actual).isEqualTo("Claimant reference: Not provided - Defendant 1 reference: Not provided - Defendant 2 reference: Not provided");
     }


### PR DESCRIPTION
…email

  The outgoing legal representative's reference is cleared from the case by
  UpdateCaseDetailsAfterNoCHandler before the parties are notified, so the
  you have come off record email showed  (not provided) in its subject.

  Capture the reference on ChangeOfRepresentation when the NoC decision is
  applied, and restore it into the party references when building the former
  solicitor email subject. buildPartiesReferencesEmailSubject now has an
  overload that takes the references to use instead of reading them off the
  case, and the captured reference is cleared alongside the former email.

**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x ] README and other documentation has been updated / added (if needed)
- [x ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
[DTSCCI-6001](https://tools.hmcts.net/jira/browse/DTSCCI-6001)


### Change description ###

Add reference to notification (NOC) (When a LR replaces another LR (NOC) we send a notification saying to the original LR that you have come off record, but we do not provide their reference if one has been provided)

AC1:
Given there is a LR for claimant or defendant
When another LR (from another Organisation) 
And the first LR receives an email that they are no longer representing the client
Then include the reference number in the Email Subject

Notes:

From LR Org A there's an NOC to LR in Org B. In the email that is sent out to Org A solicitor, we want to include the reference number in the email notification which tells them they have been unassigned from the case. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
