### PR TITLE
DTSCCI-5931 IllegalArgumentException deserializing java.time.LocalDate from malformed case-data dates

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/civil/config/LenientLocalDateDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/LenientLocalDateDeserializer.java
@@ -24,6 +24,7 @@ public class LenientLocalDateDeserializer extends JsonDeserializer<LocalDate> {
 
         String raw = parser.getValueAsString();
         if (raw == null || raw.isBlank()) {
+            parser.skipChildren();
             return null;
         }
 
@@ -40,7 +41,7 @@ public class LenientLocalDateDeserializer extends JsonDeserializer<LocalDate> {
 
         while (parser.nextToken() != JsonToken.END_ARRAY) {
             if (!parser.currentToken().isNumeric()) {
-                parser.skipChildren();
+                skipRemainingArray(parser);
                 log.warn("Unparseable LocalDate array for field '{}' - treating as null", parser.currentName());
                 return null;
             }
@@ -57,6 +58,12 @@ public class LenientLocalDateDeserializer extends JsonDeserializer<LocalDate> {
         } catch (DateTimeException exception) {
             log.warn("Unparseable LocalDate array '{}' for field '{}' - treating as null", values, parser.currentName());
             return null;
+        }
+    }
+
+    private void skipRemainingArray(JsonParser parser) throws IOException {
+        while (parser.currentToken() != JsonToken.END_ARRAY && parser.nextToken() != JsonToken.END_ARRAY) {
+            parser.skipChildren();
         }
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/civil/config/LenientLocalDateDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/LenientLocalDateDeserializer.java
@@ -1,19 +1,27 @@
 package uk.gov.hmcts.reform.civil.config;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
 
 @Slf4j
 public class LenientLocalDateDeserializer extends JsonDeserializer<LocalDate> {
 
     @Override
     public LocalDate deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        if (JsonToken.START_ARRAY == parser.currentToken()) {
+            return deserializeArray(parser);
+        }
+
         String raw = parser.getValueAsString();
         if (raw == null || raw.isBlank()) {
             return null;
@@ -23,6 +31,31 @@ public class LenientLocalDateDeserializer extends JsonDeserializer<LocalDate> {
             return LocalDate.parse(raw);
         } catch (DateTimeParseException exception) {
             log.warn("Unparseable LocalDate '{}' for field '{}' - treating as null", raw, parser.currentName());
+            return null;
+        }
+    }
+
+    private LocalDate deserializeArray(JsonParser parser) throws IOException {
+        List<Integer> values = new ArrayList<>();
+
+        while (parser.nextToken() != JsonToken.END_ARRAY) {
+            if (!parser.currentToken().isNumeric()) {
+                parser.skipChildren();
+                log.warn("Unparseable LocalDate array for field '{}' - treating as null", parser.currentName());
+                return null;
+            }
+            values.add(parser.getIntValue());
+        }
+
+        if (values.size() != 3) {
+            log.warn("Unparseable LocalDate array '{}' for field '{}' - treating as null", values, parser.currentName());
+            return null;
+        }
+
+        try {
+            return LocalDate.of(values.get(0), values.get(1), values.get(2));
+        } catch (DateTimeException exception) {
+            log.warn("Unparseable LocalDate array '{}' for field '{}' - treating as null", values, parser.currentName());
             return null;
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/civil/config/LenientLocalDateDeserializer.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/config/LenientLocalDateDeserializer.java
@@ -1,0 +1,29 @@
+package uk.gov.hmcts.reform.civil.config;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
+@Slf4j
+public class LenientLocalDateDeserializer extends JsonDeserializer<LocalDate> {
+
+    @Override
+    public LocalDate deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+        String raw = parser.getValueAsString();
+        if (raw == null || raw.isBlank()) {
+            return null;
+        }
+
+        try {
+            return LocalDate.parse(raw);
+        } catch (DateTimeParseException exception) {
+            log.warn("Unparseable LocalDate '{}' for field '{}' - treating as null", raw, parser.currentName());
+            return null;
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/civil/model/UnavailableDate.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/model/UnavailableDate.java
@@ -1,9 +1,11 @@
 package uk.gov.hmcts.reform.civil.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
+import uk.gov.hmcts.reform.civil.config.LenientLocalDateDeserializer;
 import uk.gov.hmcts.reform.civil.enums.dq.UnavailableDateType;
 import uk.gov.hmcts.reform.civil.validation.groups.UnavailableDateGroup;
 import uk.gov.hmcts.reform.civil.validation.interfaces.IsPresentOrEqualToOrLessThanOneYearInTheFuture;
@@ -18,10 +20,14 @@ import java.time.LocalDate;
 public class UnavailableDate {
 
     private String who;
+    @JsonDeserialize(using = LenientLocalDateDeserializer.class)
     private LocalDate date;
+    @JsonDeserialize(using = LenientLocalDateDeserializer.class)
     private LocalDate fromDate;
+    @JsonDeserialize(using = LenientLocalDateDeserializer.class)
     private LocalDate toDate;
     private UnavailableDateType unavailableDateType;
     private String eventAdded;
+    @JsonDeserialize(using = LenientLocalDateDeserializer.class)
     private LocalDate dateAdded;
 }

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/UnavailableDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/UnavailableDateTest.java
@@ -35,6 +35,48 @@ class UnavailableDateTest {
     }
 
     @Test
+    void shouldTreatBlankAndUnexpectedUnavailableDateValuesAsNull() throws Exception {
+        String json = """
+            {
+              "date": " ",
+              "fromDate": null,
+              "toDate": {"unexpected": "object"},
+              "dateAdded": "",
+              "unavailableDateType": "DATE_RANGE"
+            }
+            """;
+
+        UnavailableDate unavailableDate = objectMapper.readValue(json, UnavailableDate.class);
+
+        assertThat(unavailableDate.getDate()).isNull();
+        assertThat(unavailableDate.getFromDate()).isNull();
+        assertThat(unavailableDate.getToDate()).isNull();
+        assertThat(unavailableDate.getDateAdded()).isNull();
+        assertThat(unavailableDate.getUnavailableDateType()).isEqualTo(UnavailableDateType.DATE_RANGE);
+    }
+
+    @Test
+    void shouldTreatMalformedTimestampArrayUnavailableDatesAsNull() throws Exception {
+        String json = """
+            {
+              "date": [2026, "bad-month", 21],
+              "fromDate": [2026, 8],
+              "toDate": [2026, 13, 40],
+              "dateAdded": [2026, 8, 20, 1],
+              "unavailableDateType": "DATE_RANGE"
+            }
+            """;
+
+        UnavailableDate unavailableDate = objectMapper.readValue(json, UnavailableDate.class);
+
+        assertThat(unavailableDate.getDate()).isNull();
+        assertThat(unavailableDate.getFromDate()).isNull();
+        assertThat(unavailableDate.getToDate()).isNull();
+        assertThat(unavailableDate.getDateAdded()).isNull();
+        assertThat(unavailableDate.getUnavailableDateType()).isEqualTo(UnavailableDateType.DATE_RANGE);
+    }
+
+    @Test
     void shouldDeserializeValidIsoUnavailableDates() throws Exception {
         String json = """
             {

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/UnavailableDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/UnavailableDateTest.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.reform.civil.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import uk.gov.hmcts.reform.civil.enums.dq.UnavailableDateType;
+import uk.gov.hmcts.reform.civil.testutils.ObjectMapperFactory;
+
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UnavailableDateTest {
+
+    private final ObjectMapper objectMapper = ObjectMapperFactory.instance();
+
+    @Test
+    void shouldTreatMalformedUnavailableDatesAsNull() throws Exception {
+        String json = """
+            {
+              "date": "--28",
+              "fromDate": "bad-from-date",
+              "toDate": "2026-13-40",
+              "dateAdded": "not-a-date",
+              "unavailableDateType": "SINGLE_DATE"
+            }
+            """;
+
+        UnavailableDate unavailableDate = objectMapper.readValue(json, UnavailableDate.class);
+
+        assertThat(unavailableDate.getDate()).isNull();
+        assertThat(unavailableDate.getFromDate()).isNull();
+        assertThat(unavailableDate.getToDate()).isNull();
+        assertThat(unavailableDate.getDateAdded()).isNull();
+        assertThat(unavailableDate.getUnavailableDateType()).isEqualTo(UnavailableDateType.SINGLE_DATE);
+    }
+
+    @Test
+    void shouldDeserializeValidIsoUnavailableDates() throws Exception {
+        String json = """
+            {
+              "date": "2026-08-21",
+              "fromDate": "2026-08-22",
+              "toDate": "2026-08-23",
+              "dateAdded": "2026-08-20",
+              "unavailableDateType": "DATE_RANGE"
+            }
+            """;
+
+        UnavailableDate unavailableDate = objectMapper.readValue(json, UnavailableDate.class);
+
+        assertThat(unavailableDate.getDate()).isEqualTo(LocalDate.of(2026, 8, 21));
+        assertThat(unavailableDate.getFromDate()).isEqualTo(LocalDate.of(2026, 8, 22));
+        assertThat(unavailableDate.getToDate()).isEqualTo(LocalDate.of(2026, 8, 23));
+        assertThat(unavailableDate.getDateAdded()).isEqualTo(LocalDate.of(2026, 8, 20));
+        assertThat(unavailableDate.getUnavailableDateType()).isEqualTo(UnavailableDateType.DATE_RANGE);
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/civil/model/UnavailableDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/civil/model/UnavailableDateTest.java
@@ -54,4 +54,25 @@ class UnavailableDateTest {
         assertThat(unavailableDate.getDateAdded()).isEqualTo(LocalDate.of(2026, 8, 20));
         assertThat(unavailableDate.getUnavailableDateType()).isEqualTo(UnavailableDateType.DATE_RANGE);
     }
+
+    @Test
+    void shouldDeserializeTimestampArrayUnavailableDates() throws Exception {
+        String json = """
+            {
+              "date": [2026, 8, 21],
+              "fromDate": [2026, 8, 22],
+              "toDate": [2026, 8, 23],
+              "dateAdded": [2026, 8, 20],
+              "unavailableDateType": "DATE_RANGE"
+            }
+            """;
+
+        UnavailableDate unavailableDate = objectMapper.readValue(json, UnavailableDate.class);
+
+        assertThat(unavailableDate.getDate()).isEqualTo(LocalDate.of(2026, 8, 21));
+        assertThat(unavailableDate.getFromDate()).isEqualTo(LocalDate.of(2026, 8, 22));
+        assertThat(unavailableDate.getToDate()).isEqualTo(LocalDate.of(2026, 8, 23));
+        assertThat(unavailableDate.getDateAdded()).isEqualTo(LocalDate.of(2026, 8, 20));
+        assertThat(unavailableDate.getUnavailableDateType()).isEqualTo(UnavailableDateType.DATE_RANGE);
+    }
 }


### PR DESCRIPTION

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-5931

### Change description ###

  - Added LenientLocalDateDeserializer to parse ISO LocalDate, return null for blank/malformed values, and log a warning.
  - Applied it to UnavailableDate date fields: date, fromDate, toDate, dateAdded.
  - Added UnavailableDateTest covering malformed values like --28 and valid ISO dates.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
