### PR TITLE
Dtscci 6143 cleanupscheduler

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/BaseIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/BaseIntegrationTest.java
@@ -31,11 +31,16 @@ import uk.gov.hmcts.reform.civil.scheduler.bundlecreation.BundleCreationSchedule
 import uk.gov.hmcts.reform.civil.scheduler.casedismissed.CaseDismissedScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.casedismissed.ClaimDetailsNotificationDeadlineScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.decisionoutcome.DecisionOutcomeScheduler;
+import uk.gov.hmcts.reform.civil.scheduler.defendantresponse.DefendantResponseDeadlineScheduler;
+import uk.gov.hmcts.reform.civil.scheduler.evidenceupload.EvidenceUploadScheduler;
+import uk.gov.hmcts.reform.civil.scheduler.fulladmitpayimmediatelynopayfromdef.FullAdmitPayImmediatelyNoPaymentFromDefendantScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.gadocumentuploadnotify.GADocumentUploadNotifyScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.gaordermade.GAOrderMadeScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.gaproofofdebt.GAProofOfDebtScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.gaunlessorder.GAUnlessOrderScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.hearingcvplink.HearingCvpLinkScheduler;
+import uk.gov.hmcts.reform.civil.scheduler.hearingfee.HearingFeeScheduler;
+import uk.gov.hmcts.reform.civil.scheduler.judgementbuffer.JudgementBufferScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.managestaywatask.ManageStayWATaskScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.mediationfiletransfer.MediationFileTransferScheduler;
 import uk.gov.hmcts.reform.civil.scheduler.orderreviewobligation.OrderReviewObligationCheckScheduler;
@@ -66,14 +71,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 @ActiveProfiles("integration-test")
-@SpringBootTest(
-    classes = {Application.class, TestIdamConfiguration.class},
-    properties = {
-        "scheduler.full-admit-pay-immediately-no-payment-from-def.enabled=false",
-        "scheduler.defendantResponse.enabled=false",
-        "scheduler.hearing-fee.enabled=false",
-        "scheduler.evidence-upload.enabled=false",
-    })
+@SpringBootTest(classes = {Application.class, TestIdamConfiguration.class})
 @AutoConfigureMockMvc
 @SuppressWarnings({"java:S112", "java:S6813", "java:S1874"})
 public abstract class BaseIntegrationTest {
@@ -113,6 +111,12 @@ public abstract class BaseIntegrationTest {
     @MockBean
     private DecisionOutcomeScheduler decisionOutcomeScheduler;
     @MockBean
+    private DefendantResponseDeadlineScheduler defendantResponseDeadlineScheduler;
+    @MockBean
+    private EvidenceUploadScheduler evidenceUploadScheduler;
+    @MockBean
+    private FullAdmitPayImmediatelyNoPaymentFromDefendantScheduler fullAdmitPayImmediatelyNoPaymentFromDefendantScheduler;
+    @MockBean
     private GADocumentUploadNotifyScheduler gaDocumentUploadNotifyScheduler;
     @MockBean
     private GAOrderMadeScheduler gaOrderMadeScheduler;
@@ -122,6 +126,10 @@ public abstract class BaseIntegrationTest {
     private GAUnlessOrderScheduler gaUnlessOrderScheduler;
     @MockBean
     private HearingCvpLinkScheduler hearingCvpLinkScheduler;
+    @MockBean
+    private HearingFeeScheduler hearingFeeScheduler;
+    @MockBean
+    private JudgementBufferScheduler judgementBufferScheduler;
     @MockBean
     private ManageStayWATaskScheduler manageStayWATaskScheduler;
     @MockBean

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/DefendantResponseDeadlineSchedulerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/DefendantResponseDeadlineSchedulerIT.java
@@ -32,7 +32,6 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.DEFENDANT_RESPONSE_DE
 @ActiveProfiles("integration-test")
 @SpringBootTest(classes = {Application.class, TestIdamConfiguration.class, CoreCaseDataApiMockHelperConfiguration.class}, properties = {
     "test.id=DefendantResponseDeadlineSchedulerIT",
-    "scheduler.defendant-response.enabled=true",
     "search.defendant-response.pageSize=50",
     "scheduler.lockAtLeastFor=PT0S"
 })

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/EvidenceUploadSchedulerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/EvidenceUploadSchedulerIT.java
@@ -35,7 +35,6 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.EVIDENCE_UPLOAD_CHECK
 @ActiveProfiles("integration-test")
 @SpringBootTest(classes = {Application.class, TestIdamConfiguration.class, CoreCaseDataApiMockHelperConfiguration.class}, properties = {
     "test.id=EvidenceUploadSchedulerIT",
-    "scheduler.evidence-upload.enabled=true",
     "search.evidence-upload.pageSize=50",
     "scheduler.lockAtLeastFor=PT0S"
 })

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/FullAdmitPayImmediatelyNoPaymentFromDefendantSchedulerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/FullAdmitPayImmediatelyNoPaymentFromDefendantSchedulerIT.java
@@ -38,7 +38,6 @@ import org.springframework.test.context.ActiveProfiles;
     CoreCaseDataApiMockHelperConfiguration.class
 }, properties = {
     "test.id=FullAdmitPayImmediatelyNoPaymentFromDefendantSchedulerIT",
-    "scheduler.full-admit-pay-immediately-no-payment-from-def.enabled=true",
     "search.full-admit-pay-immediately-no-payment-from-def.pageSize=50",
     "scheduler.lockAtLeastFor=PT0S"
 })

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/HearingFeeSchedulerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/HearingFeeSchedulerIT.java
@@ -35,7 +35,6 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.NO_HEARING_FEE_DUE;
 @ActiveProfiles("integration-test")
 @SpringBootTest(classes = {Application.class, TestIdamConfiguration.class, CoreCaseDataApiMockHelperConfiguration.class}, properties = {
     "test.id=HearingFeeSchedulerIT",
-    "scheduler.hearing-fee.enabled=true",
     "search.hearing-fee.pageSize=50",
     "scheduler.lockAtLeastFor=PT0S"
 })

--- a/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/civil/scheduler/JudgementBufferSchedulerIT.java
@@ -32,7 +32,6 @@ import static uk.gov.hmcts.reform.civil.callback.CaseEvent.DEFAULT_JUDGEMENT_GRA
 @ActiveProfiles("integration-test")
 @SpringBootTest(classes = {Application.class, TestIdamConfiguration.class, CoreCaseDataApiMockHelperConfiguration.class}, properties = {
     "test.id=JudgementBufferSchedulerIT",
-    "scheduler.judgement-buffer.enabled=true",
     "search.judgement-buffer.pageSize=50",
     "scheduler.lockAtLeastFor=PT0S"
 })

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/defendantresponse/DefendantResponseDeadlineScheduler.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.civil.scheduler.defendantresponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -14,7 +13,6 @@ import uk.gov.hmcts.reform.civil.service.search.defendantresponse.DefendantRespo
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@ConditionalOnProperty(prefix = "scheduler.defendant-response", name = "enabled", havingValue = "true")
 public class DefendantResponseDeadlineScheduler implements CivilScheduler {
 
     public static final String SCHEDULER_NAME = "DefendantResponseDeadline";

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/evidenceupload/EvidenceUploadScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/evidenceupload/EvidenceUploadScheduler.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.civil.scheduler.evidenceupload;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -14,7 +13,6 @@ import uk.gov.hmcts.reform.civil.service.search.evidenceupload.EvidenceUploadNot
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@ConditionalOnProperty(prefix = "scheduler.evidence-upload", name = "enabled", havingValue = "true")
 public class EvidenceUploadScheduler implements CivilScheduler {
 
     public static final String SCHEDULER_NAME = "EvidenceUpload";

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/fulladmitpayimmediatelynopayfromdef/FullAdmitPayImmediatelyNoPaymentFromDefendantScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/fulladmitpayimmediatelynopayfromdef/FullAdmitPayImmediatelyNoPaymentFromDefendantScheduler.java
@@ -8,14 +8,12 @@ import uk.gov.hmcts.reform.civil.service.search.fulladmitpayimmediatelynopayfrom
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@ConditionalOnProperty(prefix = "scheduler.full-admit-pay-immediately-no-payment-from-def", name = "enabled", havingValue = "true")
 public class FullAdmitPayImmediatelyNoPaymentFromDefendantScheduler implements CivilScheduler {
 
     public static final String SCHEDULER_NAME = "FullAdmitPayImmediatelyNoPaymentFromDefendant";

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/hearingfee/HearingFeeScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/hearingfee/HearingFeeScheduler.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.civil.scheduler.hearingfee;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -14,7 +13,6 @@ import uk.gov.hmcts.reform.civil.service.search.hearingfee.HearingFeeDuePaginate
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@ConditionalOnProperty(prefix = "scheduler.hearing-fee", name = "enabled", havingValue = "true")
 public class HearingFeeScheduler implements CivilScheduler {
 
     public static final String SCHEDULER_NAME = "HearingFee";

--- a/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/scheduler/judgementbuffer/JudgementBufferScheduler.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.civil.scheduler.judgementbuffer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.ccd.client.model.CaseDetails;
@@ -15,7 +14,6 @@ import uk.gov.hmcts.reform.civil.service.search.judgementbuffer.JudgementBufferE
 @Component
 @RequiredArgsConstructor
 @Slf4j
-@ConditionalOnProperty(prefix = "scheduler.judgement-buffer", name = "enabled", havingValue = "true")
 public class JudgementBufferScheduler implements CivilScheduler {
 
     public static final String SCHEDULER_NAME = "JudgementBuffer";

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -80,21 +80,16 @@ scheduler:
   defaultLockAtMostFor: ${DEFAULT_LOCK_AT_MOST_FOR:PT30M}
   judgement-buffer:
     cronExpression: ${CRON_EXPRESSION_JUDGEMENT_BUFFER:0 0 2 * * *}
-    enabled: ${SCHEDULER_ENABLED_JUDGEMENT_BUFFER:false}
   defendant-response:
     cronExpression: ${CRON_EXPRESSION_DEFENDANT_RESPONSE:0 1 16 * * ?}
-    enabled: ${SCHEDULER_ENABLED_DEFENDANT_RESPONSE:false}
   settlement-no-response-from-defendant-check:
     cronExpression: ${CRON_EXPRESSION_SETTLEMENT_NO_RESPONSE_FROM_DEFENDANT_CHECK:0 0 1 * * ?}
   full-admit-pay-immediately-no-payment-from-def:
     cronExpression: ${CRON_EXPRESSION_FULL_ADMIT_PAY_IMMEDIATELY_NO_PAYMENT_FROM_DEF:0 0 0 * * ?}
-    enabled: ${SCHEDULER_ENABLED_FULL_ADMIT_PAY_IMMEDIATELY_NO_PAYMENT_FROM_DEF:false}
   hearing-fee:
     cronExpression: ${CRON_EXPRESSION_HEARING_FEE:0 0 0 * * ?}
-    enabled: ${SCHEDULER_ENABLED_HEARING_FEE:false}
   evidence-upload:
     cronExpression: ${CRON_EXPRESSION_EVIDENCE_UPLOAD:0 30 17 * * ?}
-    enabled: ${SCHEDULER_ENABLED_EVIDENCE_UPLOAD:false}
   bundle-creation:
     cronExpression: ${CRON_EXPRESSION_BUNDLE_CREATION:0 0 21 * * ?}
   hearing-cvp-link:


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6143

### Change description ###

 Removed @ConditionalOnProperty from schedulers and standardise integration testing

  Schedulers are now always managed by the Spring context, with execution
  controlled by the feature toggle check in ScheduledTaskRunner.

  - Removed @ConditionalOnProperty from DefendantResponseDeadlineScheduler,
    EvidenceUploadScheduler, FullAdmitPayImmediatelyNoPaymentFromDefendantScheduler,
    HearingFeeScheduler and JudgementBufferScheduler
  - Removed the corresponding scheduler.*.enabled settings from application.yaml
    scheduler enabled properties from its @SpringBootTest configuration
  - Removed the scheduler enabled properties from the five scheduler ITs


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
