### PR TITLE
DTSCCI-6225 Further fixes to Civil consumer Pacts

### DIFF
--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/LocationReferenceDataApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/LocationReferenceDataApiConsumerTest.java
@@ -18,7 +18,7 @@ import uk.gov.hmcts.reform.civil.referencedata.model.LocationRefData;
 
 import java.util.List;
 
-import static au.com.dius.pact.consumer.dsl.LambdaDsl.newJsonArray;
+import static au.com.dius.pact.consumer.dsl.PactDslJsonArray.arrayMinLike;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -93,26 +93,24 @@ public class LocationReferenceDataApiConsumerTest extends BaseContractTest {
     }
 
     static DslPart buildLocationRefDataResponseBody(String serviceId) {
-        return newJsonArray(response ->
-                                response
-                                    .object(locationRefData -> locationRefData
-                                        .stringType("court_venue_id", "12345")
-                                        .stringType("service_code", serviceId)
-                                        .stringType("epimms_id", "epimmsIdTest123")
-                                        .stringType("site_name", "siteNameTest123")
-                                        .stringType("region_id", "regionIdTest123")
-                                        .stringType("region", "regionTest123")
-                                        .stringType("court_type", "courtTypeTest123")
-                                        .stringType("court_type_id", "courtTypeIdTest123")
-                                        .stringType("court_address", "courtAddressTest123")
-                                        .stringType("postcode", "postcodeTest123")
-                                        .stringType("phone_number", "phoneNumberTest123")
-                                        .stringType("court_location_code", "courtLocationCodeTest123")
-                                        .stringType("court_status", "courtStatusTest123")
-                                        .stringType("court_name", "courtNameTest123")
-                                        .stringType("venue_name", "venueNameTest123")
-                                        .stringType("location_type", "locationTypeTest123")
-                                        .stringType("parent_location", "parentLocationTest123"))
-        ).build();
+        return arrayMinLike(1, 1)
+            .stringType("court_venue_id", "12345")
+            .stringType("service_code", serviceId)
+            .stringType("epimms_id", "epimmsIdTest123")
+            .stringType("site_name", "siteNameTest123")
+            .stringType("region_id", "regionIdTest123")
+            .stringType("region", "regionTest123")
+            .stringType("court_type", "courtTypeTest123")
+            .stringType("court_type_id", "courtTypeIdTest123")
+            .stringType("court_address", "courtAddressTest123")
+            .stringType("postcode", "postcodeTest123")
+            .stringType("phone_number", "phoneNumberTest123")
+            .stringType("court_location_code", "courtLocationCodeTest123")
+            .stringType("court_status", "courtStatusTest123")
+            .stringType("court_name", "courtNameTest123")
+            .stringType("venue_name", "venueNameTest123")
+            .stringType("location_type", "locationTypeTest123")
+            .stringType("parent_location", "parentLocationTest123")
+            .closeObject();
     }
 }

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/SendLetterApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/SendLetterApiConsumerTest.java
@@ -61,7 +61,7 @@ public class SendLetterApiConsumerTest extends BaseContractTest {
             .willRespondWith()
             .matchHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
             .body(buildSendLetterResponse())
-            .status(HttpStatus.SC_CREATED)
+            .status(HttpStatus.SC_OK)
             .uponReceiving("a bulk print letter status request")
             .path("/letters/" + LETTER_ID)
             .matchQuery("include-additional-info", "false", "false")

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/TaskManagementApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/TaskManagementApiConsumerTest.java
@@ -119,11 +119,9 @@ public class TaskManagementApiConsumerTest extends BaseContractTest {
     private DslPart buildSearchTasksResponse() {
         return LambdaDsl.newJsonBody((root) -> {
             root
-                .array("tasks", tasksArray -> {
-                    tasksArray.object(taskObject -> {
+                .minArrayLike("tasks", 1, taskObject -> {
                         taskObject.stringType("id", TASK_ID);
                         taskObject.stringType("task_title", TASK_TITLE);
-                    });
                 });
         }).build();
     }

--- a/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/TaskManagementApiConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/civil/consumer/TaskManagementApiConsumerTest.java
@@ -120,8 +120,8 @@ public class TaskManagementApiConsumerTest extends BaseContractTest {
         return LambdaDsl.newJsonBody((root) -> {
             root
                 .minArrayLike("tasks", 1, taskObject -> {
-                        taskObject.stringType("id", TASK_ID);
-                        taskObject.stringType("task_title", TASK_TITLE);
+                    taskObject.stringType("id", TASK_ID);
+                    taskObject.stringType("task_title", TASK_TITLE);
                 });
         }).build();
     }


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSCCI-6225

### Change description ###

  - referenceData_location: changed the response pact to accept one or more location records, while still validating the required fields.
  - send_letter: corrected the POST /letters expected status from 201 Created to 200 OK.
  - task_management: changed the tasks response to accept one or more tasks instead of requiring exactly one.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
