### PR TITLE
Patch Flyway migrations for integration tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,20 @@ sourceSets {
   }
 }
 
+tasks.register('preparePatchedMigrations', Copy) {
+  from 'src/main/resources/db/migration'
+  into "${layout.buildDirectory.get().asFile.absolutePath}/tmp/patched-migrations"
+  filter { line ->
+    if (line.contains('CONCURRENTLY')) {
+      return line.replace('CONCURRENTLY', '')
+    }
+    if (line.contains('-- flyway:executeInTransaction=false')) {
+      return ''
+    }
+    return line
+  }
+}
+
 tasks.withType(JavaCompile).configureEach {
   options.compilerArgs << "-Xlint:unchecked" << "-Xlint:-removal" << "-Werror"
 }
@@ -138,6 +152,11 @@ tasks.named('test', Test) {
 
 tasks.withType(Copy).configureEach {
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+tasks.withType(Test).configureEach {
+  dependsOn preparePatchedMigrations
+  systemProperty 'spring.flyway.locations', "filesystem:${layout.buildDirectory.get().asFile.absolutePath}/tmp/patched-migrations"
 }
 
 def integration = tasks.register('integration', Test) {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/repositories/CasemanReferenceNumberRepositoryIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/repositories/CasemanReferenceNumberRepositoryIT.java
@@ -33,7 +33,7 @@ class CasemanReferenceNumberRepositoryIT {
 
         Flyway.configure()
             .dataSource(dataSource)
-            .locations("classpath:db/migration")
+            .locations(System.getProperty("spring.flyway.locations", "classpath:db/migration"))
             .placeholderReplacement(false)
             .load()
             .migrate();


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Implement a Gradle task to remove 'CONCURRENTLY' and non-transactional
headers from Flyway migrations during test execution. This prevents
integration tests from hanging when applying indexes that were merged
with production-only settings, while keeping the original migrations
intact for production use.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
