### PR TITLE
DTSCCI-5930: truncates every bundle document title

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/bundle/BundleUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/bundle/BundleUtils.java
@@ -15,6 +15,8 @@ public class BundleUtils {
     private static final String DATE_FORMAT = "dd/MM/yyyy";
 
     public static final int MAX_DOC_TITLE_LENGTH = 255;
+    private static final int PRESERVED_DOC_TITLE_SUFFIX_LENGTH = 40;
+    private static final String TRUNCATION_MARKER = "...";
 
     private BundleUtils() {
         //NO-OP
@@ -38,20 +40,30 @@ public class BundleUtils {
             formattedTitle = String.format(fileName, strParam, strParam2, formatLocalDate);
         }
 
-        if (formattedTitle.length() > MAX_DOC_TITLE_LENGTH) {
-            log.info("Truncating generated doc name to 255 chars: {}", formattedTitle);
-            formattedTitle = formattedTitle.substring(0, MAX_DOC_TITLE_LENGTH);
-        }
-        return formattedTitle;
+        return truncateDocName(formattedTitle);
     }
 
     public static BundlingRequestDocument buildBundlingRequestDoc(String docName, Document document, String docType) {
         return new BundlingRequestDocument()
-            .setDocumentFileName(docName)
+            .setDocumentFileName(truncateDocName(docName))
             .setDocumentType(docType)
             .setDocumentLink(new DocumentLink()
                                  .setDocumentUrl(document.getDocumentUrl())
                                  .setDocumentBinaryUrl(document.getDocumentBinaryUrl())
                                  .setDocumentFilename(document.getDocumentFileName()));
+    }
+
+    private static String truncateDocName(String docName) {
+        if (docName == null || docName.length() <= MAX_DOC_TITLE_LENGTH) {
+            return docName;
+        }
+
+        log.info("Truncating bundle document name to {} chars: {}", MAX_DOC_TITLE_LENGTH, docName);
+        int prefixLength = MAX_DOC_TITLE_LENGTH
+            - TRUNCATION_MARKER.length()
+            - PRESERVED_DOC_TITLE_SUFFIX_LENGTH;
+        return docName.substring(0, prefixLength)
+            + TRUNCATION_MARKER
+            + docName.substring(docName.length() - PRESERVED_DOC_TITLE_SUFFIX_LENGTH);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/bundle/BundleUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/bundle/BundleUtils.java
@@ -62,8 +62,10 @@ public class BundleUtils {
         int prefixLength = MAX_DOC_TITLE_LENGTH
             - TRUNCATION_MARKER.length()
             - PRESERVED_DOC_TITLE_SUFFIX_LENGTH;
-        return docName.substring(0, prefixLength)
+        String truncatedName = docName.substring(0, prefixLength)
             + TRUNCATION_MARKER
             + docName.substring(docName.length() - PRESERVED_DOC_TITLE_SUFFIX_LENGTH);
+        log.info("Truncated bundle document name to {}", truncatedName);
+        return truncatedName;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/helpers/bundle/mappers/ManageDocMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/helpers/bundle/mappers/ManageDocMapper.java
@@ -6,6 +6,7 @@ import uk.gov.hmcts.reform.civil.model.bundle.BundlingRequestDocument;
 import uk.gov.hmcts.reform.civil.model.citizenui.ManageDocument;
 import uk.gov.hmcts.reform.civil.model.common.Element;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -21,7 +22,7 @@ public interface ManageDocMapper {
             bundlingRequestDocuments.add(
                 buildBundlingRequestDoc(
                     generateDocName(getDocumentNameBasedOfCategory(docCategory), md.getValue().getDocumentName(),
-                                    null, LocalDateTime.parse(md.getValue().getDocumentLink().getUploadTimestamp()).toLocalDate()),
+                                    null, getDocumentDate(md.getValue())),
                     md.getValue().getDocumentLink(),
                     md.getValue().getDocumentType().name()
                 )
@@ -36,12 +37,21 @@ public interface ManageDocMapper {
             bundlingRequestDocuments.add(
                 buildBundlingRequestDoc(
                     generateDocName(getDocumentNameBasedOfCategory(docCategory), md.getValue().getDocumentName(),
-                                    null, LocalDateTime.parse(md.getValue().getDocumentLink().getUploadTimestamp()).toLocalDate()),
+                                    null, getDocumentDate(md.getValue())),
                      md.getValue().getDocumentLink(),
                      md.getValue().getDocumentType().name()
                  )
             );
         }
+    }
+
+    default LocalDate getDocumentDate(ManageDocument manageDocument) {
+        String uploadTimestamp = manageDocument.getDocumentLink().getUploadTimestamp();
+        if (uploadTimestamp != null) {
+            return LocalDateTime.parse(uploadTimestamp).toLocalDate();
+        }
+
+        return manageDocument.getCreatedDatetime().toLocalDate();
     }
 
     default String getDocumentNameBasedOfCategory(DocCategory docCategory) {

--- a/src/test/java/uk/gov/hmcts/reform/civil/helpers/bundle/BundleUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/helpers/bundle/BundleUtilsTest.java
@@ -72,6 +72,28 @@ class BundleUtilsTest {
     }
 
     @Test
+    void shouldTruncateLongDocNameWhenBuildingBundlingRequestDocAndPreserveSuffix() {
+        String docName = "A".repeat(260) + " 24/04/2023.pdf";
+        Document document = new Document().setDocumentFileName("document.pdf");
+
+        BundlingRequestDocument result = BundleUtils.buildBundlingRequestDoc(docName, document, "TestDocType");
+
+        assertEquals(BundleUtils.MAX_DOC_TITLE_LENGTH, result.getDocumentFileName().length());
+        assertTrue(result.getDocumentFileName().startsWith("A"));
+        assertTrue(result.getDocumentFileName().endsWith(" 24/04/2023.pdf"));
+        assertTrue(result.getDocumentFileName().contains("..."));
+    }
+
+    @Test
+    void shouldLeaveDocNameAtMaxLengthUnchangedWhenBuildingBundlingRequestDoc() {
+        String docName = "A".repeat(BundleUtils.MAX_DOC_TITLE_LENGTH);
+        Document document = new Document().setDocumentFileName("document.pdf");
+
+        BundlingRequestDocument result = BundleUtils.buildBundlingRequestDoc(docName, document, "TestDocType");
+        assertEquals(docName, result.getDocumentFileName());
+    }
+
+    @Test
     void shouldTruncateDocNameWhenExceedsMaxLength() {
         String longParam = "A".repeat(300); // More than 255 characters
         String fileName = "%s";
@@ -80,7 +102,7 @@ class BundleUtilsTest {
         String result = BundleUtils.generateDocName(fileName, longParam, "Param2", date);
 
         assertEquals(BundleUtils.MAX_DOC_TITLE_LENGTH, result.length());
-        assertEquals(longParam.substring(0, BundleUtils.MAX_DOC_TITLE_LENGTH), result);
+        assertTrue(result.startsWith(longParam.substring(0, 200)));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/civil/helpers/bundle/ConversionToBundleRequestDocsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/helpers/bundle/ConversionToBundleRequestDocsTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 class ConversionToBundleRequestDocsTest {
@@ -211,6 +212,37 @@ class ConversionToBundleRequestDocsTest {
 
         assertNotNull(result);
         assertEquals("document", result.getFirst().getDocumentFileName());
+    }
+
+    @Test
+    void shouldLimitOriginalDocumentFileNamesInBundleRequest() {
+        String longBaseName = "source-document-" + "A".repeat(250) + "-important-suffix";
+        Document longNameDocument = new Document()
+            .setDocumentFileName(longBaseName + ".pdf")
+            .setCategoryID("SomeCategoryID");
+        Document ordinaryDocument = new Document()
+            .setDocumentFileName("ordinary-document.pdf")
+            .setCategoryID("SomeCategoryID");
+        List<Element<UploadEvidenceDocumentType>> uploads = List.of(longNameDocument, ordinaryDocument).stream()
+            .map(document -> new Element<UploadEvidenceDocumentType>().setValue(
+                new UploadEvidenceDocumentType()
+                    .setDocumentIssuedDate(LocalDate.of(2023, 4, 24))
+                    .setDocumentUpload(document)
+            ))
+            .toList();
+
+        List<BundlingRequestDocument> result = conversionToBundleRequestDocs.covertEvidenceUploadTypeToBundleRequestDocs(
+            uploads,
+            "DOC_FILE_NAME",
+            EvidenceUploadType.COSTS.name(),
+            PartyType.CLAIMANT1
+        );
+
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(document ->
+            document.getDocumentFileName().length() <= BundleUtils.MAX_DOC_TITLE_LENGTH));
+        assertTrue(result.getFirst().getDocumentFileName().endsWith("-important-suffix"));
+        assertEquals("ordinary-document", result.get(1).getDocumentFileName());
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/civil/helpers/bundle/mappers/ManageDocMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/helpers/bundle/mappers/ManageDocMapperTest.java
@@ -1,0 +1,41 @@
+package uk.gov.hmcts.reform.civil.helpers.bundle.mappers;
+
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.handler.callback.user.task.evidenceupload.documenthandler.DocumentCategory;
+import uk.gov.hmcts.reform.civil.model.bundle.BundlingRequestDocument;
+import uk.gov.hmcts.reform.civil.model.citizenui.ManageDocument;
+import uk.gov.hmcts.reform.civil.model.common.Element;
+
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static uk.gov.hmcts.reform.civil.helpers.bundle.mappers.MockManageDocument.getManageDocumentElement;
+import static uk.gov.hmcts.reform.civil.model.citizenui.ManageDocumentType.OTHER;
+
+class ManageDocMapperTest {
+
+    private final ManageDocMapper mapper = new ManageDocMapper() { };
+
+    @Test
+    void shouldUseManageDocumentCreatedDateWhenUploadTimestampIsMissing() {
+        Element<ManageDocument> manageDocument = getManageDocumentElement(
+            OTHER,
+            DocumentCategory.APPLICANT_ONE_EXPERT_REPORT
+        );
+        manageDocument.getValue().getDocumentLink().setUploadTimestamp(null);
+        manageDocument.getValue().setCreatedDatetime(LocalDateTime.of(2024, Month.JUNE, 15, 10, 30));
+        List<BundlingRequestDocument> documents = new ArrayList<>();
+
+        mapper.addDocumentByCategoryId(
+            manageDocument,
+            documents,
+            DocumentCategory.APPLICANT_ONE_EXPERT_REPORT
+        );
+
+        assertEquals(1, documents.size());
+        assertEquals("Applicant1 Expert Report test_file 15/06/2024", documents.getFirst().getDocumentFileName());
+    }
+}


### PR DESCRIPTION

### JIRA link (if applicable) ###
DTSCCI-5930


### Change description ###
  - buildBundlingRequestDoc now truncates every bundle document title.
  - Truncation preserves the first portion, adds ..., and retains the final 40 characters for useful suffixes/dates.
  - Existing generated-title truncation uses the same strategy.
  - Added coverage for:
      - original filenames over 255 characters;
      - exactly 255 characters;
      - every produced bundle title staying within the limit;
      - ordinary filenames remaining unchanged.

 -- BundleRequestExecutor has no production callers in this repository- dead production code
 -- create-new-bundle path (createNewBundle): no retry wrapper at all.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
