### PR TITLE
DTSCCI-6049 Extend contract test coverage for remaining common-component gaps (Camunda, CRD, JRD, Send Letter, CJES, Dashboard, Payments, Docmosis convert)

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CamundaRuntimeApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CamundaRuntimeApiConsumerTest.java
@@ -1,0 +1,220 @@
+package uk.gov.hmcts.reform.civil.consumer;
+
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import org.apache.http.HttpStatus;
+import org.camunda.community.rest.client.model.IncidentDto;
+import org.camunda.community.rest.client.model.ProcessInstanceDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.civil.service.camunda.CamundaRuntimeApi;
+import uk.gov.hmcts.reform.civil.service.camunda.CamundaRuntimeClient;
+
+import java.util.List;
+import java.util.Map;
+
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArray;
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@PactTestFor(providerName = "camunda_rest_engine")
+@MockServerConfig(hostInterface = "localhost", port = "6687")
+@TestPropertySource(properties = "feign.client.config.processInstance.url=http://localhost:6687")
+public class CamundaRuntimeApiConsumerTest extends BaseContractTest {
+
+    private static final String PROCESS_INSTANCE_ID = "process-instance-id";
+    private static final String INCIDENT_ID = "incident-id";
+    private static final String JOB_ID = "job-id";
+
+    @Autowired
+    private CamundaRuntimeClient camundaRuntimeClient;
+
+    @Autowired
+    private CamundaRuntimeApi camundaRuntimeApi;
+
+    @MockBean
+    private AuthTokenGenerator authTokenGenerator;
+
+    @BeforeEach
+    void setUp() {
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact getProcessVariables(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a Camunda process variables request")
+            .path("/process-instance/" + PROCESS_INSTANCE_ID + "/variables")
+            .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
+            .method(HttpMethod.GET.toString())
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildProcessVariablesResponse())
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact queryProcessInstances(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a Camunda history process instance query request")
+            .path("/history/process-instance")
+            .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN, HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .matchQuery("maxResults", "\\d+", "50")
+            .matchQuery("sortBy", "startTime", "startTime")
+            .matchQuery("sortOrder", "desc|asc", "desc")
+            .method(HttpMethod.POST.toString())
+            .body("""
+                {
+                  "processDefinitionKey": "civil"
+                }
+                """)
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildProcessInstanceResponse())
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact fetchExternalTaskErrorDetails(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a Camunda external task error details request")
+            .path("/history/external-task-log/" + INCIDENT_ID + "/error-details")
+            .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
+            .method(HttpMethod.GET.toString())
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(newJsonBody(root -> root.stringValue("message", "External task failed")).build())
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact getLatestIncident(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a Camunda latest open incident request")
+            .path("/incident")
+            .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
+            .matchQuery("open", "true|false", "true")
+            .matchQuery("processInstanceId", PROCESS_INSTANCE_ID, PROCESS_INSTANCE_ID)
+            .matchQuery("sortBy", "incidentTimestamp", "incidentTimestamp")
+            .matchQuery("sortOrder", "desc|asc", "desc")
+            .matchQuery("maxResults", "\\d+", "1")
+            .method(HttpMethod.GET.toString())
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildIncidentResponse())
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact setJobRetries(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a Camunda set job retries request")
+            .path("/job/" + JOB_ID + "/retries")
+            .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN, HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .method(HttpMethod.PUT.toString())
+            .body("""
+                {
+                  "retries": 1
+                }
+                """)
+            .willRespondWith()
+            .status(HttpStatus.SC_NO_CONTENT)
+            .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getProcessVariables")
+    public void verifyGetProcessVariables() {
+        Map<String, Object> response = camundaRuntimeClient.getProcessVariables(PROCESS_INSTANCE_ID);
+
+        assertThat(response.get("caseId"), is(equalTo("1712345678901234")));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "queryProcessInstances")
+    public void verifyQueryProcessInstances() {
+        List<ProcessInstanceDto> response = camundaRuntimeApi.queryProcessInstances(
+            SERVICE_AUTH_TOKEN,
+            null,
+            50,
+            "startTime",
+            "desc",
+            Map.of("processDefinitionKey", "civil")
+        );
+
+        assertThat(response.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "fetchExternalTaskErrorDetails")
+    public void verifyFetchExternalTaskErrorDetails() {
+        Map<String, Object> response = camundaRuntimeApi.fetchErrorDetails(INCIDENT_ID, SERVICE_AUTH_TOKEN);
+
+        assertThat(response.get("message"), is(equalTo("External task failed")));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getLatestIncident")
+    public void verifyGetLatestIncident() {
+        List<IncidentDto> response = camundaRuntimeApi.getLatestOpenIncidentForProcessInstance(
+            SERVICE_AUTH_TOKEN,
+            true,
+            PROCESS_INSTANCE_ID,
+            "incidentTimestamp",
+            "desc",
+            1
+        );
+
+        assertThat(response.size(), is(equalTo(1)));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "setJobRetries")
+    public void verifySetJobRetries() {
+        camundaRuntimeApi.setJobRetries(SERVICE_AUTH_TOKEN, JOB_ID, Map.of("retries", 1));
+    }
+
+    private DslPart buildProcessVariablesResponse() {
+        return newJsonBody(root -> root.object("caseId", caseId -> caseId
+            .stringValue("type", "String")
+            .stringValue("value", "1712345678901234")
+            .object("valueInfo", valueInfo -> {
+            }))).build();
+    }
+
+    private DslPart buildProcessInstanceResponse() {
+        return newJsonArray(root -> root.object(processInstance -> processInstance
+            .stringValue("id", PROCESS_INSTANCE_ID)
+            .stringValue("definitionId", "civil:1:definition")
+            .stringValue("businessKey", "1712345678901234")
+            .booleanValue("ended", false)
+            .booleanValue("suspended", false))).build();
+    }
+
+    private DslPart buildIncidentResponse() {
+        return newJsonArray(root -> root.object(incident -> incident
+            .stringValue("id", INCIDENT_ID)
+            .stringValue("processInstanceId", PROCESS_INSTANCE_ID)
+            .stringValue("incidentType", "failedExternalTask")
+            .stringValue("incidentMessage", "External task failed")
+            .stringValue("configuration", JOB_ID))).build();
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CjesApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CjesApiConsumerTest.java
@@ -1,0 +1,73 @@
+package uk.gov.hmcts.reform.civil.consumer;
+
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.civil.client.CjesApiClient;
+import uk.gov.hmcts.reform.civil.model.judgmentonline.JudgmentAddress;
+import uk.gov.hmcts.reform.civil.model.judgmentonline.cjes.JudgmentDefendantDetails;
+import uk.gov.hmcts.reform.civil.model.judgmentonline.cjes.JudgmentDetailsCJES;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@PactTestFor(providerName = "rtl")
+@MockServerConfig(hostInterface = "localhost", port = "6685")
+@TestPropertySource(properties = "rtl.api.url=http://localhost:6685")
+public class CjesApiConsumerTest extends BaseContractTest {
+
+    private static final String JUDGMENT_ID = "J-0001";
+
+    @Autowired
+    private CjesApiClient cjesApiClient;
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact sendJudgment(PactDslWithProvider builder) throws Exception {
+        return builder
+            .uponReceiving("a CJES judgment registration request")
+            .path("/judgment%7D")
+            .method(HttpMethod.POST.toString())
+            .body(createJsonObject(buildJudgmentDetails()))
+            .willRespondWith()
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "sendJudgment")
+    public void verifySendJudgment() {
+        cjesApiClient.sendJudgmentDetailsCJES(buildJudgmentDetails());
+    }
+
+    private JudgmentDetailsCJES buildJudgmentDetails() {
+        return new JudgmentDetailsCJES(
+            "AAA7",
+            JUDGMENT_ID,
+            LocalDateTime.of(2026, 8, 14, 10, 15, 30),
+            "20262",
+            "1712345678901234",
+            "000MC001",
+            100.00,
+            LocalDate.of(2026, 8, 14),
+            "judgmentRegistered",
+            null,
+            buildDefendant(),
+            null
+        );
+    }
+
+    private JudgmentDefendantDetails buildDefendant() {
+        return new JudgmentDefendantDetails(
+            "Jane Smith",
+            LocalDate.of(1980, 1, 1),
+            new JudgmentAddress("1 High Street", null, null, null, "London", "SW1A 1AA")
+        );
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CommonRefDataApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CommonRefDataApiConsumerTest.java
@@ -1,0 +1,84 @@
+package uk.gov.hmcts.reform.civil.consumer;
+
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.civil.crd.model.CategorySearchResult;
+import uk.gov.hmcts.reform.civil.service.CategoryService;
+
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@PactTestFor(providerName = "rd_commondata_api")
+@MockServerConfig(hostInterface = "localhost", port = "6682")
+@TestPropertySource(properties = "rd_commondata.api.url=http://localhost:6682")
+public class CommonRefDataApiConsumerTest extends BaseContractTest {
+
+    private static final String CATEGORY_ID = "HearingChannel";
+    private static final String SERVICE_ID = "AAA7";
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @MockBean
+    private AuthTokenGenerator authTokenGenerator;
+
+    @BeforeEach
+    void setUp() {
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact getListOfValuesCategory(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a common ref data list of values category request")
+            .path("/refdata/commondata/lov/categories/" + CATEGORY_ID)
+            .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN, AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
+            .method(HttpMethod.GET.toString())
+            .matchQuery("serviceId", "AAA6|AAA7", SERVICE_ID)
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildCategoryResponse())
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getListOfValuesCategory")
+    public void verifyGetListOfValuesCategory() {
+        CategorySearchResult response = categoryService
+            .findCategoryByCategoryIdAndServiceId(AUTHORIZATION_TOKEN, CATEGORY_ID, SERVICE_ID)
+            .orElseThrow();
+
+        assertThat(response.getCategories().size(), is(equalTo(1)));
+        assertThat(response.getCategories().get(0).getKey(), is(equalTo("INTER")));
+    }
+
+    private DslPart buildCategoryResponse() {
+        return newJsonBody(root -> root.minArrayLike("list_of_values", 1, 1, category -> category
+            .stringValue("active_flag", "Y")
+            .stringValue("category_key", CATEGORY_ID)
+            .stringValue("key", "INTER")
+            .numberValue("lov_order", 1)
+            .stringValue("value_en", "In person")
+            .stringValue("value_cy", "Wyneb yn wyneb")
+            .minArrayLike("child_nodes", 0, 0, child -> {
+            }))).build();
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/DashboardApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/DashboardApiConsumerTest.java
@@ -1,0 +1,107 @@
+package uk.gov.hmcts.reform.civil.consumer;
+
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.civil.ga.client.DashboardApiClient;
+import uk.gov.hmcts.reform.dashboard.data.ScenarioRequestParams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@PactTestFor(providerName = "dashboard_api")
+@MockServerConfig(hostInterface = "localhost", port = "6686")
+@TestPropertySource(properties = "dashboard.api.url=http://localhost:6686")
+public class DashboardApiConsumerTest extends BaseContractTest {
+
+    private static final String CASE_ID = "1712345678901234";
+    private static final String ROLE_TYPE = "APPLICANT";
+    private static final String TEMPLATE_NAME = "application-submitted";
+    private static final String SCENARIO_REF = "Scenario.AAA6.GeneralApps.ApplicationSubmitted.Applicant";
+
+    @Autowired
+    private DashboardApiClient dashboardApiClient;
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact recordScenario(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a dashboard record scenario request")
+            .path("/dashboard/scenarios/" + SCENARIO_REF + "/" + CASE_ID)
+            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .method(HttpMethod.POST.toString())
+            .body("""
+                {
+                  "params": {
+                    "ccdCaseReference": "%s",
+                    "partyName": "Jane Smith"
+                  }
+                }
+                """.formatted(CASE_ID))
+            .willRespondWith()
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact deleteNotificationsForRole(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a dashboard delete notifications for role request")
+            .path("/dashboard/notifications/" + CASE_ID + "/role/" + ROLE_TYPE)
+            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
+            .method(HttpMethod.DELETE.toString())
+            .willRespondWith()
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact deleteTemplateNotificationsForRole(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a dashboard delete template notifications for role request")
+            .path("/dashboard/notifications/" + CASE_ID + "/role/" + ROLE_TYPE + "/" + TEMPLATE_NAME)
+            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
+            .method(HttpMethod.DELETE.toString())
+            .willRespondWith()
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "recordScenario")
+    public void verifyRecordScenario() {
+        dashboardApiClient.recordScenario(CASE_ID, SCENARIO_REF, AUTHORIZATION_TOKEN, scenarioRequestParams());
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "deleteNotificationsForRole")
+    public void verifyDeleteNotificationsForRole() {
+        dashboardApiClient.deleteNotificationsForCaseIdentifierAndRole(CASE_ID, ROLE_TYPE, AUTHORIZATION_TOKEN);
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "deleteTemplateNotificationsForRole")
+    public void verifyDeleteTemplateNotificationsForRole() {
+        dashboardApiClient.deleteTemplateNotificationsForCaseIdentifierAndRole(
+            CASE_ID,
+            ROLE_TYPE,
+            TEMPLATE_NAME,
+            AUTHORIZATION_TOKEN
+        );
+    }
+
+    private ScenarioRequestParams scenarioRequestParams() {
+        return new ScenarioRequestParams(new HashMap<>(Map.of(
+            "ccdCaseReference", CASE_ID,
+            "partyName", "Jane Smith"
+        )));
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/DocmosisApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/DocmosisApiConsumerTest.java
@@ -7,28 +7,49 @@ import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
 import org.apache.http.HttpStatus;
 import org.json.JSONException;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.civil.documentmanagement.DocumentManagementService;
+import uk.gov.hmcts.reform.civil.documentmanagement.model.Document;
 import uk.gov.hmcts.reform.civil.client.DocmosisApiClient;
 import uk.gov.hmcts.reform.civil.helpers.ResourceReader;
 import uk.gov.hmcts.reform.civil.model.docmosis.DocmosisRequest;
+import uk.gov.hmcts.reform.civil.service.DocumentConversionService;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
 
 @PactTestFor(providerName = "docmosis_render")
 @MockServerConfig(hostInterface = "localhost", port = "6660")
+@TestPropertySource(properties = "docmosis.tornado.key=accessKey")
 public class DocmosisApiConsumerTest extends BaseContractTest {
 
     public static final String ENDPOINT = "/rs/render";
+    public static final String CONVERT_ENDPOINT = "/rs/convert";
+    private static final String SOURCE_FILE_NAME = "source-document.docx";
+    private static final String CONVERTED_FILE_NAME = "source-document.pdf";
+    private static final String DOCUMENT_URL = "http://dm-store/documents/document-id";
 
     @Autowired
     private DocmosisApiClient docmosisApiClient;
+
+    @Autowired
+    private DocumentConversionService documentConversionService;
+
+    @MockBean
+    private DocumentManagementService documentManagementService;
 
     @Pact(consumer = "civil_service")
     public RequestResponsePact postCreateDocumentRequest(PactDslWithProvider builder)
@@ -36,10 +57,42 @@ public class DocmosisApiConsumerTest extends BaseContractTest {
         return buildCreateDocumentResponsePact(builder);
     }
 
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact postConvertDocumentRequest(PactDslWithProvider builder) throws IOException {
+        return builder
+            .uponReceiving("a convert document request")
+            .path(CONVERT_ENDPOINT)
+            .method(HttpMethod.POST.toString())
+            .matchHeader(HttpHeaders.CONTENT_TYPE, "multipart/form-data.*", "multipart/form-data")
+            .willRespondWith()
+            .withBinaryData(getResponse(), "application/pdf")
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @AfterEach
+    void cleanUpConvertedSourceFile() throws IOException {
+        Files.deleteIfExists(Path.of(CONVERTED_FILE_NAME));
+    }
+
     @Test
     @PactTestFor(pactMethod = "postCreateDocumentRequest")
     public void verifyCreateDocumentRequest() throws IOException {
         byte[] response = docmosisApiClient.createDocument(getDocmosisRequest());
+
+        assertThat(
+            response,
+            is(equalTo(getResponse()))
+        );
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "postConvertDocumentRequest")
+    public void verifyConvertDocumentRequest() throws IOException {
+        when(documentManagementService.downloadDocument(AUTHORIZATION_TOKEN, DOCUMENT_URL))
+            .thenReturn("source document".getBytes());
+
+        byte[] response = documentConversionService.convert(getSourceDocument(), 1712345678901234L, AUTHORIZATION_TOKEN);
 
         assertThat(
             response,
@@ -70,6 +123,12 @@ public class DocmosisApiConsumerTest extends BaseContractTest {
             .setOutputFormat("outputFormat")
             .setOutputName("outputName")
             .setData(Map.of("data", "dataV"));
+    }
+
+    private Document getSourceDocument() {
+        return new Document()
+            .setDocumentUrl(DOCUMENT_URL)
+            .setDocumentFileName(SOURCE_FILE_NAME);
     }
 
 }

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/JudicialRefDataApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/JudicialRefDataApiConsumerTest.java
@@ -1,0 +1,99 @@
+package uk.gov.hmcts.reform.civil.consumer;
+
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.civil.referencedata.JudicialRefDataService;
+import uk.gov.hmcts.reform.civil.referencedata.model.JudgeRefData;
+
+import java.util.List;
+
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArray;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@PactTestFor(providerName = "judicial_ref_data")
+@MockServerConfig(hostInterface = "localhost", port = "6683")
+@TestPropertySource(properties = {
+    "genApp.jrd.url=http://localhost:6683",
+    "genApp.jrd.endpoint=/refdata/judicial/users/search"
+})
+public class JudicialRefDataApiConsumerTest extends BaseContractTest {
+
+    private static final String SEARCH_STRING = "Smith";
+    private static final String PERSONAL_CODE = "1234567";
+
+    @Autowired
+    private JudicialRefDataService judicialRefDataService;
+
+    @MockBean
+    private AuthTokenGenerator authTokenGenerator;
+
+    @BeforeEach
+    void setUp() {
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact searchJudicialUsers(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a judicial ref data user search request")
+            .path("/refdata/judicial/users/search")
+            .headers(
+                SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN,
+                AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN,
+                HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE
+            )
+            .method(HttpMethod.POST.toString())
+            .body("""
+                {
+                  "searchString": "%s",
+                  "serviceCode": null,
+                  "location": null
+                }
+                """.formatted(SEARCH_STRING))
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildJudicialUsersResponse())
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "searchJudicialUsers")
+    public void verifySearchJudicialUsers() {
+        List<JudgeRefData> response = judicialRefDataService.getJudgeReferenceData(SEARCH_STRING, AUTHORIZATION_TOKEN);
+
+        assertThat(response.size(), is(equalTo(1)));
+        assertThat(response.get(0).getPersonalCode(), is(equalTo(PERSONAL_CODE)));
+    }
+
+    private DslPart buildJudicialUsersResponse() {
+        return newJsonArray(root -> root.object(judge -> judge
+            .stringValue("post_nominals", "DJ")
+            .stringValue("known_as", "Jane")
+            .stringValue("surname", "Smith")
+            .stringValue("full_name", "District Judge Jane Smith")
+            .stringValue("ejudiciary_email", "jane.smith@judiciary.uk")
+            .stringValue("sidam_id", "11111111-1111-1111-1111-111111111111")
+            .stringValue("personal_code", PERSONAL_CODE)
+            .stringValue("is_judge", "Y")
+            .stringValue("is_panel_member", "N")
+            .stringValue("is_magistrate", "N"))).build();
+    }
+}

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/PaymentsApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/PaymentsApiConsumerTest.java
@@ -24,9 +24,18 @@ import uk.gov.hmcts.reform.civil.prd.model.Organisation;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
 import uk.gov.hmcts.reform.civil.service.PaymentsService;
+import uk.gov.hmcts.reform.payments.client.PaymentsClient;
 import uk.gov.hmcts.reform.payments.client.models.PaymentDto;
+import uk.gov.hmcts.reform.payments.request.CardPaymentRequest;
+import uk.gov.hmcts.reform.payments.request.CardPaymentServiceRequestDTO;
+import uk.gov.hmcts.reform.payments.request.CreateServiceRequestDTO;
+import uk.gov.hmcts.reform.payments.request.PBAServiceRequestDTO;
+import uk.gov.hmcts.reform.payments.response.CardPaymentServiceRequestResponse;
+import uk.gov.hmcts.reform.payments.response.PBAServiceRequestResponse;
+import uk.gov.hmcts.reform.payments.response.PaymentServiceResponse;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,10 +58,17 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
     private static final Organisation ORGANISATION = new Organisation()
         .setName("test org")
         .setContactInformation(List.of(new ContactInformation()));
+    private static final String PAYMENT_REFERENCE = "RC-1700000000000001";
+    private static final String SERVICE_REQUEST_REFERENCE = "2026-1700000000000001";
+    private static final String RETURN_URL = "https://civil-service/return";
+    private static final String CALLBACK_URL = "https://civil-service/callback";
     protected static final String ACCOUNT_NUMBER = "PBA0077597";
 
     @Autowired
     private PaymentsService paymentsService;
+
+    @Autowired
+    private PaymentsClient paymentsClient;
 
     @MockBean
     AuthTokenGenerator authTokenGenerator;
@@ -71,6 +87,107 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
         return buildCardPaymentRequestPact(builder);
     }
 
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact createCardPayment(PactDslWithProvider builder) throws IOException {
+        return builder
+            .uponReceiving("a request to create a card payment")
+            .path("/card-payments")
+            .headers(
+                AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN,
+                SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN,
+                "return-url", RETURN_URL,
+                "service-callback-url", CALLBACK_URL
+            )
+            .method(HttpMethod.POST.toString())
+            .body(createJsonObject(buildCardPaymentRequest()))
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildPaymentResponseDsl("Initiated"))
+            .status(HttpStatus.SC_CREATED)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact retrieveCardPayment(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a request to retrieve a card payment")
+            .path("/card-payments/" + PAYMENT_REFERENCE)
+            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
+            .method(HttpMethod.GET.toString())
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildPaymentResponseDsl("Success"))
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact retrieveCardPaymentStatus(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a request to retrieve a card payment status")
+            .path("/card-payments/" + PAYMENT_REFERENCE + "/statuses")
+            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
+            .method(HttpMethod.GET.toString())
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildPaymentResponseDsl("Success"))
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact createServiceRequest(PactDslWithProvider builder) throws IOException {
+        return builder
+            .uponReceiving("a request to create a payments service request")
+            .path("/service-request")
+            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
+            .method(HttpMethod.POST.toString())
+            .body(createJsonObject(buildCreateServiceRequest()))
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(newJsonBody(root -> root.stringValue("service_request_reference", SERVICE_REQUEST_REFERENCE)).build())
+            .status(HttpStatus.SC_CREATED)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact createPbaPayment(PactDslWithProvider builder) throws IOException {
+        return builder
+            .uponReceiving("a request to create a PBA payment for a service request")
+            .path("/service-request/" + SERVICE_REQUEST_REFERENCE + "/pba-payments")
+            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
+            .method(HttpMethod.POST.toString())
+            .body(createJsonObject(buildPbaServiceRequest()))
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(newJsonBody(root -> root
+                .stringValue("payment_reference", PAYMENT_REFERENCE)
+                .stringValue("status", "Success")
+                .stringValue("date_created", "2026-08-14T10:15:30.000Z")).build())
+            .status(HttpStatus.SC_CREATED)
+            .toPact();
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact createGovPayCardPaymentRequest(PactDslWithProvider builder) throws IOException {
+        return builder
+            .uponReceiving("a request to create a service request card payment")
+            .path("/service-request/" + SERVICE_REQUEST_REFERENCE + "/card-payments")
+            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
+            .method(HttpMethod.POST.toString())
+            .body(createJsonObject(buildCardPaymentServiceRequest()))
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(newJsonBody(root -> root
+                .stringValue("external_reference", "external-reference")
+                .stringValue("payment_reference", PAYMENT_REFERENCE)
+                .stringValue("status", "Initiated")
+                .stringValue("next_url", "https://payments/next")
+                .stringValue("date_created", "2026-08-14T10:15:30Z")).build())
+            .status(HttpStatus.SC_CREATED)
+            .toPact();
+    }
+
     @BeforeEach
     void setUp() {
         when(paymentsConfiguration.getService()).thenReturn(SERVICE);
@@ -86,6 +203,70 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
         PaymentDto response = paymentsService.createCreditAccountPayment(caseData, AUTHORIZATION_TOKEN);
         assertThat(response.getStatus(), is("Success"));
 
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "createCardPayment")
+    public void verifyCreateCardPayment() {
+        PaymentDto response = paymentsClient.createCardPayment(
+            AUTHORIZATION_TOKEN,
+            buildCardPaymentRequest(),
+            RETURN_URL,
+            CALLBACK_URL
+        );
+
+        assertThat(response.getStatus(), is("Initiated"));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "retrieveCardPayment")
+    public void verifyRetrieveCardPayment() {
+        PaymentDto response = paymentsClient.retrieveCardPayment(AUTHORIZATION_TOKEN, PAYMENT_REFERENCE);
+
+        assertThat(response.getPaymentReference(), is(PAYMENT_REFERENCE));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "retrieveCardPaymentStatus")
+    public void verifyRetrieveCardPaymentStatus() {
+        PaymentDto response = paymentsClient.getGovPayCardPaymentStatus(PAYMENT_REFERENCE, AUTHORIZATION_TOKEN);
+
+        assertThat(response.getStatus(), is("Success"));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "createServiceRequest")
+    public void verifyCreateServiceRequest() {
+        PaymentServiceResponse response = paymentsClient.createServiceRequest(
+            AUTHORIZATION_TOKEN,
+            buildCreateServiceRequest()
+        );
+
+        assertThat(response.getServiceRequestReference(), is(SERVICE_REQUEST_REFERENCE));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "createPbaPayment")
+    public void verifyCreatePbaPayment() {
+        PBAServiceRequestResponse response = paymentsClient.createPbaPayment(
+            SERVICE_REQUEST_REFERENCE,
+            AUTHORIZATION_TOKEN,
+            buildPbaServiceRequest()
+        );
+
+        assertThat(response.getPaymentReference(), is(PAYMENT_REFERENCE));
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "createGovPayCardPaymentRequest")
+    public void verifyCreateGovPayCardPaymentRequest() {
+        CardPaymentServiceRequestResponse response = paymentsClient.createGovPayCardPaymentRequest(
+            SERVICE_REQUEST_REFERENCE,
+            AUTHORIZATION_TOKEN,
+            buildCardPaymentServiceRequest()
+        );
+
+        assertThat(response.getPaymentReference(), is(PAYMENT_REFERENCE));
     }
 
     private RequestResponsePact buildCardPaymentRequestPact(PactDslWithProvider builder) throws IOException {
@@ -116,6 +297,7 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
     static DslPart getDslPart(String status, String paymentStatus, String errorCode, String errorMessage) {
         return newJsonBody((o) -> {
             o.stringType("reference", "reference")
+                .stringValue("payment_reference", PAYMENT_REFERENCE)
                 .stringType("status", status)
                 .minArrayLike("status_histories", 1, 1,
                     (sh) -> {
@@ -133,5 +315,64 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
                         }
                     });
         }).build();
+    }
+
+    private DslPart buildPaymentResponseDsl(String status) {
+        return newJsonBody(root -> root
+            .stringValue("reference", "reference")
+            .stringValue("payment_reference", PAYMENT_REFERENCE)
+            .stringValue("status", status)
+            .stringValue("currency", "GBP")
+            .numberValue("amount", 100.00)).build();
+    }
+
+    private CardPaymentRequest buildCardPaymentRequest() {
+        return CardPaymentRequest.builder()
+            .amount(new BigDecimal("100.00"))
+            .caseReference("000MC001")
+            .ccdCaseNumber("1712345678901234")
+            .channel("online")
+            .description("Claim issue payment")
+            .provider("govpay")
+            .caseType("CIVIL")
+            .fees(new uk.gov.hmcts.reform.payments.client.models.FeeDto[] {buildFee()})
+            .build();
+    }
+
+    private CreateServiceRequestDTO buildCreateServiceRequest() {
+        return CreateServiceRequestDTO.builder()
+            .callBackUrl(CALLBACK_URL)
+            .caseReference("000MC001")
+            .ccdCaseNumber("1712345678901234")
+            .hmctsOrgId(SITE_ID)
+            .fees(new uk.gov.hmcts.reform.payments.client.models.FeeDto[] {buildFee()})
+            .build();
+    }
+
+    private PBAServiceRequestDTO buildPbaServiceRequest() {
+        return PBAServiceRequestDTO.builder()
+            .accountNumber(ACCOUNT_NUMBER)
+            .amount(new BigDecimal("100.00"))
+            .customerReference("customer-reference")
+            .idempotencyKey("idempotency-key")
+            .organisationName("test org")
+            .build();
+    }
+
+    private CardPaymentServiceRequestDTO buildCardPaymentServiceRequest() {
+        return CardPaymentServiceRequestDTO.builder()
+            .amount(new BigDecimal("100.00"))
+            .language("en")
+            .returnUrl(RETURN_URL)
+            .build();
+    }
+
+    private uk.gov.hmcts.reform.payments.client.models.FeeDto buildFee() {
+        return uk.gov.hmcts.reform.payments.client.models.FeeDto.builder()
+            .calculatedAmount(new BigDecimal("100.00"))
+            .code("FEE0204")
+            .version("1")
+            .volume(1)
+            .build();
     }
 }

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/SendLetterApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/SendLetterApiConsumerTest.java
@@ -1,0 +1,127 @@
+package uk.gov.hmcts.reform.civil.consumer;
+
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.civil.service.BulkPrintService;
+import uk.gov.hmcts.reform.sendletter.api.SendLetterResponse;
+
+import java.util.List;
+
+import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonBody;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+
+@PactTestFor(providerName = "send_letter")
+@MockServerConfig(hostInterface = "localhost", port = "6684")
+@TestPropertySource(properties = "send-letter.url=http://localhost:6684")
+public class SendLetterApiConsumerTest extends BaseContractTest {
+
+    private static final String LETTER_ID = "11111111-2222-3333-4444-555555555555";
+    private static final String CASE_ID = "1712345678901234";
+    private static final String CASE_REFERENCE = "000MC001";
+    private static final String LETTER_TYPE = "final-order";
+    private static final String LETTER_V2_MEDIA_TYPE = "application/vnd.uk.gov.hmcts.letter-service.in.letter.v2+json";
+
+    @Autowired
+    private BulkPrintService bulkPrintService;
+
+    @MockBean
+    private AuthTokenGenerator authTokenGenerator;
+
+    @BeforeEach
+    void setUp() {
+        when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
+    }
+
+    @Pact(consumer = "civil_service")
+    public RequestResponsePact sendLetter(PactDslWithProvider builder) {
+        return builder
+            .uponReceiving("a bulk print send letter request")
+            .path("/letters")
+            .matchQuery("isAsync", "true", "true")
+            .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN, HttpHeaders.CONTENT_TYPE, LETTER_V2_MEDIA_TYPE)
+            .method(HttpMethod.POST.toString())
+            .body(buildSendLetterRequest(), LETTER_V2_MEDIA_TYPE)
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildSendLetterResponse())
+            .status(HttpStatus.SC_CREATED)
+            .uponReceiving("a bulk print letter status request")
+            .path("/letters/" + LETTER_ID)
+            .matchQuery("include-additional-info", "false", "false")
+            .matchQuery("check-duplicate", "true", "true")
+            .method(HttpMethod.GET.toString())
+            .willRespondWith()
+            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .body(buildLetterStatusResponse())
+            .status(HttpStatus.SC_OK)
+            .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "sendLetter")
+    public void verifySendLetter() {
+        SendLetterResponse response = bulkPrintService.printLetter(
+            "test letter".getBytes(),
+            CASE_ID,
+            CASE_REFERENCE,
+            LETTER_TYPE,
+            List.of("Jane Smith"),
+            List.of("final-order.pdf")
+        );
+
+        assertThat(response.letterId.toString(), is(equalTo(LETTER_ID)));
+    }
+
+    private String buildSendLetterRequest() {
+        return """
+            {
+              "type": "CMC001",
+              "documents": [
+                "dGVzdCBsZXR0ZXI="
+              ],
+              "additional_data": {
+                "letterType": "%s",
+                "caseIdentifier": "%s",
+                "caseReferenceNumber": "%s",
+                "recipients": [
+                  "Jane Smith"
+                ],
+                "fileNames": [
+                  "final-order.pdf"
+                ]
+              }
+            }
+            """.formatted(LETTER_TYPE, CASE_ID, CASE_REFERENCE);
+    }
+
+    private DslPart buildSendLetterResponse() {
+        return newJsonBody(root -> root.stringValue("letter_id", LETTER_ID)).build();
+    }
+
+    private DslPart buildLetterStatusResponse() {
+        return newJsonBody(root -> root
+            .stringValue("id", LETTER_ID)
+            .stringValue("status", "Created")
+            .stringValue("message_id", "checksum")
+            .stringValue("checksum", "checksum")
+            .stringValue("created_at", "2026-08-14T10:15:30Z")
+            .numberValue("copies", 1)).build();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6049

### Change description ###

 Added new consumer Pact tests for:

  - Camunda REST: process variables, process-instance query, external task error details, incident lookup, job retry
  - CRD: list-of-values category lookup
  - JRD: /refdata/judicial/users/search
  - Send Letter: create letter + status poll
  - CJES/RTL: judgment submission
  - Dashboard API: record scenario + delete notification variants

  Extended existing tests for:

  - Payments: card payment create/retrieve/status, service request, PBA payment, service-request card payment
  - Docmosis: added /rs/convert alongside existing /rs/render

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
