### PR TITLE
DTSCCI-6088 Handle duplicate payment calls

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/fees/FeesPaymentControllerTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/controllers/fees/FeesPaymentControllerTest.java
@@ -14,6 +14,7 @@ import uk.gov.hmcts.reform.civil.BaseIntegrationTest;
 import uk.gov.hmcts.reform.civil.ga.service.GaCoreCaseDataService;
 import uk.gov.hmcts.reform.civil.model.CardPaymentStatusResponse;
 import uk.gov.hmcts.reform.civil.model.Fee;
+import uk.gov.hmcts.reform.civil.model.PaymentDetails;
 import uk.gov.hmcts.reform.civil.model.SRPbaDetails;
 import uk.gov.hmcts.reform.civil.model.genapplication.GAPbaDetails;
 import uk.gov.hmcts.reform.civil.service.CoreCaseDataService;
@@ -48,10 +49,6 @@ import static uk.gov.hmcts.reform.civil.enums.FeeType.HEARING;
 
 public class FeesPaymentControllerTest extends BaseIntegrationTest {
 
-    private static final StartEventResponse START_EVENT_RESPONSE = StartEventResponse.builder()
-        .eventId("eventId")
-        .token("token")
-        .build();
     private static final Long CASE_REFERENCE = 1701090368574910L;
     private static final CaseDetails EXPECTED_CASE_DETAILS = CaseDetails.builder().id(CASE_REFERENCE)
         .data(Map.of(
@@ -61,6 +58,11 @@ public class FeesPaymentControllerTest extends BaseIntegrationTest {
             "hearingFee",
             new Fee().setCalculatedAmountInPence(new BigDecimal("23200"))
         )).build();
+    private static final StartEventResponse START_EVENT_RESPONSE = StartEventResponse.builder()
+        .eventId("eventId")
+        .token("token")
+        .caseDetails(EXPECTED_CASE_DETAILS)
+        .build();
     private static final String HEARING_PAYMENT_RETURN_URL =
         "http://localhost:3001/hearing-payment-confirmation/" + CASE_REFERENCE;
 
@@ -146,6 +148,40 @@ public class FeesPaymentControllerTest extends BaseIntegrationTest {
         verify(coreCaseDataService, times(3)).getCase(123L);
         verify(coreCaseDataService, times(3)).startUpdate("123", SERVICE_REQUEST_RECEIVED);
         verify(coreCaseDataService, times(3)).submitUpdate(eq("123"), any(CaseDataContent.class));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"Success"})
+    @SneakyThrows
+    void shouldNotCallSubmitUpdate_WhenPaymentAlreadyApplied(String status) {
+        String paymentReference = "RC-1701-0909-0602-0418";
+        PaymentDto response = buildGovPayCardPaymentStatusResponse(status);
+        when(paymentsClient.getGovPayCardPaymentStatus(paymentReference, BEARER_TOKEN))
+            .thenReturn(response);
+
+        CaseDetails caseDetailsWithPayment = CaseDetails.builder().id(123L)
+            .data(Map.of(
+                "hearingFeePaymentDetails",
+                new PaymentDetails()
+                    .setStatus(uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS)
+                    .setReference(paymentReference)
+            )).build();
+
+        when(coreCaseDataService.getCase(123L)).thenReturn(caseDetailsWithPayment);
+        when(coreCaseDataService.startUpdate("123", SERVICE_REQUEST_RECEIVED))
+            .thenReturn(StartEventResponse.builder()
+                            .eventId("eventId")
+                            .token("token")
+                            .caseDetails(caseDetailsWithPayment)
+                            .build());
+
+        doGet(BEARER_TOKEN, FEES_PAYMENT_STATUS_URL, HEARING.name(), "123", paymentReference)
+            .andExpect(content().json(toJson(expectedResponse(status))))
+            .andExpect(status().isOk());
+
+        verify(coreCaseDataService).getCase(123L);
+        verify(coreCaseDataService).startUpdate("123", SERVICE_REQUEST_RECEIVED);
+        verify(coreCaseDataService, times(0)).submitUpdate(eq("123"), any(CaseDataContent.class));
     }
 
     @Nested
@@ -243,6 +279,41 @@ public class FeesPaymentControllerTest extends BaseIntegrationTest {
             verify(gaCoreCaseDataService, times(3)).getCase(123L);
             verify(gaCoreCaseDataService, times(3)).startUpdate("123", INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT);
             verify(gaCoreCaseDataService, times(3)).submitUpdate(eq("123"), any(CaseDataContent.class));
+        }
+
+        @ParameterizedTest
+        @CsvSource({"Success"})
+        @SneakyThrows
+        void shouldNotCallSubmitUpdate_WhenPaymentAlreadyApplied(String status) {
+            String paymentReference = "RC-1701-0909-0602-0418";
+            PaymentDto response = buildGovPayCardPaymentStatusResponse(status);
+            when(paymentsClient.getGovPayCardPaymentStatus(paymentReference, BEARER_TOKEN))
+                .thenReturn(response);
+
+            CaseDetails caseDetailsWithPayment = CaseDetails.builder().id(123L)
+                .data(Map.of(
+                    "generalAppPBADetails",
+                    new GAPbaDetails()
+                        .setPaymentDetails(new PaymentDetails()
+                                            .setStatus(uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS)
+                                            .setReference(paymentReference))
+                )).build();
+
+            when(gaCoreCaseDataService.getCase(123L)).thenReturn(caseDetailsWithPayment);
+            when(gaCoreCaseDataService.startUpdate("123", INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT))
+                .thenReturn(StartEventResponse.builder()
+                                .eventId("eventId")
+                                .token("token")
+                                .caseDetails(caseDetailsWithPayment)
+                                .build());
+
+            doGet(BEARER_TOKEN, GA_FEES_PAYMENT_STATUS_URL, "123", paymentReference)
+                .andExpect(content().json(toJson(gaExpectedResponse(status))))
+                .andExpect(status().isOk());
+
+            verify(gaCoreCaseDataService).getCase(123L);
+            verify(gaCoreCaseDataService).startUpdate("123", INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT);
+            verify(gaCoreCaseDataService, times(0)).submitUpdate(eq("123"), any(CaseDataContent.class));
         }
 
         private CardPaymentStatusResponse gaExpectedResponse(String status) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackService.java
@@ -20,7 +20,6 @@ import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.GeneralAppParentCaseLink;
 import uk.gov.hmcts.reform.civil.model.PaymentDetails;
 import uk.gov.hmcts.reform.civil.model.ServiceRequestUpdateDto;
-import uk.gov.hmcts.reform.civil.notify.NotificationException;
 import uk.gov.hmcts.reform.civil.service.Time;
 import uk.gov.hmcts.reform.payments.client.models.PaymentDto;
 
@@ -56,7 +55,7 @@ public class GaPaymentRequestUpdateCallbackService {
         return processServiceRequest(serviceRequestUpdateDto, caseData, true);
     }
 
-    @Retryable(retryFor = CaseDataUpdateException.class, backoff = @Backoff(delay = 500))
+    @Retryable(retryFor = CaseDataUpdateException.class, noRetryFor = IllegalArgumentException.class, backoff = @Backoff(delay = 500))
     public GeneralApplicationCaseData processServiceRequest(ServiceRequestUpdateDto serviceRequestUpdateDto,
                                                             GeneralApplicationCaseData caseData,
                                                             boolean hwf) {
@@ -76,6 +75,8 @@ public class GaPaymentRequestUpdateCallbackService {
             } else {
                 log.error("Case id {} not present", serviceRequestUpdateDto.getCcdCaseNumber());
             }
+        } catch (IllegalArgumentException ex) {
+            throw ex;
         } catch (Exception ex) {
             throw new CaseDataUpdateException(ex.getMessage(), ex);
         }
@@ -112,85 +113,70 @@ public class GaPaymentRequestUpdateCallbackService {
                                                     boolean hwf) {
         log.info("Processing the callback for making Additional Payment"
                      + "for the caseId {}", serviceRequestUpdateDto.getCcdCaseNumber());
-        try {
-
-            if (!isGeneralAppConsentOrder(caseData)) {
-                judicialNotificationService.sendNotification(caseData, "respondent");
-            }
-
-            caseData = updateCaseDataWithStateAndPaymentDetails(serviceRequestUpdateDto, caseData);
-            if (!hwf) {
-                createEvent(caseData, MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID,
-                        serviceRequestUpdateDto.getCcdCaseNumber());
-            }
-            return caseData;
-
-        } catch (NotificationException e) {
-            log.info("processing callback failed at Judicial Notification service, "
-                         + "please update the caseData with ga status "
-                         + "along with the Additional payment details "
-                         + "and trigger MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID event  %s ", e);
+        if (!isGeneralAppConsentOrder(caseData)) {
+            judicialNotificationService.sendNotification(caseData, "respondent");
         }
-        return null;
-    }
 
-    private GeneralApplicationCaseData updateCaseDataWithPaymentDetails(ServiceRequestUpdateDto serviceRequestUpdateDto,
-                                                      GeneralApplicationCaseData caseData) {
-        GeneralApplicationPbaDetails pbaDetails = caseData.getGeneralAppPBADetails();
-        String paymentReference = ofNullable(serviceRequestUpdateDto.getPayment())
-            .map(PaymentDto::getCustomerReference)
-            .orElse(pbaDetails.getServiceReqReference());
-
-        PaymentDetails paymentDetails = ofNullable(pbaDetails.getPaymentDetails())
-            .map(PaymentDetails::copy)
-            .orElse(new PaymentDetails())
-            .setStatus(SUCCESS)
-            .setCustomerReference(paymentReference)
-            .setReference(serviceRequestUpdateDto.getPayment().getPaymentReference())
-            .setErrorCode(null)
-            .setErrorMessage(null)
-            ;
-
-        GeneralApplicationPbaDetails updatedPbaDetails = pbaDetails.copy();
-        updatedPbaDetails
-            .setPaymentDetails(paymentDetails)
-            .setPaymentSuccessfulDate(time.now());
-
-        caseData = caseData.copy()
-            .generalAppPBADetails(updatedPbaDetails)
-            .build();
-
+        caseData = updateCaseDataWithStateAndPaymentDetails(serviceRequestUpdateDto, caseData);
+        if (!hwf) {
+            createEvent(caseData, MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID,
+                        serviceRequestUpdateDto.getCcdCaseNumber());
+        }
         return caseData;
     }
 
-    private GeneralApplicationCaseData updateCaseDataWithStateAndPaymentDetails(ServiceRequestUpdateDto serviceRequestUpdateDto,
-                                                              GeneralApplicationCaseData caseData) {
+    private GeneralApplicationCaseData updateCaseDataWithPaymentDetails(ServiceRequestUpdateDto serviceRequestUpdateDto,
+                                                                        GeneralApplicationCaseData caseData) {
         GeneralApplicationPbaDetails pbaDetails = caseData.getGeneralAppPBADetails();
-        String customerReference = ofNullable(serviceRequestUpdateDto.getPayment())
-            .map(PaymentDto::getCustomerReference)
-            .orElse(pbaDetails.getAdditionalPaymentServiceRef());
+        PaymentDetails paymentDetails = buildPaymentDetails(serviceRequestUpdateDto,
+                                                            pbaDetails.getPaymentDetails(),
+                                                            pbaDetails.getServiceReqReference());
 
-        PaymentDetails paymentDetails = ofNullable(pbaDetails.getAdditionalPaymentDetails())
+        GeneralApplicationPbaDetails updatedPbaDetails = pbaDetails.copy()
+            .setPaymentDetails(paymentDetails)
+            .setPaymentSuccessfulDate(time.now());
+
+        return caseData.copy()
+            .generalAppPBADetails(updatedPbaDetails)
+            .build();
+    }
+
+    private GeneralApplicationCaseData updateCaseDataWithStateAndPaymentDetails(ServiceRequestUpdateDto serviceRequestUpdateDto,
+                                                                                GeneralApplicationCaseData caseData) {
+        GeneralApplicationPbaDetails pbaDetails = caseData.getGeneralAppPBADetails();
+        PaymentDetails paymentDetails = buildPaymentDetails(serviceRequestUpdateDto,
+                                                            pbaDetails.getAdditionalPaymentDetails(),
+                                                            pbaDetails.getAdditionalPaymentServiceRef());
+
+        GeneralApplicationPbaDetails updatedPbaDetails = pbaDetails.copy()
+            .setAdditionalPaymentDetails(paymentDetails)
+            .setPaymentSuccessfulDate(time.now());
+
+        return caseData.copy()
+            .ccdState(stateGeneratorService.getCaseStateForEndJudgeBusinessProcess(caseData))
+            .generalAppPBADetails(updatedPbaDetails)
+            .build();
+    }
+
+    private PaymentDetails buildPaymentDetails(ServiceRequestUpdateDto serviceRequestUpdateDto,
+                                               PaymentDetails existingDetails,
+                                               String fallbackCustomerReference) {
+        PaymentDto payment = serviceRequestUpdateDto.getPayment();
+        String customerReference = ofNullable(payment)
+            .map(PaymentDto::getCustomerReference)
+            .orElse(fallbackCustomerReference);
+        String paymentReference = ofNullable(payment)
+            .map(PaymentDto::getPaymentReference)
+            .orElse(customerReference);
+
+        return ofNullable(existingDetails)
             .map(PaymentDetails::copy)
             .orElse(new PaymentDetails())
             .setStatus(SUCCESS)
             .setCustomerReference(customerReference)
-            .setReference(serviceRequestUpdateDto.getPayment().getPaymentReference())
+            .setReference(paymentReference)
             .setErrorCode(null)
-            .setErrorMessage(null)
-            ;
-
-        GeneralApplicationPbaDetails updatedPbaDetails = pbaDetails.copy();
-        updatedPbaDetails
-            .setAdditionalPaymentDetails(paymentDetails)
-            .setPaymentSuccessfulDate(time.now());
-
-        caseData = caseData.copy()
-            .ccdState(stateGeneratorService.getCaseStateForEndJudgeBusinessProcess(caseData))
-            .generalAppPBADetails(updatedPbaDetails)
-            .build();
-
-        return caseData;
+            .setErrorMessage(null);
     }
 
     private void createEvent(GeneralApplicationCaseData updatedStaleCaseData, CaseEvent eventName, String generalApplicationCaseId) {
@@ -236,7 +222,6 @@ public class GaPaymentRequestUpdateCallbackService {
         freshPba.setPaymentSuccessfulDate(stalePba.getPaymentSuccessfulDate());
 
         freshData.setGeneralAppPBADetails(freshPba);
-        freshData.setCcdState(updatedStaleCaseData.getCcdState());
     }
 
     private PaymentDetails getPaymentDetails(CaseEvent eventName, GeneralApplicationCaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackService.java
@@ -204,13 +204,24 @@ public class GaPaymentRequestUpdateCallbackService {
         PaymentDetails freshPayment = getPaymentDetails(eventName, freshData);
 
         if (isPaymentAlreadyApplied(intendedPayment, freshPayment)) {
-            String reference = freshPayment != null ? freshPayment.getReference() : "N/A";
-            log.info("{} Payment with reference {} already applied for case {}. Skipping submission.",
-                     eventName == INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT ? "Application" : "Additional",
-                     reference, generalApplicationCaseId);
+            log.info("{} Payment already applied for case {}. Skipping submission.",
+                     eventName == INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT ? "Application" : "Additional", generalApplicationCaseId);
             return;
         }
 
+        populateFreshData(updatedStaleCaseData, eventName, freshData);
+
+        CaseDataContent caseDataContent = buildCaseDataContent(
+            startEventResponse,
+            freshData,
+            freshData.getBusinessProcess(),
+            generalApplicationCaseId,
+            freshData.getGeneralAppParentCaseLink()
+        );
+        coreCaseDataService.submitGaUpdate(generalApplicationCaseId, caseDataContent);
+    }
+
+    private static void populateFreshData(GeneralApplicationCaseData updatedStaleCaseData, CaseEvent eventName, GeneralApplicationCaseData freshData) {
         GeneralApplicationPbaDetails freshPba = ofNullable(freshData.getGeneralAppPBADetails())
             .map(GeneralApplicationPbaDetails::copy)
             .orElse(new GeneralApplicationPbaDetails());
@@ -226,15 +237,6 @@ public class GaPaymentRequestUpdateCallbackService {
 
         freshData.setGeneralAppPBADetails(freshPba);
         freshData.setCcdState(updatedStaleCaseData.getCcdState());
-
-        CaseDataContent caseDataContent = buildCaseDataContent(
-            startEventResponse,
-            freshData,
-            freshData.getBusinessProcess(),
-            generalApplicationCaseId,
-            freshData.getGeneralAppParentCaseLink()
-        );
-        coreCaseDataService.submitGaUpdate(generalApplicationCaseId, caseDataContent);
     }
 
     private PaymentDetails getPaymentDetails(CaseEvent eventName, GeneralApplicationCaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackService.java
@@ -4,11 +4,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDataContent;
 import uk.gov.hmcts.reform.ccd.client.model.Event;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
+import uk.gov.hmcts.reform.civil.exceptions.CaseDataUpdateException;
 import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.ga.model.genapplication.GeneralApplicationPbaDetails;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
@@ -28,23 +32,19 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.INITIATE_GENERAL_APPL
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID;
 import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS;
 import static uk.gov.hmcts.reform.civil.ga.utils.JudicialDecisionNotificationUtil.isGeneralAppConsentOrder;
+import static uk.gov.hmcts.reform.civil.utils.PaymentUtils.isPaymentAlreadyApplied;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class GaPaymentRequestUpdateCallbackService {
 
-    public static final String PAID = "Paid";
-
     private final CaseDetailsConverter caseDetailsConverter;
     private final GaCoreCaseDataService coreCaseDataService;
     private final JudicialNotificationService judicialNotificationService;
-    private final GeneralApplicationCreationNotificationService gaNotificationService;
     private final ObjectMapper objectMapper;
     private final Time time;
     private final StateGeneratorService stateGeneratorService;
-
-    private GeneralApplicationCaseData data;
 
     public GeneralApplicationCaseData processHwf(GeneralApplicationCaseData caseData) {
         ServiceRequestUpdateDto serviceRequestUpdateDto = new ServiceRequestUpdateDto()
@@ -56,25 +56,47 @@ public class GaPaymentRequestUpdateCallbackService {
         return processServiceRequest(serviceRequestUpdateDto, caseData, true);
     }
 
+    @Retryable(retryFor = CaseDataUpdateException.class, backoff = @Backoff(delay = 500))
     public GeneralApplicationCaseData processServiceRequest(ServiceRequestUpdateDto serviceRequestUpdateDto,
                                                             GeneralApplicationCaseData caseData,
                                                             boolean hwf) {
-        if (!Objects.isNull(caseData)) {
+        try {
+            if (!Objects.isNull(caseData)) {
 
-            switch (caseData.getCcdState()) {
-                case APPLICATION_ADD_PAYMENT:
-                    return processAndTriggerAdditionalPayment(caseData, serviceRequestUpdateDto, hwf);
-                case AWAITING_APPLICATION_PAYMENT:
-                    return processAndTriggerAwaitingPayment(caseData, serviceRequestUpdateDto, hwf);
-                default:
-                    log.error("This Case id {} is not in a valid state APPLICATION_ADD_PAYMENT,"
-                                    + "AWAITING_APPLICATION_PAYMENT to process payment callback ",
-                            serviceRequestUpdateDto.getCcdCaseNumber());
+                switch (caseData.getCcdState()) {
+                    case APPLICATION_ADD_PAYMENT:
+                        return processAndTriggerAdditionalPayment(caseData, serviceRequestUpdateDto, hwf);
+                    case AWAITING_APPLICATION_PAYMENT:
+                        return processAndTriggerAwaitingPayment(caseData, serviceRequestUpdateDto, hwf);
+                    default:
+                        log.error("This Case id {} is not in a valid state APPLICATION_ADD_PAYMENT,"
+                                      + "AWAITING_APPLICATION_PAYMENT to process payment callback ",
+                                  serviceRequestUpdateDto.getCcdCaseNumber());
+                }
+            } else {
+                log.error("Case id {} not present", serviceRequestUpdateDto.getCcdCaseNumber());
             }
-        } else {
-            log.error("Case id {} not present", serviceRequestUpdateDto.getCcdCaseNumber());
+        } catch (Exception ex) {
+            throw new CaseDataUpdateException(ex.getMessage(), ex);
         }
         return null;
+    }
+
+    @Recover
+    public void recover(CaseDataUpdateException ex, ServiceRequestUpdateDto serviceRequestUpdateDto,
+                        GeneralApplicationCaseData caseData, boolean hwf) {
+        String status = serviceRequestUpdateDto != null ? serviceRequestUpdateDto.getServiceRequestStatus() : "N/A";
+        String paymentReference = (serviceRequestUpdateDto != null && serviceRequestUpdateDto.getPayment() != null)
+            ? serviceRequestUpdateDto.getPayment().getPaymentReference() : "N/A";
+        String caseNumber = serviceRequestUpdateDto != null ? serviceRequestUpdateDto.getCcdCaseNumber() : "N/A";
+
+        log.error(
+            "Payment status update failed after retries for case {}. Status: {}, PaymentReference: {}, HWF: {}",
+            caseNumber,
+            status,
+            paymentReference,
+            hwf,
+            ex);
     }
 
     private GeneralApplicationCaseData processAndTriggerAwaitingPayment(GeneralApplicationCaseData caseData,
@@ -176,22 +198,61 @@ public class GaPaymentRequestUpdateCallbackService {
         return caseData;
     }
 
-    private void createEvent(GeneralApplicationCaseData caseData, CaseEvent eventName, String generalApplicationCaseId) {
+    private void createEvent(GeneralApplicationCaseData updatedStaleCaseData, CaseEvent eventName, String generalApplicationCaseId) {
         StartEventResponse startEventResponse = coreCaseDataService.startGaUpdate(
             generalApplicationCaseId,
             eventName
         );
-        GeneralApplicationCaseData startEventData = caseDetailsConverter.toGeneralApplicationCaseData(startEventResponse.getCaseDetails());
+        GeneralApplicationCaseData freshData = caseDetailsConverter.toGeneralApplicationCaseData(startEventResponse.getCaseDetails());
 
-        BusinessProcess businessProcess = startEventData.getBusinessProcess();
+        PaymentDetails intendedPayment = getPaymentDetails(eventName, updatedStaleCaseData);
+        PaymentDetails freshPayment = getPaymentDetails(eventName, freshData);
+
+        if (isPaymentAlreadyApplied(intendedPayment, freshPayment)) {
+            String reference = freshPayment != null ? freshPayment.getReference() : "N/A";
+            log.info("{} Payment with reference {} already applied for case {}. Skipping submission.",
+                     eventName == INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT ? "Application" : "Additional",
+                     reference, generalApplicationCaseId);
+            return;
+        }
+
+        GeneralApplicationPbaDetails freshPba = ofNullable(freshData.getGeneralAppPBADetails())
+            .map(GeneralApplicationPbaDetails::copy)
+            .orElse(new GeneralApplicationPbaDetails());
+
+        GeneralApplicationPbaDetails stalePba = updatedStaleCaseData.getGeneralAppPBADetails();
+
+        if (eventName == INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT) {
+            freshPba.setPaymentDetails(stalePba.getPaymentDetails());
+        } else if (eventName == MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID) {
+            freshPba.setAdditionalPaymentDetails(stalePba.getAdditionalPaymentDetails());
+        }
+        freshPba.setPaymentSuccessfulDate(stalePba.getPaymentSuccessfulDate());
+
+        freshData.setGeneralAppPBADetails(freshPba);
+        freshData.setCcdState(updatedStaleCaseData.getCcdState());
+
         CaseDataContent caseDataContent = buildCaseDataContent(
             startEventResponse,
-            caseData,
-            businessProcess,
+            freshData,
+            freshData.getBusinessProcess(),
             generalApplicationCaseId,
-            startEventData.getGeneralAppParentCaseLink()
+            freshData.getGeneralAppParentCaseLink()
         );
         coreCaseDataService.submitGaUpdate(generalApplicationCaseId, caseDataContent);
+    }
+
+    private PaymentDetails getPaymentDetails(CaseEvent eventName, GeneralApplicationCaseData caseData) {
+        GeneralApplicationPbaDetails pbaDetails = caseData.getGeneralAppPBADetails();
+        if (pbaDetails == null) {
+            return null;
+        }
+        if (eventName == INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT) {
+            return pbaDetails.getPaymentDetails();
+        } else if (eventName == MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID) {
+            return pbaDetails.getAdditionalPaymentDetails();
+        }
+        return null;
     }
 
     private CaseDataContent buildCaseDataContent(StartEventResponse startEventResponse, GeneralApplicationCaseData caseData,

--- a/src/main/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackService.java
@@ -83,19 +83,14 @@ public class GaPaymentRequestUpdateCallbackService {
     }
 
     @Recover
-    public void recover(CaseDataUpdateException ex, ServiceRequestUpdateDto serviceRequestUpdateDto,
-                        GeneralApplicationCaseData caseData, boolean hwf) {
+    public void recover(CaseDataUpdateException ex, ServiceRequestUpdateDto serviceRequestUpdateDto) {
         String status = serviceRequestUpdateDto != null ? serviceRequestUpdateDto.getServiceRequestStatus() : "N/A";
-        String paymentReference = (serviceRequestUpdateDto != null && serviceRequestUpdateDto.getPayment() != null)
-            ? serviceRequestUpdateDto.getPayment().getPaymentReference() : "N/A";
         String caseNumber = serviceRequestUpdateDto != null ? serviceRequestUpdateDto.getCcdCaseNumber() : "N/A";
 
         log.error(
-            "Payment status update failed after retries for case {}. Status: {}, PaymentReference: {}, HWF: {}",
+            "Payment status update failed after retries for case {}. Status: {}",
             caseNumber,
             status,
-            paymentReference,
-            hwf,
             ex);
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/ga/service/JudicialNotificationService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/ga/service/JudicialNotificationService.java
@@ -179,15 +179,17 @@ public class JudicialNotificationService implements NotificationDataGA {
 
     private void sendNotificationForJudicialDecision(GeneralApplicationCaseData caseData, GeneralApplicationCaseData mainCaseData, String recipient, String template)
         throws NotificationException {
-        try {
-            log.info("JudicialNotificationService.class::sendNotificationForJudicialDecision::templateId: {}",
-                     template);
-            notificationService.sendMail(recipient, template, addProperties(caseData, mainCaseData),
-                                         String.format(REFERENCE_TEMPLATE,
-                                                       caseData.getGeneralAppParentCaseLink().getCaseReference()));
-        } catch (NotificationException e) {
-            throw new NotificationException(e);
-        }
+        log.info(
+            "JudicialNotificationService.class::sendNotificationForJudicialDecision::templateId: {}",
+            template
+        );
+        notificationService.sendMail(
+            recipient, template, addProperties(caseData, mainCaseData),
+            String.format(
+                REFERENCE_TEMPLATE,
+                caseData.getGeneralAppParentCaseLink().getCaseReference()
+            )
+        );
     }
 
     private void concurrentWrittenRepNotification(GeneralApplicationCaseData caseData, GeneralApplicationCaseData mainCaseData, String solicitorType) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/ga/service/UpdatePaymentStatusService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/ga/service/UpdatePaymentStatusService.java
@@ -19,6 +19,7 @@ import uk.gov.hmcts.reform.civil.ga.model.genapplication.GeneralApplicationPbaDe
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
 import uk.gov.hmcts.reform.civil.model.CardPaymentStatusResponse;
 import uk.gov.hmcts.reform.civil.model.PaymentDetails;
+import uk.gov.hmcts.reform.civil.utils.PaymentUtils;
 
 import java.util.Map;
 
@@ -74,13 +75,49 @@ public class UpdatePaymentStatusService {
             caseEvent
         );
 
+        GeneralApplicationCaseData freshData = caseDetailsConverter.toGeneralApplicationCaseData(startEventResponse.getCaseDetails());
+        PaymentDetails intendedPayment = getPaymentDetails(caseData);
+        PaymentDetails freshPayment = getPaymentDetails(freshData);
+
+        if (PaymentUtils.isPaymentAlreadyApplied(intendedPayment, freshPayment)) {
+            String reference = freshPayment != null ? freshPayment.getReference() : "N/A";
+            log.info("{} Payment with reference {} already applied for GA case {}. Skipping submission.",
+                     caseData.isAdditionalFeeRequested() ? "Additional" : "Application",
+                     reference, caseReference);
+            return;
+        }
+
+        GeneralApplicationPbaDetails freshPba = freshData.getGeneralAppPBADetails() != null
+            ? freshData.getGeneralAppPBADetails().copy()
+            : new GeneralApplicationPbaDetails();
+
+        GeneralApplicationPbaDetails stalePba = caseData.getGeneralAppPBADetails();
+
+        if (caseData.isAdditionalFeeRequested()) {
+            freshPba.setAdditionalPaymentDetails(stalePba.getAdditionalPaymentDetails());
+        } else {
+            freshPba.setPaymentDetails(stalePba.getPaymentDetails());
+        }
+
+        freshData.setGeneralAppPBADetails(freshPba);
+
         CaseDataContent caseDataContent = buildCaseDataContent(
             startEventResponse,
-            caseData
+            freshData
         );
 
         log.info("Submitting case update with new data for caseReference: {}", caseReference);
         gaCoreCaseDataService.submitUpdate(caseReference, caseDataContent);
+    }
+
+    private PaymentDetails getPaymentDetails(GeneralApplicationCaseData caseData) {
+        GeneralApplicationPbaDetails pbaDetails = caseData.getGeneralAppPBADetails();
+        if (pbaDetails == null) {
+            return null;
+        }
+        return caseData.isAdditionalFeeRequested()
+            ? pbaDetails.getAdditionalPaymentDetails()
+            : pbaDetails.getPaymentDetails();
     }
 
     private CaseDataContent buildCaseDataContent(StartEventResponse startEventResponse, GeneralApplicationCaseData caseData) {

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentStatusRetryService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/PaymentStatusRetryService.java
@@ -26,6 +26,7 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CITIZEN_HEARING_FEE_P
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_CLAIM_AFTER_PAYMENT;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.CREATE_CLAIM_SPEC_AFTER_PAYMENT;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.SERVICE_REQUEST_RECEIVED;
+import static uk.gov.hmcts.reform.civil.utils.PaymentUtils.isPaymentAlreadyApplied;
 
 @Slf4j
 @Service
@@ -132,7 +133,7 @@ public class PaymentStatusRetryService {
 
     private void submitUpdatePaymentEvent(CaseData caseData, Long caseId, FeeType feeType) {
         CaseEvent event = determineEventFromFeeType(caseData, feeType);
-        submitEvent(caseData, caseId, event);
+        submitEvent(caseData, caseId, event, feeType);
     }
 
     CaseEvent determineEventFromFeeType(CaseData caseData, FeeType feeType) {
@@ -153,16 +154,30 @@ public class PaymentStatusRetryService {
         }
     }
 
-    private void submitEvent(CaseData caseData, Long caseId, CaseEvent event) {
+    private void submitEvent(CaseData caseData, Long caseId, CaseEvent event, FeeType feeType) {
         StartEventResponse startEvent = coreCaseDataService.startUpdate(
             String.valueOf(caseId),
             event
         );
 
+        CaseData freshCaseData = caseDetailsConverter.toCaseData(startEvent.getCaseDetails());
+
+        PaymentDetails intendedPayment = getPaymentDetails(feeType, caseData);
+        PaymentDetails freshPayment = getPaymentDetails(feeType, freshCaseData);
+
+        if (isPaymentAlreadyApplied(intendedPayment, freshPayment)) {
+            String reference = freshPayment != null ? freshPayment.getReference() : "N/A";
+            log.info("Payment with reference {} already applied for case {} and fee type {}. Skipping submission.",
+                     reference, caseId, feeType);
+            return;
+        }
+
+        applyPaymentDetails(freshCaseData, feeType, intendedPayment);
+
         CaseDataContent caseDataContent = CaseDataContent.builder()
             .eventToken(startEvent.getToken())
             .event(Event.builder().id(startEvent.getEventId()).build())
-            .data(caseData.toMap(objectMapper))
+            .data(freshCaseData.toMap(objectMapper))
             .build();
 
         coreCaseDataService.submitUpdate(String.valueOf(caseId), caseDataContent);

--- a/src/main/java/uk/gov/hmcts/reform/civil/utils/PaymentUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/utils/PaymentUtils.java
@@ -1,0 +1,19 @@
+package uk.gov.hmcts.reform.civil.utils;
+
+import uk.gov.hmcts.reform.civil.enums.PaymentStatus;
+import uk.gov.hmcts.reform.civil.model.PaymentDetails;
+
+import java.util.Objects;
+
+public class PaymentUtils {
+
+    private PaymentUtils() {
+        // Utility class
+    }
+
+    public static boolean isPaymentAlreadyApplied(PaymentDetails intendedPayment, PaymentDetails freshPayment) {
+        return freshPayment != null && PaymentStatus.SUCCESS.equals(freshPayment.getStatus())
+            && freshPayment.getReference() != null
+            && intendedPayment != null && Objects.equals(intendedPayment.getReference(), freshPayment.getReference());
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackServiceTest.java
@@ -178,10 +178,11 @@ class GaPaymentRequestUpdateCallbackServiceTest {
     }
 
     @Test
-    public void shouldNotProceed_WhenAdditionalPaymentExist_WithPaymentFail_AndNotificationServiceIsDown() {
+    public void shouldThrowCaseDataUpdateException_WhenAdditionalPaymentExist_AndNotificationServiceIsDown() {
 
-        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().judicialOrderMadeWithUncloakApplication(YesOrNo.NO).build();
-        caseData = caseData.copy().ccdState(APPLICATION_ADD_PAYMENT)
+        final GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder()
+            .judicialOrderMadeWithUncloakApplication(YesOrNo.NO)
+            .build().copy().ccdState(APPLICATION_ADD_PAYMENT)
             .generalAppPBADetails(new GeneralApplicationPbaDetails()
                                       .setAdditionalPaymentDetails(new PaymentDetails()
                                                                     .setStatus(FAILED)
@@ -198,11 +199,11 @@ class GaPaymentRequestUpdateCallbackServiceTest {
             .when(judicialNotificationService)
             .sendNotification(caseData, "respondent");
 
-        paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false);
+        assertThatThrownBy(() -> paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false))
+            .isInstanceOf(CaseDataUpdateException.class);
 
         verify(coreCaseDataService, never()).startGaUpdate(any(), any());
         verify(coreCaseDataService, never()).submitGaUpdate(any(), any());
-        verify(coreCaseDataService, never()).triggerEvent(any(), any());
     }
 
     @Test
@@ -498,5 +499,22 @@ class GaPaymentRequestUpdateCallbackServiceTest {
 
         verify(coreCaseDataService, times(1)).startGaUpdate(any(), any());
         verify(coreCaseDataService, never()).submitGaUpdate(any(), any());
+    }
+
+    @Test
+    void shouldThrowIllegalArgumentException_whenIllegalArgumentExceptionIsThrown() {
+        final GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder()
+            .buildPaymentSuccessfulCaseData().copy()
+            .ccdState(APPLICATION_ADD_PAYMENT).build();
+
+        when(stateGeneratorService.getCaseStateForEndJudgeBusinessProcess(any())).thenReturn(CaseState.APPLICATION_ADD_PAYMENT);
+        when(coreCaseDataService.startGaUpdate(any(), any())).thenThrow(new IllegalArgumentException("Invalid argument"));
+
+        ServiceRequestUpdateDto dto = buildServiceDto(PAID);
+        assertThatThrownBy(() -> paymentRequestUpdateCallbackService.processServiceRequest(dto, caseData, false))
+            .isExactlyInstanceOf(IllegalArgumentException.class)
+            .hasMessage("Invalid argument");
+
+        verify(coreCaseDataService, times(1)).startGaUpdate(any(), any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackServiceTest.java
@@ -255,12 +255,11 @@ class GaPaymentRequestUpdateCallbackServiceTest {
         ServiceRequestUpdateDto dto = buildServiceDto(PAID);
         GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
 
-        paymentRequestUpdateCallbackService.recover(ex, dto, caseData, false);
+        paymentRequestUpdateCallbackService.recover(ex, dto);
 
         assertThat(listAppender.list.stream()
                        .anyMatch(event -> event.getFormattedMessage()
-                           .contains("Payment status update failed after retries for case 12345. "
-                                         + "Status: Paid, PaymentReference: 123445, HWF: false")))
+                           .contains("Payment status update failed after retries for case 12345. Status: Paid")))
             .isTrue();
         assertThat(listAppender.list.stream()
                        .anyMatch(event -> event.getLevel().equals(Level.ERROR)))
@@ -272,12 +271,11 @@ class GaPaymentRequestUpdateCallbackServiceTest {
         CaseDataUpdateException ex = new CaseDataUpdateException("Test Error", new RuntimeException());
         GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
 
-        paymentRequestUpdateCallbackService.recover(ex, null, caseData, false);
+        paymentRequestUpdateCallbackService.recover(ex, null);
 
         assertThat(listAppender.list.stream()
                        .anyMatch(event -> event.getFormattedMessage()
-                           .contains("Payment status update failed after retries for case N/A. "
-                                         + "Status: N/A, PaymentReference: N/A, HWF: false")))
+                           .contains("Payment status update failed after retries for case N/A. Status: N/A")))
             .isTrue();
         assertThat(listAppender.list.stream()
                        .anyMatch(event -> event.getLevel().equals(Level.ERROR)))

--- a/src/test/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackServiceTest.java
@@ -1,37 +1,46 @@
 package uk.gov.hmcts.reform.civil.ga.service;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
 import uk.gov.hmcts.reform.ccd.client.model.StartEventResponse;
 import uk.gov.hmcts.reform.civil.callback.CaseEvent;
 import uk.gov.hmcts.reform.civil.enums.CaseState;
 import uk.gov.hmcts.reform.civil.enums.YesOrNo;
+import uk.gov.hmcts.reform.civil.exceptions.CaseDataUpdateException;
+import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.service.Time;
 import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.ga.model.genapplication.GeneralApplicationPbaDetails;
-import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
-import uk.gov.hmcts.reform.civil.model.Fee;
 import uk.gov.hmcts.reform.civil.model.PaymentDetails;
 import uk.gov.hmcts.reform.civil.model.ServiceRequestUpdateDto;
 import uk.gov.hmcts.reform.civil.model.citizenui.HelpWithFees;
 import uk.gov.hmcts.reform.civil.notify.NotificationException;
 import uk.gov.hmcts.reform.civil.sampledata.GeneralApplicationCaseDataBuilder;
 import uk.gov.hmcts.reform.civil.testutils.ObjectMapperFactory;
-import uk.gov.hmcts.reform.civil.service.Time;
 import uk.gov.hmcts.reform.payments.client.models.PaymentDto;
 
 import java.math.BigDecimal;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -74,11 +83,30 @@ class GaPaymentRequestUpdateCallbackServiceTest {
     @Mock
     CaseDetailsConverter caseDetailsConverter;
 
+    private ListAppender<ILoggingEvent> listAppender;
+    private Logger logger;
+
+    @BeforeEach
+    void setup() {
+        logger = (Logger) LoggerFactory.getLogger(GaPaymentRequestUpdateCallbackService.class);
+        listAppender = new ListAppender<>();
+        listAppender.start();
+        logger.addAppender(listAppender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        logger.detachAppender(listAppender);
+    }
+
     @Test
     public void shouldStartAndSubmitEventWithCaseDetails() {
 
         GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().judicialOrderMadeWithUncloakApplication(YesOrNo.NO).build();
-        caseData = caseData.copy().ccdState(APPLICATION_ADD_PAYMENT).build();
+        caseData = caseData.copy().ccdState(APPLICATION_ADD_PAYMENT)
+            .generalAppPBADetails(new GeneralApplicationPbaDetails()
+                                      .setAdditionalPaymentDetails(new PaymentDetails().setStatus(FAILED)))
+            .build();
         CaseDetails caseDetails = buildCaseDetails(caseData);
 
         when(caseDetailsConverter.toGeneralApplicationCaseData(caseDetails)).thenReturn(caseData);
@@ -100,6 +128,8 @@ class GaPaymentRequestUpdateCallbackServiceTest {
 
         GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().judicialOrderMadeWithUncloakApplication(YesOrNo.NO).build();
         caseData = caseData.copy().ccdState(APPLICATION_ADD_PAYMENT)
+            .generalAppPBADetails(new GeneralApplicationPbaDetails()
+                                      .setAdditionalPaymentDetails(new PaymentDetails().setStatus(FAILED)))
             .generalAppParentCaseLink(null).build();
         CaseDetails caseDetails = buildCaseDetails(caseData);
 
@@ -181,7 +211,7 @@ class GaPaymentRequestUpdateCallbackServiceTest {
         caseData = caseData.copy().ccdState(APPLICATION_ADD_PAYMENT)
             .generalAppPBADetails(new GeneralApplicationPbaDetails()
                                       .setAdditionalPaymentDetails(new PaymentDetails()
-                                                                    .setStatus(SUCCESS)
+                                                                    .setStatus(FAILED)
                                                                     .setCustomerReference(null)
                                                                     .setReference(REFERENCE)
                                                                     .setErrorCode(null)
@@ -219,10 +249,113 @@ class GaPaymentRequestUpdateCallbackServiceTest {
         verify(coreCaseDataService, never()).triggerEvent(any(), any());
     }
 
+    @Test
+    void shouldRecover_whenCaseDataUpdateExceptionThrown() {
+        CaseDataUpdateException ex = new CaseDataUpdateException("Test Error", new RuntimeException());
+        ServiceRequestUpdateDto dto = buildServiceDto(PAID);
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+
+        paymentRequestUpdateCallbackService.recover(ex, dto, caseData, false);
+
+        assertThat(listAppender.list.stream()
+                       .anyMatch(event -> event.getFormattedMessage()
+                           .contains("Payment status update failed after retries for case 12345. "
+                                         + "Status: Paid, PaymentReference: 123445, HWF: false")))
+            .isTrue();
+        assertThat(listAppender.list.stream()
+                       .anyMatch(event -> event.getLevel().equals(Level.ERROR)))
+            .isTrue();
+    }
+
+    @Test
+    void shouldRecover_whenCaseDataUpdateExceptionThrownAndDtoIsNull() {
+        CaseDataUpdateException ex = new CaseDataUpdateException("Test Error", new RuntimeException());
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+
+        paymentRequestUpdateCallbackService.recover(ex, null, caseData, false);
+
+        assertThat(listAppender.list.stream()
+                       .anyMatch(event -> event.getFormattedMessage()
+                           .contains("Payment status update failed after retries for case N/A. "
+                                         + "Status: N/A, PaymentReference: N/A, HWF: false")))
+            .isTrue();
+        assertThat(listAppender.list.stream()
+                       .anyMatch(event -> event.getLevel().equals(Level.ERROR)))
+            .isTrue();
+    }
+
+    @Test
+    void shouldNotSubmitUpdate_whenPaymentAlreadyApplied() {
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+        caseData.setCcdState(AWAITING_APPLICATION_PAYMENT);
+        caseData.setGeneralAppPBADetails(new GeneralApplicationPbaDetails()
+                                      .setPaymentDetails(new PaymentDetails()
+                                                             .setStatus(SUCCESS)
+                                                             .setReference(REFERENCE)));
+        CaseDetails freshDetails = buildCaseDetails(caseData);
+
+        when(coreCaseDataService.startGaUpdate(any(), eq(INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT)))
+            .thenReturn(startEventResponse(freshDetails, INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT));
+        when(caseDetailsConverter.toGeneralApplicationCaseData(freshDetails)).thenReturn(caseData);
+
+        paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false);
+
+        verify(coreCaseDataService, never()).submitGaUpdate(any(), any());
+    }
+
+    @Test
+    void shouldSubmitUpdate_whenFreshPbaIsNull() {
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+        caseData.setCcdState(AWAITING_APPLICATION_PAYMENT);
+        caseData.setGeneralAppPBADetails(new GeneralApplicationPbaDetails()
+                                      .setPaymentDetails(new PaymentDetails()
+                                                             .setStatus(FAILED)
+                                                             .setReference("123")));
+
+        GeneralApplicationCaseData freshData = caseData.copy();
+        freshData.setGeneralAppPBADetails(null);
+        CaseDetails freshCaseDetails = buildCaseDetails(freshData);
+
+        when(caseDetailsConverter.toGeneralApplicationCaseData(freshCaseDetails)).thenReturn(freshData);
+        when(coreCaseDataService.startGaUpdate(any(), eq(INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT)))
+            .thenReturn(startEventResponse(freshCaseDetails, INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT));
+
+        paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false);
+
+        verify(coreCaseDataService, times(1)).submitGaUpdate(any(), any());
+    }
+
+    @Test
+    void shouldHandleInvalidState_returnsNull() {
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+        caseData.setCcdState(PENDING_CASE_ISSUED);
+
+        GeneralApplicationCaseData result = paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void shouldProcessHwf() {
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+        caseData.setCcdCaseReference(Long.valueOf(CASE_ID));
+        caseData.setCcdState(AWAITING_APPLICATION_PAYMENT);
+        caseData.setGeneralAppHelpWithFees(new HelpWithFees().setHelpWithFeesReferenceNumber("HWF-REF"));
+        caseData.setGeneralAppPBADetails(new GeneralApplicationPbaDetails());
+
+        GeneralApplicationCaseData result = paymentRequestUpdateCallbackService.processHwf(caseData);
+
+        assertThat(result).isNotNull();
+        verify(coreCaseDataService, never()).startGaUpdate(any(), any());
+    }
+
     private CaseDetails buildCaseDetails(GeneralApplicationCaseData caseData) {
         return CaseDetails.builder()
             .data(objectMapper.convertValue(caseData,
-                    new TypeReference<Map<String, Object>>() {})).id(Long.valueOf(CASE_ID)).build();
+                                           new TypeReference<Map<String, Object>>() {}))
+            .id(Long.valueOf(CASE_ID))
+            .caseTypeId("GENERALAPPLICATION")
+            .build();
     }
 
     private ServiceRequestUpdateDto buildServiceDto(String status) {
@@ -250,7 +383,10 @@ class GaPaymentRequestUpdateCallbackServiceTest {
     public void shouldProceedAfterInitialPaymentIsSuccess() {
 
         GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().buildPaymentSuccessfulCaseData().copy().build();
-        caseData = caseData.copy().ccdState(AWAITING_APPLICATION_PAYMENT).build();
+        caseData = caseData.copy().ccdState(AWAITING_APPLICATION_PAYMENT)
+            .generalAppPBADetails(caseData.getGeneralAppPBADetails().copy()
+                                      .setPaymentDetails(new PaymentDetails().setStatus(FAILED)))
+            .build();
         CaseDetails caseDetails = buildCaseDetails(caseData);
         when(caseDetailsConverter.toGeneralApplicationCaseData(caseDetails))
             .thenReturn(caseData);
@@ -285,31 +421,84 @@ class GaPaymentRequestUpdateCallbackServiceTest {
     }
 
     @Test
-    public void shouldProcessHwf() {
-        GeneralApplicationCaseData caseData = new GeneralApplicationCaseData()
-                .ccdState(AWAITING_APPLICATION_PAYMENT)
-                .ccdCaseReference(1L)
-                .generalAppPBADetails(new GeneralApplicationPbaDetails()
-                        .setFee(new Fee().setCalculatedAmountInPence(BigDecimal.ONE)))
-                .generalAppHelpWithFees(new HelpWithFees()
-                        .setHelpWithFeesReferenceNumber("ref"))
-                .build();
+    public void shouldNotProcessHwf() {
+        GeneralApplicationCaseData caseData = new GeneralApplicationCaseData();
+        caseData.setCcdState(PENDING_APPLICATION_ISSUED);
+        caseData.setCcdCaseReference(1L);
+        caseData.setGeneralAppPBADetails(new GeneralApplicationPbaDetails());
+        caseData.setGeneralAppHelpWithFees(new HelpWithFees().setHelpWithFeesReferenceNumber("ref"));
+
         GeneralApplicationCaseData updatedCaseData = paymentRequestUpdateCallbackService.processHwf(caseData);
-        verify(coreCaseDataService, never()).startGaUpdate(any(), any());
-        assertThat(updatedCaseData).isNotNull();
+        assertThat(updatedCaseData).isNull();
     }
 
     @Test
-    public void shouldNotProcessHwf() {
-        GeneralApplicationCaseData caseData = new GeneralApplicationCaseData()
-                .ccdState(PENDING_APPLICATION_ISSUED)
-                .ccdCaseReference(1L)
-                .generalAppPBADetails(new GeneralApplicationPbaDetails()
-                        .setFee(new Fee().setCalculatedAmountInPence(BigDecimal.ONE)))
-                .generalAppHelpWithFees(new HelpWithFees()
-                        .setHelpWithFeesReferenceNumber("ref"))
-                .build();
-        GeneralApplicationCaseData updatedCaseData = paymentRequestUpdateCallbackService.processHwf(caseData);
-        assertThat(updatedCaseData).isNull();
+    void shouldThrowRetryableException_whenStartGaUpdateFails() {
+        final GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder()
+            .buildPaymentSuccessfulCaseData().copy()
+            .ccdState(APPLICATION_ADD_PAYMENT).build();
+
+        when(stateGeneratorService.getCaseStateForEndJudgeBusinessProcess(any())).thenReturn(CaseState.APPLICATION_ADD_PAYMENT);
+        when(coreCaseDataService.startGaUpdate(any(), any())).thenThrow(new RuntimeException("Lock conflict"));
+
+        ServiceRequestUpdateDto dto = buildServiceDto(PAID);
+        assertThatThrownBy(() -> paymentRequestUpdateCallbackService.processServiceRequest(dto, caseData, false))
+            .isInstanceOf(CaseDataUpdateException.class);
+    }
+
+    @Test
+    public void shouldNotSubmitEvent_WhenInitialPaymentAlreadyApplied() {
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+        caseData = caseData.copy()
+            .ccdState(AWAITING_APPLICATION_PAYMENT)
+            .generalAppPBADetails(new GeneralApplicationPbaDetails())
+            .build();
+        CaseDetails caseDetails = buildCaseDetails(caseData);
+
+        // fresh data from CCD already has the payment
+        GeneralApplicationCaseData freshData = caseData.copy()
+            .generalAppPBADetails(new GeneralApplicationPbaDetails()
+                                      .setPaymentDetails(new PaymentDetails()
+                                                             .setStatus(SUCCESS)
+                                                             .setReference(REFERENCE)))
+            .build();
+        CaseDetails freshDetails = buildCaseDetails(freshData);
+
+        when(caseDetailsConverter.toGeneralApplicationCaseData(freshDetails)).thenReturn(freshData);
+        when(coreCaseDataService.startGaUpdate(any(), eq(INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT)))
+            .thenReturn(startEventResponse(freshDetails, INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT));
+
+        paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false);
+
+        verify(coreCaseDataService, times(1)).startGaUpdate(any(), any());
+        verify(coreCaseDataService, never()).submitGaUpdate(any(), any());
+    }
+
+    @Test
+    public void shouldNotSubmitEvent_WhenAdditionalPaymentAlreadyApplied() {
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+        caseData = caseData.copy()
+            .ccdState(APPLICATION_ADD_PAYMENT)
+            .generalAppPBADetails(new GeneralApplicationPbaDetails())
+            .build();
+        CaseDetails caseDetails = buildCaseDetails(caseData);
+
+        // fresh data from CCD already has the payment
+        GeneralApplicationCaseData freshData = caseData.copy()
+            .generalAppPBADetails(new GeneralApplicationPbaDetails()
+                                      .setAdditionalPaymentDetails(new PaymentDetails()
+                                                                       .setStatus(SUCCESS)
+                                                                       .setReference(REFERENCE)))
+            .build();
+        CaseDetails freshDetails = buildCaseDetails(freshData);
+
+        when(caseDetailsConverter.toGeneralApplicationCaseData(freshDetails)).thenReturn(freshData);
+        when(coreCaseDataService.startGaUpdate(any(), eq(CaseEvent.MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID)))
+            .thenReturn(startEventResponse(freshDetails, CaseEvent.MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID));
+
+        paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false);
+
+        verify(coreCaseDataService, times(1)).startGaUpdate(any(), any());
+        verify(coreCaseDataService, never()).submitGaUpdate(any(), any());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/ga/service/GaPaymentRequestUpdateCallbackServiceTest.java
@@ -193,13 +193,14 @@ class GaPaymentRequestUpdateCallbackServiceTest {
                                                                     )
                                       )
             .build();
-        CaseDetails caseDetails = buildCaseDetails(caseData);
 
         doThrow(buildNotificationException())
             .when(judicialNotificationService)
             .sendNotification(caseData, "respondent");
 
-        assertThatThrownBy(() -> paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false))
+        ServiceRequestUpdateDto serviceRequestUpdateDto = buildServiceDto(PAID);
+
+        assertThatThrownBy(() -> paymentRequestUpdateCallbackService.processServiceRequest(serviceRequestUpdateDto, caseData, false))
             .isInstanceOf(CaseDataUpdateException.class);
 
         verify(coreCaseDataService, never()).startGaUpdate(any(), any());
@@ -241,7 +242,6 @@ class GaPaymentRequestUpdateCallbackServiceTest {
     public void shouldNotDoProceed_WhenApplicationNotIn_AdditionalPayment_Status() {
         GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().judicialOrderMadeWithUncloakApplication(YesOrNo.NO).build();
         caseData = caseData.copy().ccdState(PENDING_CASE_ISSUED).build();
-        CaseDetails caseDetails = buildCaseDetails(caseData);
 
         paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false);
 
@@ -254,7 +254,6 @@ class GaPaymentRequestUpdateCallbackServiceTest {
     void shouldRecover_whenCaseDataUpdateExceptionThrown() {
         CaseDataUpdateException ex = new CaseDataUpdateException("Test Error", new RuntimeException());
         ServiceRequestUpdateDto dto = buildServiceDto(PAID);
-        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
 
         paymentRequestUpdateCallbackService.recover(ex, dto);
 
@@ -270,7 +269,6 @@ class GaPaymentRequestUpdateCallbackServiceTest {
     @Test
     void shouldRecover_whenCaseDataUpdateExceptionThrownAndDtoIsNull() {
         CaseDataUpdateException ex = new CaseDataUpdateException("Test Error", new RuntimeException());
-        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
 
         paymentRequestUpdateCallbackService.recover(ex, null);
 
@@ -405,7 +403,6 @@ class GaPaymentRequestUpdateCallbackServiceTest {
 
         GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().buildPaymentSuccessfulCaseData().copy().build();
         caseData = caseData.copy().ccdState(AWAITING_RESPONDENT_RESPONSE).build();
-        CaseDetails caseDetails = buildCaseDetails(caseData);
 
         paymentRequestUpdateCallbackService.processServiceRequest(buildServiceDto(PAID), caseData, false);
 
@@ -452,7 +449,6 @@ class GaPaymentRequestUpdateCallbackServiceTest {
             .ccdState(AWAITING_APPLICATION_PAYMENT)
             .generalAppPBADetails(new GeneralApplicationPbaDetails())
             .build();
-        CaseDetails caseDetails = buildCaseDetails(caseData);
 
         // fresh data from CCD already has the payment
         GeneralApplicationCaseData freshData = caseData.copy()
@@ -480,7 +476,6 @@ class GaPaymentRequestUpdateCallbackServiceTest {
             .ccdState(APPLICATION_ADD_PAYMENT)
             .generalAppPBADetails(new GeneralApplicationPbaDetails())
             .build();
-        CaseDetails caseDetails = buildCaseDetails(caseData);
 
         // fresh data from CCD already has the payment
         GeneralApplicationCaseData freshData = caseData.copy()

--- a/src/test/java/uk/gov/hmcts/reform/civil/ga/service/UpdatePaymentStatusServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/ga/service/UpdatePaymentStatusServiceTest.java
@@ -23,6 +23,7 @@ import uk.gov.hmcts.reform.civil.exceptions.CaseDataUpdateException;
 import uk.gov.hmcts.reform.civil.ga.model.GeneralApplicationCaseData;
 import uk.gov.hmcts.reform.civil.ga.model.genapplication.GeneralApplicationPbaDetails;
 import uk.gov.hmcts.reform.civil.helpers.CaseDetailsConverter;
+import uk.gov.hmcts.reform.civil.sampledata.GeneralApplicationCaseDataBuilder;
 import uk.gov.hmcts.reform.civil.model.BusinessProcess;
 import uk.gov.hmcts.reform.civil.model.CardPaymentStatusResponse;
 import uk.gov.hmcts.reform.civil.model.PaymentDetails;
@@ -32,13 +33,18 @@ import java.math.BigDecimal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT;
 import static uk.gov.hmcts.reform.civil.callback.CaseEvent.MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID;
+import static uk.gov.hmcts.reform.civil.enums.CaseState.AWAITING_APPLICATION_PAYMENT;
 import static uk.gov.hmcts.reform.civil.enums.CaseState.CASE_PROGRESSION;
+import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.FAILED;
+import static uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS;
 
 @ExtendWith(MockitoExtension.class)
 class UpdatePaymentStatusServiceTest {
@@ -164,12 +170,112 @@ class UpdatePaymentStatusServiceTest {
             .setPaymentReference("1234")
             .setStatus("Invalid");
 
-        assertThatThrownBy(() -> updatePaymentStatusService.updatePaymentStatus(String.valueOf(CASE_ID), cardPaymentStatusResponse))
+        String caseId = String.valueOf(CASE_ID);
+        assertThatThrownBy(() -> updatePaymentStatusService.updatePaymentStatus(caseId, cardPaymentStatusResponse))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Invalid payment status: Invalid");
 
         verify(gaCoreCaseDataService, times(1)).getCase(CASE_ID);
         verifyNoMoreInteractions(gaCoreCaseDataService);
+    }
+
+    @Test
+    public void shouldNotSubmitEvent_WhenInitialPaymentAlreadyApplied() {
+        GeneralApplicationCaseData caseData = GeneralApplicationCaseDataBuilder.builder().build();
+        caseData.setCcdState(AWAITING_APPLICATION_PAYMENT);
+        caseData.setGeneralAppPBADetails(new GeneralApplicationPbaDetails()
+                                      .setPaymentDetails(new PaymentDetails()
+                                                             .setStatus(SUCCESS)
+                                                             .setReference("PAY123")));
+        CaseDetails caseDetails = buildCaseDetails(caseData);
+
+        when(gaCoreCaseDataService.getCase(CASE_ID)).thenReturn(caseDetails);
+        when(caseDetailsConverter.toGeneralApplicationCaseData(caseDetails)).thenReturn(caseData);
+
+        // fresh data from CCD already has the payment
+        GeneralApplicationCaseData freshData = caseData.copy();
+        CaseDetails freshDetails = buildCaseDetails(freshData);
+
+        when(gaCoreCaseDataService.startUpdate(any(), any()))
+            .thenReturn(startEventResponse(freshDetails, INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT));
+
+        CardPaymentStatusResponse response = new CardPaymentStatusResponse()
+            .setStatus("SUCCESS")
+            .setPaymentReference("PAY123");
+
+        updatePaymentStatusService.updatePaymentStatus(String.valueOf(CASE_ID), response);
+
+        verify(gaCoreCaseDataService, times(1)).startUpdate(any(), any());
+        verify(gaCoreCaseDataService, never()).submitUpdate(any(), any());
+    }
+
+    @Test
+    public void shouldNotSubmitEvent_WhenAdditionalPaymentAlreadyApplied() {
+        GeneralApplicationCaseData caseData = new GeneralApplicationCaseData();
+        caseData.setCcdState(CASE_PROGRESSION);
+        caseData.setApplicationFeeAmountInPence(new BigDecimal("10000"));
+        caseData.setGeneralAppPBADetails(new GeneralApplicationPbaDetails()
+                                      .setAdditionalPaymentServiceRef("ADD-REF")
+                                      .setAdditionalPaymentDetails(new PaymentDetails()
+                                                                       .setStatus(SUCCESS)
+                                                                       .setReference("PAY456")));
+        CaseDetails caseDetails = buildCaseDetails(caseData);
+
+        when(gaCoreCaseDataService.getCase(CASE_ID)).thenReturn(caseDetails);
+        when(caseDetailsConverter.toGeneralApplicationCaseData(caseDetails)).thenReturn(caseData);
+
+        // fresh data from CCD already has the payment
+        GeneralApplicationCaseData freshData = caseData.copy();
+        CaseDetails freshDetails = buildCaseDetails(freshData);
+
+        when(gaCoreCaseDataService.startUpdate(any(), eq(MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID)))
+            .thenReturn(startEventResponse(freshDetails, MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID));
+
+        CardPaymentStatusResponse response = new CardPaymentStatusResponse()
+            .setStatus("SUCCESS")
+            .setPaymentReference("PAY456");
+
+        updatePaymentStatusService.updatePaymentStatus(String.valueOf(CASE_ID), response);
+
+        verify(gaCoreCaseDataService, times(1)).startUpdate(any(), eq(MODIFY_STATE_AFTER_ADDITIONAL_FEE_PAID));
+        verify(gaCoreCaseDataService, never()).submitUpdate(any(), any());
+    }
+
+    @Test
+    public void shouldSubmitUpdate_whenFreshPbaIsNull() {
+        GeneralApplicationCaseData caseData = new GeneralApplicationCaseData()
+            .ccdState(CASE_PROGRESSION)
+            .generalAppPBADetails(new GeneralApplicationPbaDetails().setPaymentDetails(new PaymentDetails()
+                                                                                           .setStatus(FAILED)))
+            .build();
+        CaseDetails staleCaseDetails = buildCaseDetails(caseData);
+
+        GeneralApplicationCaseData freshData = caseData.copy()
+            .generalAppPBADetails(null)
+            .build();
+        CaseDetails freshCaseDetails = buildCaseDetails(freshData);
+
+        when(gaCoreCaseDataService.getCase(CASE_ID)).thenReturn(staleCaseDetails);
+        when(caseDetailsConverter.toGeneralApplicationCaseData(staleCaseDetails)).thenReturn(caseData);
+        when(caseDetailsConverter.toGeneralApplicationCaseData(freshCaseDetails)).thenReturn(freshData);
+        when(gaCoreCaseDataService.startUpdate(any(), any()))
+            .thenReturn(startEventResponse(freshCaseDetails, INITIATE_GENERAL_APPLICATION_AFTER_PAYMENT));
+        when(gaCoreCaseDataService.submitUpdate(any(), any())).thenReturn(caseData);
+
+        updatePaymentStatusService.updatePaymentStatus(String.valueOf(CASE_ID), getCardPaymentStatusResponse());
+
+        verify(gaCoreCaseDataService, times(1)).submitUpdate(any(), any());
+    }
+
+    @Test
+    public void shouldThrowCaseDataUpdateException_whenUnexpectedErrorOccurs() {
+        when(gaCoreCaseDataService.getCase(CASE_ID)).thenThrow(new RuntimeException("Lock conflict"));
+
+        String caseId = String.valueOf(CASE_ID);
+        CardPaymentStatusResponse response = getCardPaymentStatusResponse();
+        assertThatThrownBy(() -> updatePaymentStatusService.updatePaymentStatus(caseId, response))
+            .isInstanceOf(CaseDataUpdateException.class)
+            .hasMessage("Lock conflict");
     }
 
     private CaseDetails buildCaseDetails(GeneralApplicationCaseData caseData) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/PaymentStatusRetryServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/PaymentStatusRetryServiceTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -76,14 +77,18 @@ class PaymentStatusRetryServiceTest {
 
     @Test
     void shouldUpdatePaymentStatusUsingCaseData() {
+        CaseDetails freshCaseDetails = mock(CaseDetails.class);
+        CaseData freshCaseData = mock(CaseData.class);
         StartEventResponse startEventResponse = StartEventResponse.builder()
             .token("token")
             .eventId("eventId")
+            .caseDetails(freshCaseDetails)
             .build();
 
         when(caseData.isLipvLipOneVOne()).thenReturn(true);
         when(coreCaseDataService.startUpdate(CASE_ID.toString(), CaseEvent.CITIZEN_CLAIM_ISSUE_PAYMENT))
             .thenReturn(startEventResponse);
+        when(caseDetailsConverter.toCaseData(freshCaseDetails)).thenReturn(freshCaseData);
 
         service.updatePaymentStatus(FeeType.CLAIMISSUED, CASE_ID.toString(), caseData);
 
@@ -100,12 +105,16 @@ class PaymentStatusRetryServiceTest {
         when(caseData.isLipvLROneVOne()).thenReturn(false);
         when(caseData.getCaseAccessCategory()).thenReturn(CaseCategory.UNSPEC_CLAIM);
 
+        CaseDetails freshCaseDetails = mock(CaseDetails.class);
+        CaseData freshCaseData = mock(CaseData.class);
         StartEventResponse startEventResponse = StartEventResponse.builder()
             .token("token")
             .eventId("eventId")
+            .caseDetails(freshCaseDetails)
             .build();
         when(coreCaseDataService.startUpdate(CASE_ID.toString(), CaseEvent.CREATE_CLAIM_AFTER_PAYMENT))
             .thenReturn(startEventResponse);
+        when(caseDetailsConverter.toCaseData(freshCaseDetails)).thenReturn(freshCaseData);
 
         CardPaymentStatusResponse response = new CardPaymentStatusResponse()
             .setStatus("success")
@@ -199,7 +208,8 @@ class PaymentStatusRetryServiceTest {
             .setPaymentReference("1234")
             .setStatus("Invalid");
 
-        assertThatThrownBy(() -> service.updatePaymentStatus(FeeType.CLAIMISSUED, CASE_ID.toString(), response))
+        String caseIdStr = CASE_ID.toString();
+        assertThatThrownBy(() -> service.updatePaymentStatus(FeeType.CLAIMISSUED, caseIdStr, response))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("Invalid payment status: Invalid");
 
@@ -280,6 +290,74 @@ class PaymentStatusRetryServiceTest {
         assertThat(listAppender.list.getFirst().getLevel()).isEqualTo(Level.ERROR);
         assertThat(listAppender.list.getFirst().getFormattedMessage())
             .contains("Payment status update failed after retries for case 12345 and fee type CLAIMISSUED. Status: FAILED, ErrorCode: ERR123");
+    }
+
+    @Test
+    void shouldNotUpdatePaymentStatus_whenAlreadyApplied() {
+        CaseDetails freshCaseDetails = mock(CaseDetails.class);
+        CaseData freshCaseData = mock(CaseData.class);
+        StartEventResponse startEventResponse = StartEventResponse.builder()
+            .token("token")
+            .eventId("eventId")
+            .caseDetails(freshCaseDetails)
+            .build();
+
+        PaymentDetails existingPayment = new PaymentDetails()
+            .setStatus(uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS)
+            .setReference("ref");
+
+        // caseData passed to method (intended payment)
+        when(caseData.getClaimIssuedPaymentDetails()).thenReturn(existingPayment);
+        when(caseData.isLipvLipOneVOne()).thenReturn(true);
+
+        // freshCaseData from CCD (already has the payment)
+        when(freshCaseData.getClaimIssuedPaymentDetails()).thenReturn(existingPayment);
+
+        when(coreCaseDataService.startUpdate(CASE_ID.toString(), CaseEvent.CITIZEN_CLAIM_ISSUE_PAYMENT))
+            .thenReturn(startEventResponse);
+        when(caseDetailsConverter.toCaseData(freshCaseDetails)).thenReturn(freshCaseData);
+
+        service.updatePaymentStatus(FeeType.CLAIMISSUED, CASE_ID.toString(), caseData);
+
+        verify(coreCaseDataService, never()).submitUpdate(any(), any());
+    }
+
+    @Test
+    void shouldNotUpdatePaymentStatusResponse_whenAlreadyApplied() {
+        CaseDetails caseDetails = mock(CaseDetails.class);
+        CaseData staleCaseData = mock(CaseData.class);
+        when(coreCaseDataService.getCase(CASE_ID)).thenReturn(caseDetails);
+        when(caseDetailsConverter.toCaseData(caseDetails)).thenReturn(staleCaseData);
+        when(staleCaseData.isLipvLipOneVOne()).thenReturn(false);
+        when(staleCaseData.isLipvLROneVOne()).thenReturn(false);
+        when(staleCaseData.getCaseAccessCategory()).thenReturn(CaseCategory.UNSPEC_CLAIM);
+
+        CaseDetails freshCaseDetails = mock(CaseDetails.class);
+        CaseData freshCaseData = mock(CaseData.class);
+        StartEventResponse startEventResponse = StartEventResponse.builder()
+            .token("token")
+            .eventId("eventId")
+            .caseDetails(freshCaseDetails)
+            .build();
+
+        PaymentDetails existingPayment = new PaymentDetails()
+            .setStatus(uk.gov.hmcts.reform.civil.enums.PaymentStatus.SUCCESS)
+            .setReference("ref");
+
+        when(staleCaseData.getClaimIssuedPaymentDetails()).thenReturn(existingPayment);
+        when(freshCaseData.getClaimIssuedPaymentDetails()).thenReturn(existingPayment);
+
+        when(coreCaseDataService.startUpdate(CASE_ID.toString(), CaseEvent.CREATE_CLAIM_AFTER_PAYMENT))
+            .thenReturn(startEventResponse);
+        when(caseDetailsConverter.toCaseData(freshCaseDetails)).thenReturn(freshCaseData);
+
+        CardPaymentStatusResponse response = new CardPaymentStatusResponse()
+            .setStatus("SUCCESS")
+            .setPaymentReference("ref");
+
+        service.updatePaymentStatus(FeeType.CLAIMISSUED, CASE_ID.toString(), response);
+
+        verify(coreCaseDataService, never()).submitUpdate(any(), any());
     }
 }
 

--- a/src/test/java/uk/gov/hmcts/reform/civil/utils/PaymentUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/utils/PaymentUtilsTest.java
@@ -1,0 +1,76 @@
+package uk.gov.hmcts.reform.civil.utils;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.enums.PaymentStatus;
+import uk.gov.hmcts.reform.civil.model.PaymentDetails;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PaymentUtilsTest {
+
+    @Test
+    void shouldReturnTrue_whenPaymentIsAlreadyApplied() {
+        PaymentDetails intendedPayment = new PaymentDetails()
+            .setReference("REF1")
+            .setStatus(PaymentStatus.SUCCESS);
+        PaymentDetails freshPayment = new PaymentDetails()
+            .setReference("REF1")
+            .setStatus(PaymentStatus.SUCCESS);
+
+        assertThat(PaymentUtils.isPaymentAlreadyApplied(intendedPayment, freshPayment)).isTrue();
+    }
+
+    @Test
+    void shouldReturnFalse_whenReferenceMismatch() {
+        PaymentDetails intendedPayment = new PaymentDetails()
+            .setReference("REF1")
+            .setStatus(PaymentStatus.SUCCESS);
+        PaymentDetails freshPayment = new PaymentDetails()
+            .setReference("REF2")
+            .setStatus(PaymentStatus.SUCCESS);
+
+        assertThat(PaymentUtils.isPaymentAlreadyApplied(intendedPayment, freshPayment)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenStatusIsNotSuccess() {
+        PaymentDetails intendedPayment = new PaymentDetails()
+            .setReference("REF1")
+            .setStatus(PaymentStatus.SUCCESS);
+        PaymentDetails freshPayment = new PaymentDetails()
+            .setReference("REF1")
+            .setStatus(PaymentStatus.FAILED);
+
+        assertThat(PaymentUtils.isPaymentAlreadyApplied(intendedPayment, freshPayment)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenFreshPaymentIsNull() {
+        PaymentDetails intendedPayment = new PaymentDetails()
+            .setReference("REF1")
+            .setStatus(PaymentStatus.SUCCESS);
+
+        assertThat(PaymentUtils.isPaymentAlreadyApplied(intendedPayment, null)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenIntendedPaymentIsNull() {
+        PaymentDetails freshPayment = new PaymentDetails()
+            .setReference("REF1")
+            .setStatus(PaymentStatus.SUCCESS);
+
+        assertThat(PaymentUtils.isPaymentAlreadyApplied(null, freshPayment)).isFalse();
+    }
+
+    @Test
+    void shouldReturnFalse_whenBothReferencesAreNull() {
+        PaymentDetails intendedPayment = new PaymentDetails()
+            .setReference(null)
+            .setStatus(PaymentStatus.SUCCESS);
+        PaymentDetails freshPayment = new PaymentDetails()
+            .setReference(null)
+            .setStatus(PaymentStatus.SUCCESS);
+
+        assertThat(PaymentUtils.isPaymentAlreadyApplied(intendedPayment, freshPayment)).isFalse();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSCCI-6088


### Change description ###
**Resolve Duplicate Payment Callback and Lost Update Issues**

****Description****
Implements a robust, multi-layered defense to resolve data integrity issues caused by duplicate payment callbacks and concurrent case modifications ("lost updates"). The changes ensure that payment processing is idempotent, resilient to race conditions, and does not overwrite concurrent updates to unrelated case fields.

****Key Changes****

*   **Centralized Deduplication Logic**: Created `PaymentUtils` to provide a shared `isPaymentAlreadyApplied` check.
*   **Fresh-Data Aware CCD Updates (Lost Update Prevention)**: Refactored payment services to use the `CaseData` returned by the CCD `startUpdate` call rather than stale data fetched at the start of the callback.
*   **Granular Updates for General Applications**: Modified update logic to only change specific payment fields and the `paymentSuccessfulDate` on the fresh data, preserving concurrent changes to other fields like `businessProcess`.
*   **Resilience and Monitoring**: Introduced `@Retryable` logic in `GaPaymentRequestUpdateCallbackService` to handle optimistic locking conflicts.

****Testing Done****
*   **Integration Tests**: Added new scenarios to `FeesPaymentControllerTest` to verify that duplicate payment status updates result in a safe no-op.
*   **Unit Tests**: Updated `PaymentStatusRetryServiceTest` and `GaPaymentRequestUpdateCallbackServiceTest` to cover the new deduplication and fresh-data update patterns.




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
