### PR TITLE
DTSCCI-1879: fix Repayment plan decision calculator

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/repaymentplan/RepaymentPlanDecisionCalculator.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/citizen/repaymentplan/RepaymentPlanDecisionCalculator.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.enums.RespondentResponsePartAdmissionPaymentTimeLRspec;
 import uk.gov.hmcts.reform.civil.model.CaseData;
 import uk.gov.hmcts.reform.civil.model.RepaymentPlanLRspec;
+import uk.gov.hmcts.reform.civil.model.RespondToClaimAdmitPartLRspec;
 import uk.gov.hmcts.reform.civil.model.citizenui.dto.RepaymentDecisionType;
 import uk.gov.hmcts.reform.civil.model.repaymentplan.ClaimantProposedPlan;
 
@@ -36,14 +37,16 @@ public class RepaymentPlanDecisionCalculator {
                 disposableIncome
             );
             if (repaymentDecisionType.isInFavourOfDefendant()) {
-                LocalDate proposedDefendantRepaymentDate = getProposedDefendantRepaymentDate(
+                Optional<LocalDate> proposedDefendantRepaymentDate = getProposedDefendantRepaymentDate(
                     caseData,
                     claimTotalAmount
                 );
-                return calculateDecisionBasedOnProposedDate(
-                    proposedDefendantRepaymentDate,
-                    claimantProposedPlan.getRepaymentByDate()
-                );
+                return proposedDefendantRepaymentDate
+                    .map(date -> calculateDecisionBasedOnProposedDate(
+                        date,
+                        claimantProposedPlan.getRepaymentByDate()
+                    ))
+                    .orElse(repaymentDecisionType);
             }
             return repaymentDecisionType;
         }
@@ -56,12 +59,15 @@ public class RepaymentPlanDecisionCalculator {
         return RepaymentDecisionType.IN_FAVOUR_OF_DEFENDANT;
     }
 
-    private LocalDate getProposedDefendantRepaymentDate(CaseData caseData, BigDecimal claimTotalAmount) {
+    private Optional<LocalDate> getProposedDefendantRepaymentDate(CaseData caseData, BigDecimal claimTotalAmount) {
         RespondentResponsePartAdmissionPaymentTimeLRspec respondentResponseType = caseData.getDefenceAdmitPartPaymentTimeRouteRequired();
         RepaymentPlanLRspec defendantRepaymentPlan = caseData.getRespondent1RepaymentPlan();
-        return respondentResponseType == BY_SET_DATE
-            ? caseData.getRespondToClaimAdmitPartLRspec().getWhenWillThisAmountBePaid() : defendantRepaymentPlan.finalPaymentBy(
-            claimTotalAmount);
+        if (respondentResponseType == BY_SET_DATE) {
+            return Optional.ofNullable(caseData.getRespondToClaimAdmitPartLRspec())
+                .map(RespondToClaimAdmitPartLRspec::getWhenWillThisAmountBePaid);
+        }
+        return Optional.ofNullable(defendantRepaymentPlan)
+            .map(repaymentPlan -> repaymentPlan.finalPaymentBy(claimTotalAmount));
     }
 
     private RepaymentDecisionType calculateDecisionBasedOnAmountAndDisposableIncome(double totalAmount, double disposableIncome) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,7 +52,6 @@ spring:
             client-secret: internal
   flyway:
     enabled: ${REFERENCE_DATABASE_MIGRATION:true}
-    lock-retry-count: -1
     placeholder-replacement: false
     table: schema_version
     baseline-on-migrate: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,7 +52,6 @@ spring:
             client-secret: internal
   flyway:
     enabled: ${REFERENCE_DATABASE_MIGRATION:true}
-    lock-retry-count: ${FLYWAY_LOCK_RETRY_COUNT:50}
     placeholder-replacement: false
     table: schema_version
     baseline-on-migrate: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,6 +52,7 @@ spring:
             client-secret: internal
   flyway:
     enabled: ${REFERENCE_DATABASE_MIGRATION:true}
+    lock-retry-count: ${FLYWAY_LOCK_RETRY_COUNT:50}
     placeholder-replacement: false
     table: schema_version
     baseline-on-migrate: true

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -52,6 +52,7 @@ spring:
             client-secret: internal
   flyway:
     enabled: ${REFERENCE_DATABASE_MIGRATION:true}
+    lock-retry-count: -1
     placeholder-replacement: false
     table: schema_version
     baseline-on-migrate: true

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/citizen/repaymentplan/RepaymentPlanDecisionCalculatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/citizen/repaymentplan/RepaymentPlanDecisionCalculatorTest.java
@@ -16,6 +16,7 @@ import uk.gov.hmcts.reform.civil.model.repaymentplan.ClaimantProposedPlan;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.Month;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -100,9 +101,11 @@ class RepaymentPlanDecisionCalculatorTest {
     @Nested
     class DecisionCalculationOnPayBySetDate {
 
-        private static final LocalDate DEFENDANT_REPAYMENT_DATE = LocalDate.of(2023, 9, 22);
-        private static final LocalDate CLAIMANT_PROPOSED_DATE_BEFORE_DEFENDANT_DATE = LocalDate.of(2023, 8, 22);
-        private static final LocalDate CLAIMANT_PROPOSED_DATE_AFTER_DEFENDANT_DATE = LocalDate.of(2023, 10, 22);
+        private static final LocalDate DEFENDANT_REPAYMENT_DATE = LocalDate.of(2023, Month.SEPTEMBER, 22);
+        private static final LocalDate CLAIMANT_PROPOSED_DATE_BEFORE_DEFENDANT_DATE = LocalDate.of(2023,
+                                                                                                   Month.AUGUST, 22);
+        private static final LocalDate CLAIMANT_PROPOSED_DATE_AFTER_DEFENDANT_DATE = LocalDate.of(2023,
+                                                                                                  Month.OCTOBER, 22);
 
         @Mock
         private RespondToClaimAdmitPartLRspec respondToClaimAdmitPartLRspec;
@@ -194,13 +197,26 @@ class RepaymentPlanDecisionCalculatorTest {
             //Then
             assertThat(decision.isInFavourOfDefendant()).isTrue();
         }
+
+        @Test
+        void shouldChooseDefendantPlan_whenDefendantSetDateDetailsAreMissing() {
+            //Given
+            given(caseData.getDefenceAdmitPartPaymentTimeRouteRequired()).willReturn(BY_SET_DATE);
+            given(caseData.getRespondToAdmittedClaimOwingAmountPounds()).willReturn(UNAFFORDABLE_CLAIM_TOTAL);
+
+            //When
+            RepaymentDecisionType decision = repaymentPlanDecisionCalculator.calculateRepaymentDecision(
+                caseData,
+                claimantProposedPlan
+            );
+
+            //Then
+            assertThat(decision.isInFavourOfDefendant()).isTrue();
+        }
     }
 
     @Nested
     class DecisionCalculationOnPayByInstalments {
-
-        @Mock
-        private RepaymentPlanLRspec claimantRepaymentPlan;
 
         @BeforeEach
         void setUp() {


### PR DESCRIPTION

### JIRA link (if applicable) ###
DTSCCI-1879


### Change description ###
  Changes:

  - Safely handles a missing respondToClaimAdmitPartLRspec.
  - Also handles a missing defendant repayment plan.
  - Retains the existing defendant-favouring decision when no repayment date is available.
  - Added regression coverage for the reported scenario.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
