### PR TITLE
DTSCCI-6197 Fix PACT Consumer Test payment_creditAccountPayment can't be verified by payments api

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/PaymentsApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/PaymentsApiConsumerTest.java
@@ -58,8 +58,11 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
     private static final Organisation ORGANISATION = new Organisation()
         .setName("test org")
         .setContactInformation(List.of(new ContactInformation()));
-    private static final String PAYMENT_REFERENCE = "RC-1700000000000001";
+    private static final String PAYMENT_REFERENCE = "RC-1519-9028-2432-0001";
+    private static final String PAYMENT_REFERENCE_PATH = "${paymentReference}";
+    private static final String PAYMENT_REFERENCE_REGEX = "^RC-\\d{4}-\\d{4}-\\d{4}-\\d{4}$";
     private static final String SERVICE_REQUEST_REFERENCE = "2026-1700000000000001";
+    private static final String SERVICE_REQUEST_REFERENCE_PATH = "${serviceRequestReference}";
     private static final String RETURN_URL = "https://civil-service/return";
     private static final String CALLBACK_URL = "https://civil-service/callback";
     protected static final String ACCOUNT_NUMBER = "PBA0077597";
@@ -110,8 +113,12 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact retrieveCardPayment(PactDslWithProvider builder) {
         return builder
+            .given("A card payment exists", Map.of("paymentReference", PAYMENT_REFERENCE))
             .uponReceiving("a request to retrieve a card payment")
-            .path("/card-payments/" + PAYMENT_REFERENCE)
+            .pathFromProviderState(
+                "/card-payments/" + PAYMENT_REFERENCE_PATH,
+                "/card-payments/" + PAYMENT_REFERENCE
+            )
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
             .method(HttpMethod.GET.toString())
             .willRespondWith()
@@ -124,8 +131,12 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact retrieveCardPaymentStatus(PactDslWithProvider builder) {
         return builder
+            .given("A card payment exists", Map.of("paymentReference", PAYMENT_REFERENCE))
             .uponReceiving("a request to retrieve a card payment status")
-            .path("/card-payments/" + PAYMENT_REFERENCE + "/statuses")
+            .pathFromProviderState(
+                "/card-payments/" + PAYMENT_REFERENCE_PATH + "/statuses",
+                "/card-payments/" + PAYMENT_REFERENCE + "/statuses"
+            )
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
             .method(HttpMethod.GET.toString())
             .willRespondWith()
@@ -145,7 +156,7 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
             .body(createJsonObject(buildCreateServiceRequest()))
             .willRespondWith()
             .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(newJsonBody(root -> root.stringValue("service_request_reference", SERVICE_REQUEST_REFERENCE)).build())
+            .body(newJsonBody(root -> root.stringType("service_request_reference", SERVICE_REQUEST_REFERENCE)).build())
             .status(HttpStatus.SC_CREATED)
             .toPact();
     }
@@ -153,17 +164,21 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact createPbaPayment(PactDslWithProvider builder) throws IOException {
         return builder
+            .given("A service request exists", Map.of("serviceRequestReference", SERVICE_REQUEST_REFERENCE))
             .uponReceiving("a request to create a PBA payment for a service request")
-            .path("/service-request/" + SERVICE_REQUEST_REFERENCE + "/pba-payments")
+            .pathFromProviderState(
+                "/service-request/" + SERVICE_REQUEST_REFERENCE_PATH + "/pba-payments",
+                "/service-request/" + SERVICE_REQUEST_REFERENCE + "/pba-payments"
+            )
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
             .method(HttpMethod.POST.toString())
             .body(createJsonObject(buildPbaServiceRequest()))
             .willRespondWith()
             .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .body(newJsonBody(root -> root
-                .stringValue("payment_reference", PAYMENT_REFERENCE)
-                .stringValue("status", "Success")
-                .stringValue("date_created", "2026-08-14T10:15:30.000Z")).build())
+                .stringMatcher("payment_reference", PAYMENT_REFERENCE_REGEX, PAYMENT_REFERENCE)
+                .stringType("status", "Success")
+                .stringType("date_created", "2026-08-14T10:15:30.000Z")).build())
             .status(HttpStatus.SC_CREATED)
             .toPact();
     }
@@ -171,19 +186,23 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact createGovPayCardPaymentRequest(PactDslWithProvider builder) throws IOException {
         return builder
+            .given("A service request exists", Map.of("serviceRequestReference", SERVICE_REQUEST_REFERENCE))
             .uponReceiving("a request to create a service request card payment")
-            .path("/service-request/" + SERVICE_REQUEST_REFERENCE + "/card-payments")
+            .pathFromProviderState(
+                "/service-request/" + SERVICE_REQUEST_REFERENCE_PATH + "/card-payments",
+                "/service-request/" + SERVICE_REQUEST_REFERENCE + "/card-payments"
+            )
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
             .method(HttpMethod.POST.toString())
             .body(createJsonObject(buildCardPaymentServiceRequest()))
             .willRespondWith()
             .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .body(newJsonBody(root -> root
-                .stringValue("external_reference", "external-reference")
-                .stringValue("payment_reference", PAYMENT_REFERENCE)
-                .stringValue("status", "Initiated")
-                .stringValue("next_url", "https://payments/next")
-                .stringValue("date_created", "2026-08-14T10:15:30Z")).build())
+                .stringType("external_reference", "external-reference")
+                .stringMatcher("payment_reference", PAYMENT_REFERENCE_REGEX, PAYMENT_REFERENCE)
+                .stringType("status", "Initiated")
+                .stringType("next_url", "https://payments/next")
+                .stringType("date_created", "2026-08-14T10:15:30Z")).build())
             .status(HttpStatus.SC_CREATED)
             .toPact();
     }
@@ -296,8 +315,7 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
 
     static DslPart getDslPart(String status, String paymentStatus, String errorCode, String errorMessage) {
         return newJsonBody((o) -> {
-            o.stringType("reference", "reference")
-                .stringValue("payment_reference", PAYMENT_REFERENCE)
+            o.stringMatcher("reference", PAYMENT_REFERENCE_REGEX, PAYMENT_REFERENCE)
                 .stringType("status", status)
                 .minArrayLike("status_histories", 1, 1,
                     (sh) -> {
@@ -319,8 +337,8 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
 
     private DslPart buildPaymentResponseDsl(String status) {
         return newJsonBody(root -> root
-            .stringValue("reference", "reference")
-            .stringValue("payment_reference", PAYMENT_REFERENCE)
+            .stringType("reference", "reference")
+            .stringMatcher("payment_reference", PAYMENT_REFERENCE_REGEX, PAYMENT_REFERENCE)
             .stringValue("status", status)
             .stringValue("currency", "GBP")
             .numberValue("amount", 100.00)).build();

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/PaymentsApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/PaymentsApiConsumerTest.java
@@ -24,18 +24,9 @@ import uk.gov.hmcts.reform.civil.prd.model.Organisation;
 import uk.gov.hmcts.reform.civil.sampledata.CaseDataBuilder;
 import uk.gov.hmcts.reform.civil.service.OrganisationService;
 import uk.gov.hmcts.reform.civil.service.PaymentsService;
-import uk.gov.hmcts.reform.payments.client.PaymentsClient;
 import uk.gov.hmcts.reform.payments.client.models.PaymentDto;
-import uk.gov.hmcts.reform.payments.request.CardPaymentRequest;
-import uk.gov.hmcts.reform.payments.request.CardPaymentServiceRequestDTO;
-import uk.gov.hmcts.reform.payments.request.CreateServiceRequestDTO;
-import uk.gov.hmcts.reform.payments.request.PBAServiceRequestDTO;
-import uk.gov.hmcts.reform.payments.response.CardPaymentServiceRequestResponse;
-import uk.gov.hmcts.reform.payments.response.PBAServiceRequestResponse;
-import uk.gov.hmcts.reform.payments.response.PaymentServiceResponse;
 
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,19 +50,11 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
         .setName("test org")
         .setContactInformation(List.of(new ContactInformation()));
     private static final String PAYMENT_REFERENCE = "RC-1519-9028-2432-0001";
-    private static final String PAYMENT_REFERENCE_PATH = "${paymentReference}";
     private static final String PAYMENT_REFERENCE_REGEX = "^RC-\\d{4}-\\d{4}-\\d{4}-\\d{4}$";
-    private static final String SERVICE_REQUEST_REFERENCE = "2026-1700000000000001";
-    private static final String SERVICE_REQUEST_REFERENCE_PATH = "${serviceRequestReference}";
-    private static final String RETURN_URL = "https://civil-service/return";
-    private static final String CALLBACK_URL = "https://civil-service/callback";
     protected static final String ACCOUNT_NUMBER = "PBA0077597";
 
     @Autowired
     private PaymentsService paymentsService;
-
-    @Autowired
-    private PaymentsClient paymentsClient;
 
     @MockBean
     AuthTokenGenerator authTokenGenerator;
@@ -90,123 +73,6 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
         return buildCardPaymentRequestPact(builder);
     }
 
-    @Pact(consumer = "civil_service")
-    public RequestResponsePact createCardPayment(PactDslWithProvider builder) throws IOException {
-        return builder
-            .uponReceiving("a request to create a card payment")
-            .path("/card-payments")
-            .headers(
-                AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN,
-                SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN,
-                "return-url", RETURN_URL,
-                "service-callback-url", CALLBACK_URL
-            )
-            .method(HttpMethod.POST.toString())
-            .body(createJsonObject(buildCardPaymentRequest()))
-            .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(buildPaymentResponseDsl("Initiated"))
-            .status(HttpStatus.SC_CREATED)
-            .toPact();
-    }
-
-    @Pact(consumer = "civil_service")
-    public RequestResponsePact retrieveCardPayment(PactDslWithProvider builder) {
-        return builder
-            .given("A card payment exists", Map.of("paymentReference", PAYMENT_REFERENCE))
-            .uponReceiving("a request to retrieve a card payment")
-            .pathFromProviderState(
-                "/card-payments/" + PAYMENT_REFERENCE_PATH,
-                "/card-payments/" + PAYMENT_REFERENCE
-            )
-            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
-            .method(HttpMethod.GET.toString())
-            .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(buildPaymentResponseDsl("Success"))
-            .status(HttpStatus.SC_OK)
-            .toPact();
-    }
-
-    @Pact(consumer = "civil_service")
-    public RequestResponsePact retrieveCardPaymentStatus(PactDslWithProvider builder) {
-        return builder
-            .given("A card payment exists", Map.of("paymentReference", PAYMENT_REFERENCE))
-            .uponReceiving("a request to retrieve a card payment status")
-            .pathFromProviderState(
-                "/card-payments/" + PAYMENT_REFERENCE_PATH + "/statuses",
-                "/card-payments/" + PAYMENT_REFERENCE + "/statuses"
-            )
-            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
-            .method(HttpMethod.GET.toString())
-            .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(buildPaymentResponseDsl("Success"))
-            .status(HttpStatus.SC_OK)
-            .toPact();
-    }
-
-    @Pact(consumer = "civil_service")
-    public RequestResponsePact createServiceRequest(PactDslWithProvider builder) throws IOException {
-        return builder
-            .uponReceiving("a request to create a payments service request")
-            .path("/service-request")
-            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
-            .method(HttpMethod.POST.toString())
-            .body(createJsonObject(buildCreateServiceRequest()))
-            .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(newJsonBody(root -> root.stringType("service_request_reference", SERVICE_REQUEST_REFERENCE)).build())
-            .status(HttpStatus.SC_CREATED)
-            .toPact();
-    }
-
-    @Pact(consumer = "civil_service")
-    public RequestResponsePact createPbaPayment(PactDslWithProvider builder) throws IOException {
-        return builder
-            .given("A service request exists", Map.of("serviceRequestReference", SERVICE_REQUEST_REFERENCE))
-            .uponReceiving("a request to create a PBA payment for a service request")
-            .pathFromProviderState(
-                "/service-request/" + SERVICE_REQUEST_REFERENCE_PATH + "/pba-payments",
-                "/service-request/" + SERVICE_REQUEST_REFERENCE + "/pba-payments"
-            )
-            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
-            .method(HttpMethod.POST.toString())
-            .body(createJsonObject(buildPbaServiceRequest()))
-            .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(newJsonBody(root -> root
-                .stringMatcher("payment_reference", PAYMENT_REFERENCE_REGEX, PAYMENT_REFERENCE)
-                .stringType("status", "Success")
-                .stringType("date_created", "2026-08-14T10:15:30.000Z")).build())
-            .status(HttpStatus.SC_CREATED)
-            .toPact();
-    }
-
-    @Pact(consumer = "civil_service")
-    public RequestResponsePact createGovPayCardPaymentRequest(PactDslWithProvider builder) throws IOException {
-        return builder
-            .given("A service request exists", Map.of("serviceRequestReference", SERVICE_REQUEST_REFERENCE))
-            .uponReceiving("a request to create a service request card payment")
-            .pathFromProviderState(
-                "/service-request/" + SERVICE_REQUEST_REFERENCE_PATH + "/card-payments",
-                "/service-request/" + SERVICE_REQUEST_REFERENCE + "/card-payments"
-            )
-            .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
-            .method(HttpMethod.POST.toString())
-            .body(createJsonObject(buildCardPaymentServiceRequest()))
-            .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(newJsonBody(root -> root
-                .stringType("external_reference", "external-reference")
-                .stringMatcher("payment_reference", PAYMENT_REFERENCE_REGEX, PAYMENT_REFERENCE)
-                .stringType("status", "Initiated")
-                .stringType("next_url", "https://payments/next")
-                .stringType("date_created", "2026-08-14T10:15:30Z")).build())
-            .status(HttpStatus.SC_CREATED)
-            .toPact();
-    }
-
     @BeforeEach
     void setUp() {
         when(paymentsConfiguration.getService()).thenReturn(SERVICE);
@@ -222,70 +88,6 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
         PaymentDto response = paymentsService.createCreditAccountPayment(caseData, AUTHORIZATION_TOKEN);
         assertThat(response.getStatus(), is("Success"));
 
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "createCardPayment")
-    public void verifyCreateCardPayment() {
-        PaymentDto response = paymentsClient.createCardPayment(
-            AUTHORIZATION_TOKEN,
-            buildCardPaymentRequest(),
-            RETURN_URL,
-            CALLBACK_URL
-        );
-
-        assertThat(response.getStatus(), is("Initiated"));
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "retrieveCardPayment")
-    public void verifyRetrieveCardPayment() {
-        PaymentDto response = paymentsClient.retrieveCardPayment(AUTHORIZATION_TOKEN, PAYMENT_REFERENCE);
-
-        assertThat(response.getPaymentReference(), is(PAYMENT_REFERENCE));
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "retrieveCardPaymentStatus")
-    public void verifyRetrieveCardPaymentStatus() {
-        PaymentDto response = paymentsClient.getGovPayCardPaymentStatus(PAYMENT_REFERENCE, AUTHORIZATION_TOKEN);
-
-        assertThat(response.getStatus(), is("Success"));
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "createServiceRequest")
-    public void verifyCreateServiceRequest() {
-        PaymentServiceResponse response = paymentsClient.createServiceRequest(
-            AUTHORIZATION_TOKEN,
-            buildCreateServiceRequest()
-        );
-
-        assertThat(response.getServiceRequestReference(), is(SERVICE_REQUEST_REFERENCE));
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "createPbaPayment")
-    public void verifyCreatePbaPayment() {
-        PBAServiceRequestResponse response = paymentsClient.createPbaPayment(
-            SERVICE_REQUEST_REFERENCE,
-            AUTHORIZATION_TOKEN,
-            buildPbaServiceRequest()
-        );
-
-        assertThat(response.getPaymentReference(), is(PAYMENT_REFERENCE));
-    }
-
-    @Test
-    @PactTestFor(pactMethod = "createGovPayCardPaymentRequest")
-    public void verifyCreateGovPayCardPaymentRequest() {
-        CardPaymentServiceRequestResponse response = paymentsClient.createGovPayCardPaymentRequest(
-            SERVICE_REQUEST_REFERENCE,
-            AUTHORIZATION_TOKEN,
-            buildCardPaymentServiceRequest()
-        );
-
-        assertThat(response.getPaymentReference(), is(PAYMENT_REFERENCE));
     }
 
     private RequestResponsePact buildCardPaymentRequestPact(PactDslWithProvider builder) throws IOException {
@@ -335,62 +137,4 @@ public class PaymentsApiConsumerTest extends BaseContractTest {
         }).build();
     }
 
-    private DslPart buildPaymentResponseDsl(String status) {
-        return newJsonBody(root -> root
-            .stringType("reference", "reference")
-            .stringMatcher("payment_reference", PAYMENT_REFERENCE_REGEX, PAYMENT_REFERENCE)
-            .stringValue("status", status)
-            .stringValue("currency", "GBP")
-            .numberValue("amount", 100.00)).build();
-    }
-
-    private CardPaymentRequest buildCardPaymentRequest() {
-        return CardPaymentRequest.builder()
-            .amount(new BigDecimal("100.00"))
-            .caseReference("000MC001")
-            .ccdCaseNumber("1712345678901234")
-            .channel("online")
-            .description("Claim issue payment")
-            .provider("govpay")
-            .caseType("CIVIL")
-            .fees(new uk.gov.hmcts.reform.payments.client.models.FeeDto[] {buildFee()})
-            .build();
-    }
-
-    private CreateServiceRequestDTO buildCreateServiceRequest() {
-        return CreateServiceRequestDTO.builder()
-            .callBackUrl(CALLBACK_URL)
-            .caseReference("000MC001")
-            .ccdCaseNumber("1712345678901234")
-            .hmctsOrgId(SITE_ID)
-            .fees(new uk.gov.hmcts.reform.payments.client.models.FeeDto[] {buildFee()})
-            .build();
-    }
-
-    private PBAServiceRequestDTO buildPbaServiceRequest() {
-        return PBAServiceRequestDTO.builder()
-            .accountNumber(ACCOUNT_NUMBER)
-            .amount(new BigDecimal("100.00"))
-            .customerReference("customer-reference")
-            .idempotencyKey("idempotency-key")
-            .organisationName("test org")
-            .build();
-    }
-
-    private CardPaymentServiceRequestDTO buildCardPaymentServiceRequest() {
-        return CardPaymentServiceRequestDTO.builder()
-            .amount(new BigDecimal("100.00"))
-            .language("en")
-            .returnUrl(RETURN_URL)
-            .build();
-    }
-
-    private uk.gov.hmcts.reform.payments.client.models.FeeDto buildFee() {
-        return uk.gov.hmcts.reform.payments.client.models.FeeDto.builder()
-            .calculatedAmount(new BigDecimal("100.00"))
-            .code("FEE0204")
-            .version("1")
-            .volume(1)
-            .build();
-    }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6197

### Change description ###

 Fixes DTSCCI-6197 / PAY-9008.

The payment_creditAccountPayment consumer pact had drifted beyond the credit-account payment contract and was publishing unrelated service-request/card-payment interactions. This caused the Payments provider verification to fail and required a temporary provider-side shim in ccpay-payment-app#2113.

  Changes made:

  - Trimmed payment_creditAccountPayment back to the credit-account payment interaction only:
  - POST /credit-account-payments

  - Removed the extra service-request/card-payment interactions from this pact:
      - POST /service-request
      - POST /service-request/{service-request-reference}/pba-payments
      - POST /service-request/{service-request-reference}/card-payments
      - POST /card-payments
      - GET /card-payments/{payment-reference}
      - GET /card-payments/{payment-reference}/statuses

  - Replaced the old compact RC-1700000000000001 example with Payments-style RC-1519-9028-2432-0001.
  - Removed payment_reference from the /credit-account-payments response contract.
  - Matched the provider response shape where Payments returns the generated RC reference in reference.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
