### PR TITLE
DTSCCI-6150 Fix sensitive-data logging

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/service/NoCacheUserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/NoCacheUserService.java
@@ -11,7 +11,7 @@ public class NoCacheUserService extends UserService {
     private final IdamClient idamClient;
 
     public NoCacheUserService(IdamClient idamClient) {
-        super(idamClient, false);
+        super(idamClient);
         this.idamClient = idamClient;
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/service/UserService.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/service/UserService.java
@@ -1,9 +1,7 @@
 package uk.gov.hmcts.reform.civil.service;
 
 import feign.FeignException;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.civil.exceptions.UpstreamIdamException;
@@ -13,20 +11,16 @@ import uk.gov.hmcts.reform.idam.client.models.UserDetails;
 import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 
 @Service
-@Slf4j
 public class UserService {
 
     private static final int IDAM_USER_DETAILS_MAX_ATTEMPTS = 2;
     private static final long IDAM_USER_DETAILS_RETRY_DELAY_MILLIS = 250L;
 
     private final IdamClient idamClient;
-    private final boolean hmcSupportEnabled;
 
     @Autowired
-    public UserService(IdamClient idamClient,
-                       @Value("${hmc.support.enabled:false}") boolean hmcSupportEnabled) {
+    public UserService(IdamClient idamClient) {
         this.idamClient = idamClient;
-        this.hmcSupportEnabled = hmcSupportEnabled;
     }
 
     @Cacheable(value = "userInfoCache")
@@ -36,13 +30,7 @@ public class UserService {
 
     @Cacheable(value = "accessTokenCache")
     public String getAccessToken(String username, String password) {
-        var token = idamClient.getAccessToken(username, password);
-
-        if (hmcSupportEnabled) {
-            log.info("system user token: {}", token);
-        }
-
-        return token;
+        return idamClient.getAccessToken(username, password);
     }
 
     public UserDetails getUserDetails(String authorisation) {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -774,11 +774,11 @@ feign:
       externalTask:
         url: ${CAMUNDA_URL:http://localhost:9404/engine-rest/}
       idam-api:
-        loggerLevel: full
+        loggerLevel: basic
       core-case-data-api:
-        loggerLevel: full
+        loggerLevel: basic
       document-management-metadata-download-api:
-        loggerLevel: full
+        loggerLevel: basic
 
 docStore:
   doc:

--- a/src/test/java/uk/gov/hmcts/reform/civil/service/UserServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/service/UserServiceTest.java
@@ -53,7 +53,7 @@ class UserServiceTest {
 
     @BeforeEach
     public void setup() {
-        userService = new UserService(idamClient, false);
+        userService = new UserService(idamClient);
     }
 
     @Test


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSCCI-6150
Two latent logging footguns in civil-service could write sensitive data to logs if a flag or log level were toggled. Neither is active in any environment today, and civil-service is internal-only ([DTSCCI-4007](https://tools.hmcts.net/jira/browse/DTSCCI-4007) / VUL-7263), so there is no live exposure. This PR removes the code so the risk cannot be re-enabled by configuration.