### PR TITLE
DTSCCI-6212 Fixes to consumer Pacts for provider verification

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CaseDocumentAmApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CaseDocumentAmApiConsumerTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 import static uk.gov.hmcts.reform.civil.documentmanagement.model.DocumentType.SEALED_CLAIM;
 
-@PactTestFor(providerName = "ccd_case_document_am_api")
+@PactTestFor(providerName = "case-document-am-api")
 @MockServerConfig(hostInterface = "localhost", port = "6680")
 @TestPropertySource(properties = {
     "case_document_am.url=http://localhost:6680",
@@ -43,7 +43,7 @@ import static uk.gov.hmcts.reform.civil.documentmanagement.model.DocumentType.SE
 })
 public class CaseDocumentAmApiConsumerTest extends BaseContractTest {
 
-    private static final String DOCUMENT_ID = "24828900-4706-4f88-9fa4-0d8a4e047dc2";
+    private static final String DOCUMENT_ID = "6c3c3906-2b51-468e-8cbb-a4002eded076";
     private static final String FILE_NAME = "0000-claim.pdf";
     private static final byte[] FILE_CONTENT = "test document content".getBytes(StandardCharsets.UTF_8);
     private static final String DOCUMENT_SELF_URL = "http://localhost:6680/cases/documents/" + DOCUMENT_ID;
@@ -84,6 +84,7 @@ public class CaseDocumentAmApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact downloadDocumentBinary(PactDslWithProvider builder) {
         return builder
+            .given("I have existing document")
             .uponReceiving("a case document binary download request")
             .path("/cases/documents/" + DOCUMENT_ID + "/binary")
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)
@@ -97,6 +98,7 @@ public class CaseDocumentAmApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact deleteDocument(PactDslWithProvider builder) {
         return builder
+            .given("I have existing document")
             .uponReceiving("a permanent case document delete request")
             .path("/cases/documents/" + DOCUMENT_ID)
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN, SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN)

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CommonRefDataApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/CommonRefDataApiConsumerTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
-@PactTestFor(providerName = "rd_commondata_api")
+@PactTestFor(providerName = "referenceData_commondata")
 @MockServerConfig(hostInterface = "localhost", port = "6682")
 @TestPropertySource(properties = "rd_commondata.api.url=http://localhost:6682")
 public class CommonRefDataApiConsumerTest extends BaseContractTest {
@@ -47,6 +47,7 @@ public class CommonRefDataApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact getListOfValuesCategory(PactDslWithProvider builder) {
         return builder
+            .given("ListOfCategories Details Exist")
             .uponReceiving("a common ref data list of values category request")
             .path("/refdata/commondata/lov/categories/" + CATEGORY_ID)
             .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN, AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
@@ -77,8 +78,7 @@ public class CommonRefDataApiConsumerTest extends BaseContractTest {
             .stringValue("key", "INTER")
             .numberValue("lov_order", 1)
             .stringValue("value_en", "In person")
-            .stringValue("value_cy", "Wyneb yn wyneb")
-            .minArrayLike("child_nodes", 0, 0, child -> {
-            }))).build();
+            .nullValue("value_cy")
+            .nullValue("child_nodes"))).build();
     }
 }

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/IdamApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/IdamApiConsumerTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-@PactTestFor(providerName = "Idam_api")
 @MockServerConfig(hostInterface = "localhost", port = "6678")
 @TestPropertySource(properties = {
     "idam.api.url=http://localhost:6678",
@@ -35,6 +34,8 @@ import static org.hamcrest.Matchers.is;
 })
 public class IdamApiConsumerTest extends BaseContractTest {
 
+    private static final String IDAM_OIDC_PROVIDER = "idamApi_oidc";
+    private static final String IDAM_USERS_PROVIDER = "idamApi_users";
     private static final String USER_ID = "24828900-4706-4f88-9fa4-0d8a4e047dc2";
     private static final String USER_EMAIL = "civil-system-user@example.com";
     private static final String USER_FORENAME = "Civil";
@@ -53,9 +54,10 @@ public class IdamApiConsumerTest extends BaseContractTest {
     @Autowired
     private IdamClient idamClient;
 
-    @Pact(consumer = "civil_service")
+    @Pact(consumer = "civil_service", provider = IDAM_OIDC_PROVIDER)
     public RequestResponsePact generateOpenIdToken(PactDslWithProvider builder) {
         return builder
+            .given("a token is requested")
             .uponReceiving("a password grant token request")
             .path("/o/token")
             .method(HttpMethod.POST.toString())
@@ -69,9 +71,10 @@ public class IdamApiConsumerTest extends BaseContractTest {
             .toPact();
     }
 
-    @Pact(consumer = "civil_service")
+    @Pact(consumer = "civil_service", provider = IDAM_OIDC_PROVIDER)
     public RequestResponsePact retrieveUserInfo(PactDslWithProvider builder) {
         return builder
+            .given("userinfo is requested")
             .uponReceiving("a userinfo request")
             .path("/o/userinfo")
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
@@ -83,9 +86,10 @@ public class IdamApiConsumerTest extends BaseContractTest {
             .toPact();
     }
 
-    @Pact(consumer = "civil_service")
+    @Pact(consumer = "civil_service", provider = IDAM_USERS_PROVIDER)
     public RequestResponsePact retrieveUserDetails(PactDslWithProvider builder) {
         return builder
+            .given("a valid user exists")
             .uponReceiving("a tactical user details request")
             .path("/details")
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
@@ -98,7 +102,7 @@ public class IdamApiConsumerTest extends BaseContractTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "generateOpenIdToken")
+    @PactTestFor(providerName = IDAM_OIDC_PROVIDER, pactMethod = "generateOpenIdToken")
     public void verifyGenerateOpenIdToken() {
         String accessToken = idamClient.getAccessToken(USER_EMAIL, PASSWORD);
 
@@ -106,7 +110,7 @@ public class IdamApiConsumerTest extends BaseContractTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "retrieveUserInfo")
+    @PactTestFor(providerName = IDAM_OIDC_PROVIDER, pactMethod = "retrieveUserInfo")
     public void verifyRetrieveUserInfo() {
         UserInfo response = idamClient.getUserInfo(AUTHORIZATION_TOKEN);
 
@@ -115,7 +119,7 @@ public class IdamApiConsumerTest extends BaseContractTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "retrieveUserDetails")
+    @PactTestFor(providerName = IDAM_USERS_PROVIDER, pactMethod = "retrieveUserDetails")
     public void verifyRetrieveUserDetails() {
         UserDetails response = idamClient.getUserDetails(AUTHORIZATION_TOKEN);
 
@@ -139,9 +143,6 @@ public class IdamApiConsumerTest extends BaseContractTest {
         return LambdaDsl.newJsonBody(root -> root
             .stringType("sub", USER_EMAIL)
             .stringType("uid", USER_ID)
-            .stringType("name", "Civil Service")
-            .stringType("given_name", USER_FORENAME)
-            .stringType("family_name", USER_SURNAME)
             .array("roles", roles -> roles.stringType("caseworker-civil"))
         ).build();
     }

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/JudicialRefDataApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/JudicialRefDataApiConsumerTest.java
@@ -27,7 +27,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.when;
 
-@PactTestFor(providerName = "judicial_ref_data")
+@PactTestFor(providerName = "referenceData_judicialv2")
 @MockServerConfig(hostInterface = "localhost", port = "6683")
 @TestPropertySource(properties = {
     "genApp.jrd.url=http://localhost:6683",
@@ -35,8 +35,9 @@ import static org.mockito.Mockito.when;
 })
 public class JudicialRefDataApiConsumerTest extends BaseContractTest {
 
+    private static final String JRD_V2_MEDIA_TYPE = "application/vnd.jrd.api+json;Version=2.0";
     private static final String SEARCH_STRING = "Smith";
-    private static final String PERSONAL_CODE = "1234567";
+    private static final String PERSONAL_CODE = "1234";
 
     @Autowired
     private JudicialRefDataService judicialRefDataService;
@@ -52,6 +53,7 @@ public class JudicialRefDataApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact searchJudicialUsers(PactDslWithProvider builder) {
         return builder
+            .given("return judicial user profiles")
             .uponReceiving("a judicial ref data user search request")
             .path("/refdata/judicial/users/search")
             .headers(
@@ -68,7 +70,11 @@ public class JudicialRefDataApiConsumerTest extends BaseContractTest {
                 }
                 """.formatted(SEARCH_STRING))
             .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .matchHeader(
+                HttpHeaders.CONTENT_TYPE,
+                "application/(json|vnd\\.jrd\\.api\\+json;Version=2\\.0)(;.*)?",
+                JRD_V2_MEDIA_TYPE
+            )
             .body(buildJudicialUsersResponse())
             .status(HttpStatus.SC_OK)
             .toPact();
@@ -85,15 +91,14 @@ public class JudicialRefDataApiConsumerTest extends BaseContractTest {
 
     private DslPart buildJudicialUsersResponse() {
         return newJsonArray(root -> root.object(judge -> judge
-            .stringValue("post_nominals", "DJ")
-            .stringValue("known_as", "Jane")
-            .stringValue("surname", "Smith")
-            .stringValue("full_name", "District Judge Jane Smith")
-            .stringValue("ejudiciary_email", "jane.smith@judiciary.uk")
-            .stringValue("sidam_id", "11111111-1111-1111-1111-111111111111")
-            .stringValue("personal_code", PERSONAL_CODE)
-            .stringValue("is_judge", "Y")
-            .stringValue("is_panel_member", "N")
-            .stringValue("is_magistrate", "N"))).build();
+            .stringType("title", "Family Judge")
+            .stringType("knownAs", "testKnownAs")
+            .stringType("surname", "surname")
+            .stringType("fullName", "testFullName")
+            .stringType("emailId", "test@test.com")
+            .stringType("idamId", "44362987-3fe4-43b3-b59e-91c46b6b1fd4")
+            .stringType("personalCode", PERSONAL_CODE)
+            .stringType("postNominals", "testPostNominals")
+            .stringType("initials", "I N"))).build();
     }
 }

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/RoleAssignmentsApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/RoleAssignmentsApiConsumerTest.java
@@ -35,13 +35,22 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Mockito.when;
 
-@PactTestFor(providerName = "am_role_assignment_service")
 @MockServerConfig(hostInterface = "localhost", port = "6681")
 @TestPropertySource(properties = "role-assignment-service.api.url=http://localhost:6681")
 public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
 
+    private static final String ROLE_ASSIGNMENT_CREATE_PROVIDER = "am_roleAssignment_createAssignment";
+    private static final String ROLE_ASSIGNMENT_GET_PROVIDER = "am_roleAssignment_getAssignment";
+    private static final String ROLE_ASSIGNMENT_QUERY_PROVIDER = "am_roleAssignment_queryAssignment";
+    private static final String ROLE_ASSIGNMENT_GET_MEDIA_TYPE =
+        "application/vnd.uk.gov.hmcts.role-assignment-service.get-assignments+json;charset=UTF-8;version=1.0";
+    private static final String ROLE_ASSIGNMENT_QUERY_MEDIA_TYPE =
+        "application/vnd.uk.gov.hmcts.role-assignment-service.post-assignment-query-request+json;charset=UTF-8;version=1.0";
+    private static final String ROLE_ASSIGNMENT_CREATE_MEDIA_TYPE =
+        "application/vnd.uk.gov.hmcts.role-assignment-service.create-assignments+json;charset=UTF-8;version=1.0";
     private static final String ACTOR_ID = "11111111-1111-1111-1111-111111111111";
     private static final String CASE_ID = "1712345678901234";
     private static final String ROLE_NAME = "hearing-manager";
@@ -65,24 +74,27 @@ public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
         when(authTokenGenerator.generate()).thenReturn(SERVICE_AUTH_TOKEN);
     }
 
-    @Pact(consumer = "civil_service")
+    @Pact(consumer = "civil_service", provider = ROLE_ASSIGNMENT_GET_PROVIDER)
     public RequestResponsePact getRoleAssignmentsForActor(PactDslWithProvider builder) {
         return builder
+            .given("An actor with provided id is available in role assignment service")
             .uponReceiving("a get role assignments by actor id request")
             .path("/am/role-assignments/actors/" + ACTOR_ID)
             .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN, AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
             .method(HttpMethod.GET.toString())
             .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(buildRoleAssignmentResponse())
+            .matchHeader(HttpHeaders.CONTENT_TYPE, roleAssignmentMediaTypeMatcher("get-assignments"),
+                         ROLE_ASSIGNMENT_GET_MEDIA_TYPE)
+            .body(buildRoleAssignmentResponse(false))
             .status(HttpStatus.SC_OK)
             .toPact();
     }
 
-    @Pact(consumer = "civil_service")
+    @Pact(consumer = "civil_service", provider = ROLE_ASSIGNMENT_QUERY_PROVIDER)
     public RequestResponsePact queryRoleAssignmentsWithLabels(PactDslWithProvider builder)
         throws JSONException, IOException {
         return builder
+            .given("A list of role assignments for the search query")
             .uponReceiving("a query role assignments with labels request")
             .path("/am/role-assignments/query")
             .matchQuery("includeLabels", "true|false", "true")
@@ -94,16 +106,18 @@ public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
             .method(HttpMethod.POST.toString())
             .body(createJsonObject(buildActorRoleQueryRequest()))
             .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(buildRoleAssignmentResponse())
+            .matchHeader(HttpHeaders.CONTENT_TYPE, roleAssignmentMediaTypeMatcher("post-assignment-query-request"),
+                         ROLE_ASSIGNMENT_QUERY_MEDIA_TYPE)
+            .body(buildRoleAssignmentResponse(true))
             .status(HttpStatus.SC_OK)
             .toPact();
     }
 
-    @Pact(consumer = "civil_service")
+    @Pact(consumer = "civil_service", provider = ROLE_ASSIGNMENT_QUERY_PROVIDER)
     public RequestResponsePact queryRoleAssignmentsByCaseIdAndRole(PactDslWithProvider builder)
         throws JSONException, IOException {
         return builder
+            .given("A list of role assignments for the search query by attributes")
             .uponReceiving("a query role assignments by case id and role request")
             .path("/am/role-assignments/query")
             .matchQuery("includeLabels", "true|false", "true")
@@ -116,15 +130,17 @@ public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
             .method(HttpMethod.POST.toString())
             .body(createJsonObject(buildCaseRoleQueryRequest()))
             .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-            .body(buildRoleAssignmentResponse())
+            .matchHeader(HttpHeaders.CONTENT_TYPE, roleAssignmentMediaTypeMatcher("post-assignment-query-request"),
+                         ROLE_ASSIGNMENT_QUERY_MEDIA_TYPE)
+            .body(buildRoleAssignmentResponse(false))
             .status(HttpStatus.SC_OK)
             .toPact();
     }
 
-    @Pact(consumer = "civil_service")
+    @Pact(consumer = "civil_service", provider = ROLE_ASSIGNMENT_CREATE_PROVIDER)
     public RequestResponsePact createRoleAssignment(PactDslWithProvider builder) {
         return builder
+            .given("The assignment request is valid with one requested role and replaceExisting flag as true")
             .uponReceiving("a create role assignment request")
             .path("/am/role-assignments")
             .headers(
@@ -135,14 +151,21 @@ public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
             .method(HttpMethod.POST.toString())
             .body(buildCreateRoleAssignmentRequest())
             .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+            .matchHeader(HttpHeaders.CONTENT_TYPE, roleAssignmentMediaTypeMatcher("create-assignments"),
+                         ROLE_ASSIGNMENT_CREATE_MEDIA_TYPE)
             .body(buildCreateRoleAssignmentResponse())
             .status(HttpStatus.SC_CREATED)
             .toPact();
     }
 
+    private String roleAssignmentMediaTypeMatcher(String operation) {
+        return "application/(json|vnd\\.uk\\.gov\\.hmcts\\.role-assignment-service\\."
+            + operation
+            + "\\+json;charset=UTF-8;version=1\\.0)(;.*)?";
+    }
+
     @Test
-    @PactTestFor(pactMethod = "getRoleAssignmentsForActor")
+    @PactTestFor(providerName = ROLE_ASSIGNMENT_GET_PROVIDER, pactMethod = "getRoleAssignmentsForActor")
     public void verifyGetRoleAssignmentsForActor() {
         RoleAssignmentServiceResponse response = roleAssignmentsService.getRoleAssignments(ACTOR_ID, AUTHORIZATION_TOKEN);
 
@@ -152,7 +175,7 @@ public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "queryRoleAssignmentsWithLabels")
+    @PactTestFor(providerName = ROLE_ASSIGNMENT_QUERY_PROVIDER, pactMethod = "queryRoleAssignmentsWithLabels")
     public void verifyQueryRoleAssignmentsWithLabels() {
         RoleAssignmentServiceResponse response = roleAssignmentsService.getRoleAssignmentsWithLabels(
             ACTOR_ID,
@@ -165,7 +188,7 @@ public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
     }
 
     @Test
-    @PactTestFor(pactMethod = "queryRoleAssignmentsByCaseIdAndRole")
+    @PactTestFor(providerName = ROLE_ASSIGNMENT_QUERY_PROVIDER, pactMethod = "queryRoleAssignmentsByCaseIdAndRole")
     public void verifyQueryRoleAssignmentsByCaseIdAndRole() {
         RoleAssignmentServiceResponse response = roleAssignmentsService.queryRoleAssignmentsByCaseIdAndRole(
             CASE_ID,
@@ -175,11 +198,11 @@ public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
         );
 
         assertThat(response.getRoleAssignmentResponse().size(), is(equalTo(1)));
-        assertThat(response.getRoleAssignmentResponse().get(0).getAttributes().getCaseId(), is(equalTo(CASE_ID)));
+        assertThat(response.getRoleAssignmentResponse().get(0).getAttributes(), is(notNullValue()));
     }
 
     @Test
-    @PactTestFor(pactMethod = "createRoleAssignment")
+    @PactTestFor(providerName = ROLE_ASSIGNMENT_CREATE_PROVIDER, pactMethod = "createRoleAssignment")
     public void verifyCreateRoleAssignment() {
         roleAssignmentsService.assignUserRoles(ACTOR_ID, AUTHORIZATION_TOKEN, buildRoleAssignmentRequest());
     }
@@ -260,22 +283,24 @@ public class RoleAssignmentsApiConsumerTest extends BaseContractTest {
             .setRequestedRoles(List.of(roleAssignment));
     }
 
-    private DslPart buildRoleAssignmentResponse() {
+    private DslPart buildRoleAssignmentResponse(boolean includeRoleLabel) {
         return LambdaDsl.newJsonBody(root -> root
-            .minArrayLike("roleAssignmentResponse", 1, 1, roleAssignment -> roleAssignment
-                .stringValue("actorId", ACTOR_ID)
-                .stringValue("actorIdType", "IDAM")
-                .stringValue("roleType", ROLE_TYPE)
-                .stringValue("roleName", ROLE_NAME)
-                .stringValue("roleLabel", ROLE_LABEL)
-                .stringValue("classification", CLASSIFICATION)
-                .stringValue("grantType", GRANT_TYPE)
-                .stringValue("roleCategory", ROLE_CATEGORY)
-                .booleanValue("readOnly", false)
-                .object("attributes", attributes -> attributes
-                    .stringValue("caseId", CASE_ID)
-                    .stringValue("jurisdiction", "CIVIL")
-                    .stringValue("caseType", "CIVIL")))
+            .minArrayLike("roleAssignmentResponse", 1, 1, roleAssignment -> {
+                roleAssignment
+                    .stringType("actorId", ACTOR_ID)
+                    .stringType("actorIdType", "IDAM")
+                    .stringType("roleType", ROLE_TYPE)
+                    .stringType("roleName", ROLE_NAME)
+                    .stringType("classification", CLASSIFICATION)
+                    .stringType("grantType", GRANT_TYPE)
+                    .stringType("roleCategory", ROLE_CATEGORY)
+                    .booleanValue("readOnly", false)
+                    .object("attributes", attributes -> attributes
+                        .stringType("jurisdiction", "CIVIL"));
+                if (includeRoleLabel) {
+                    roleAssignment.stringType("roleLabel", ROLE_LABEL);
+                }
+            })
         ).build();
     }
 

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/ServiceAuthorisationApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/ServiceAuthorisationApiConsumerTest.java
@@ -21,7 +21,7 @@ import uk.gov.hmcts.reform.civil.service.AuthorisationService;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-@PactTestFor(providerName = "idam-s2s-auth")
+@PactTestFor(providerName = "s2s_auth")
 @MockServerConfig(hostInterface = "localhost", port = "6679")
 @TestPropertySource(properties = {
     "idam.s2s-auth.url=http://localhost:6679",
@@ -34,6 +34,7 @@ public class ServiceAuthorisationApiConsumerTest extends BaseContractTest {
     private static final String MICRO_SERVICE = "civil_service";
     private static final String ONE_TIME_PASSWORD = "123456";
     private static final String SERVICE_TOKEN = "eyJhbGciOiJub25lIn0.eyJzdWIiOiJjaXZpbF9zZXJ2aWNlIn0.";
+    private static final String TEXT_PLAIN_CONTENT_TYPE = "text/plain(;charset=.*)?";
 
     @Autowired
     private AuthTokenGenerator authTokenGenerator;
@@ -47,14 +48,15 @@ public class ServiceAuthorisationApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact generateServiceToken(PactDslWithProvider builder) {
         return builder
+            .given("microservice with valid credentials")
             .uponReceiving("a service token lease request")
             .path("/lease")
             .method(HttpMethod.POST.toString())
             .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .body(buildServiceTokenRequest())
             .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
-            .body(SERVICE_TOKEN)
+            .matchHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN_CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
+            .bodyMatchingContentType(MediaType.TEXT_PLAIN_VALUE, SERVICE_TOKEN)
             .status(HttpStatus.SC_OK)
             .toPact();
     }
@@ -62,13 +64,14 @@ public class ServiceAuthorisationApiConsumerTest extends BaseContractTest {
     @Pact(consumer = "civil_service")
     public RequestResponsePact getServiceName(PactDslWithProvider builder) {
         return builder
+            .given("microservice with valid token")
             .uponReceiving("a service name details request")
             .path("/details")
             .headers(AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
             .method(HttpMethod.GET.toString())
             .willRespondWith()
-            .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
-            .body(MICRO_SERVICE)
+            .matchHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN_CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
+            .bodyMatchingContentType(MediaType.TEXT_PLAIN_VALUE, MICRO_SERVICE)
             .status(HttpStatus.SC_OK)
             .toPact();
     }

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/TaskManagementApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/TaskManagementApiConsumerTest.java
@@ -91,6 +91,7 @@ public class TaskManagementApiConsumerTest extends BaseContractTest {
 
     private RequestResponsePact buildSearchTaskResponsePact(PactDslWithProvider builder) throws IOException {
         return builder
+            .given("appropriate tasks are returned by criteria")
             .uponReceiving("a new task search request")
             .path(ENDPOINT)
             .method(HttpMethod.POST.toString())
@@ -104,12 +105,14 @@ public class TaskManagementApiConsumerTest extends BaseContractTest {
 
     private RequestResponsePact buildClaimTaskResponsePact(PactDslWithProvider builder) {
         return builder
+            .given("claim a task using taskId")
             .uponReceiving("a new claim task request")
             .path(CLAIM_ENDPOINT)
             .method(HttpMethod.POST.toString())
             .headers(SERVICE_AUTHORIZATION_HEADER, SERVICE_AUTH_TOKEN, AUTHORIZATION_HEADER, AUTHORIZATION_TOKEN)
+            .body("", "application/json")
             .willRespondWith()
-            .status(HttpStatus.SC_OK)
+            .status(HttpStatus.SC_NO_CONTENT)
             .toPact();
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/civil/referencedata/model/JudgeRefData.java
+++ b/src/main/java/uk/gov/hmcts/reform/civil/referencedata/model/JudgeRefData.java
@@ -1,7 +1,6 @@
 package uk.gov.hmcts.reform.civil.referencedata.model;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -9,41 +8,27 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class JudgeRefData {
 
+    @JsonAlias("post_nominals")
     private String title;
+    @JsonAlias("known_as")
     private String knownAs;
     private String surname;
+    @JsonAlias("full_name")
     private String fullName;
+    @JsonAlias("ejudiciary_email")
     private String emailId;
+    @JsonAlias("sidam_id")
     private String idamId;
+    @JsonAlias("personal_code")
     private String personalCode;
+    @JsonAlias("is_judge")
     private String isJudge;
+    @JsonAlias("is_panel_member")
     private String isPanelMember;
+    @JsonAlias("is_magistrate")
     private String isMagistrate;
 
     public JudgeRefData() {
         // default constructor for frameworks/tests
-    }
-
-    @JsonCreator
-    public JudgeRefData(@JsonProperty("post_nominals") String title,
-                        @JsonProperty("known_as") String knownAs,
-                        @JsonProperty("surname") String surname,
-                        @JsonProperty("full_name") String fullName,
-                        @JsonProperty("ejudiciary_email") String emailId,
-                        @JsonProperty("sidam_id") String idamId,
-                        @JsonProperty("personal_code") String personalCode,
-                        @JsonProperty("is_judge") String isJudge,
-                        @JsonProperty("is_panel_member") String isPanelMember,
-                        @JsonProperty("is_magistrate") String isMagistrate) {
-        this.title = title;
-        this.knownAs = knownAs;
-        this.surname = surname;
-        this.fullName = fullName;
-        this.emailId = emailId;
-        this.idamId = idamId;
-        this.personalCode = personalCode;
-        this.isJudge = isJudge;
-        this.isPanelMember = isPanelMember;
-        this.isMagistrate = isMagistrate;
     }
 }


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6212

### Change description ###

Align Civil consumer Pact provider names/states with the provider repos so the new provider-verification tickets target the correct Pact Broker pacticipants.

  - Split IDAM Pact into idamApi_oidc and idamApi_users.
  - Renamed S2S, CDAM, RAS, CRD and JRD provider names to match provider-side Pact tests.
  - Added provider states required by provider verification.
  - Updated JRD response contract to provider v2 camelCase shape and made JudgeRefData accept legacy snake_case fields via @JsonAlias.
  - Loosened over-specific response matching for S2S, RAS and JRD where Civil only depends on type/deserialisation.
  - Aligned CDAM document example UUID with provider state.
  - Fixes WA/TM provider-name/state fixes for wa_task_management_api_search and wa_task_management_api_claim_task_by_id.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
